### PR TITLE
chore: fix README license badge — MIT → Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,3 +378,8 @@ Issues and Pull Requests are welcome!
 ---
 
 **Status**: **Network**: Sepolia Testnet | **Security**: WebAuthn + KMS Enhanced
+
+## License
+
+Licensed under the [Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0). See [LICENSE](./LICENSE) for details.
+


### PR DESCRIPTION
## Summary
- Fix incorrect MIT license references in README (actual LICENSE is Apache 2.0)
- Add Apache 2.0 badge where missing
- Add license section where missing

Automated fix via `scripts/fix-readme-license.sh`