### PR TITLE
Potential fix for code scanning alert no. 40: Use of externally-controlled format string

### DIFF
--- a/signer/src/modules/gossip/gossip.service.ts
+++ b/signer/src/modules/gossip/gossip.service.ts
@@ -259,7 +259,7 @@ export class GossipService implements OnModuleInit, OnModuleDestroy {
       });
 
       ws.on("error", (error: Error) => {
-        console.error(`❌ WebSocket error for ${endpoint}:`, error.message);
+        console.error("❌ WebSocket error for %s:", endpoint, error.message);
         console.error(`    Error details:`, error);
       });
     } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/fanhousanbu/YetAnotherAA/security/code-scanning/40](https://github.com/fanhousanbu/YetAnotherAA/security/code-scanning/40)

To fix the problem, we need to ensure that the untrusted `endpoint` value is not interpreted as part of a format string by the logging function. The canonical approach is to avoid putting untrusted data directly into the format string—in this case, the template literal that is passed as the first argument to `console.error`—and instead use a static format string with a substitution placeholder (`%s`), passing untrusted values as separate arguments. This makes it impossible for a maliciously crafted `endpoint` value to introduce unexpected format specifiers.

In practice, change this:

```ts
console.error(`❌ WebSocket error for ${endpoint}:`, error.message);
```

to:

```ts
console.error("❌ WebSocket error for %s:", endpoint, error.message);
```

This only requires a code change on line 262 of `signer/src/modules/gossip/gossip.service.ts`. No new imports or function definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
