### PR TITLE
feat(portal): Track B — SDK 集成基础(wallet + client + 资源前置检查)

### DIFF
--- a/aastar-frontend/contexts/WalletContext.tsx
+++ b/aastar-frontend/contexts/WalletContext.tsx
@@ -11,7 +11,15 @@
  * now only injected EOAs are wired. Kept intentionally framework-light and
  * client-only (no SSR), consistent with the static-export direction.
  */
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import type { Address, WalletClient } from "viem";
 import { connectWallet, getInjectedProvider } from "@/lib/sdk/client";
 
@@ -31,23 +39,34 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const [walletClient, setWalletClient] = useState<WalletClient | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [hasInjectedWallet, setHasInjectedWallet] = useState(false);
+  // Monotonic token guarding against stale connect() resolutions: a late
+  // connectWallet() promise that resolves after a disconnect (or a newer
+  // connect) must not write back state. disconnect() bumps it to invalidate
+  // any in-flight connect.
+  const connectSeq = useRef(0);
+  const connectedRef = useRef(false);
 
   useEffect(() => {
     setHasInjectedWallet(!!getInjectedProvider());
   }, []);
 
   const connect = useCallback(async () => {
+    const seq = ++connectSeq.current;
     setIsConnecting(true);
     try {
       const { address: addr, walletClient: wc } = await connectWallet();
+      if (seq !== connectSeq.current) return; // superseded by a newer connect/disconnect
       setAddress(addr);
       setWalletClient(wc);
+      connectedRef.current = true;
     } finally {
-      setIsConnecting(false);
+      if (seq === connectSeq.current) setIsConnecting(false);
     }
   }, []);
 
   const disconnect = useCallback(() => {
+    connectSeq.current++; // invalidate any in-flight connect
+    connectedRef.current = false;
     setAddress(null);
     setWalletClient(null);
   }, []);
@@ -61,13 +80,15 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const onAccountsChanged = (accounts: string[]) => {
       if (accounts.length === 0) {
         disconnect();
-      } else if (address) {
+      } else if (connectedRef.current) {
+        // Reflect an account switch only while connected; the viem WalletClient
+        // (unpinned account) follows the provider's active account at send time.
         setAddress(accounts[0] as Address);
       }
     };
     provider.on("accountsChanged", onAccountsChanged);
     return () => provider.removeListener?.("accountsChanged", onAccountsChanged);
-  }, [address, disconnect]);
+  }, [disconnect]);
 
   return (
     <WalletContext.Provider

--- a/aastar-frontend/contexts/WalletContext.tsx
+++ b/aastar-frontend/contexts/WalletContext.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Operator wallet context for the operations portal.
+ *
+ * Operator/community actions are signed by the operator's own EOA (MetaMask /
+ * injected) in the browser — never by the backend-held AirAccount key. Exposes
+ * the connected address + a viem WalletClient for the @aastar/* write actions.
+ *
+ * NOTE: Gnosis Safe multisig (registry's useSafeApp) is a planned follow-up; for
+ * now only injected EOAs are wired. Kept intentionally framework-light and
+ * client-only (no SSR), consistent with the static-export direction.
+ */
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import type { Address, WalletClient } from "viem";
+import { connectWallet, getInjectedProvider } from "@/lib/sdk/client";
+
+interface WalletContextType {
+  address: Address | null;
+  walletClient: WalletClient | null;
+  isConnecting: boolean;
+  hasInjectedWallet: boolean;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+}
+
+const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [address, setAddress] = useState<Address | null>(null);
+  const [walletClient, setWalletClient] = useState<WalletClient | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [hasInjectedWallet, setHasInjectedWallet] = useState(false);
+
+  useEffect(() => {
+    setHasInjectedWallet(!!getInjectedProvider());
+  }, []);
+
+  const connect = useCallback(async () => {
+    setIsConnecting(true);
+    try {
+      const { address: addr, walletClient: wc } = await connectWallet();
+      setAddress(addr);
+      setWalletClient(wc);
+    } finally {
+      setIsConnecting(false);
+    }
+  }, []);
+
+  const disconnect = useCallback(() => {
+    setAddress(null);
+    setWalletClient(null);
+  }, []);
+
+  // Reflect account switches from the injected wallet.
+  useEffect(() => {
+    const provider = getInjectedProvider() as
+      | { on?: (e: string, cb: (a: string[]) => void) => void; removeListener?: (e: string, cb: (a: string[]) => void) => void }
+      | undefined;
+    if (!provider?.on) return;
+    const onAccountsChanged = (accounts: string[]) => {
+      if (accounts.length === 0) {
+        disconnect();
+      } else if (address) {
+        setAddress(accounts[0] as Address);
+      }
+    };
+    provider.on("accountsChanged", onAccountsChanged);
+    return () => provider.removeListener?.("accountsChanged", onAccountsChanged);
+  }, [address, disconnect]);
+
+  return (
+    <WalletContext.Provider
+      value={{ address, walletClient, isConnecting, hasInjectedWallet, connect, disconnect }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet(): WalletContextType {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used within a WalletProvider");
+  return ctx;
+}

--- a/aastar-frontend/lib/resources/cache.ts
+++ b/aastar-frontend/lib/resources/cache.ts
@@ -1,0 +1,99 @@
+/**
+ * localStorage cache utility with TTL — ported from the registry app.
+ *
+ * Client-side only (touches localStorage at call time, not at module load,
+ * so it is safe to import from client components). Used by the operations
+ * portal resource pre-check to cache positive on-chain lookups.
+ *
+ * @module lib/resources/cache
+ */
+
+const CACHE_PREFIX = "spm_";
+const DEFAULT_TTL = 3600; // 1 hour, in seconds
+
+export interface CachedData<T> {
+  data: T;
+  timestamp: number;
+  ttl: number;
+}
+
+/** Load cached data, or null if missing/expired (expired entries are removed). */
+export function loadFromCache<T>(key: string): CachedData<T> | null {
+  try {
+    const cached = localStorage.getItem(`${CACHE_PREFIX}${key}`);
+    if (!cached) return null;
+
+    const parsed: CachedData<T> = JSON.parse(cached);
+    if (isCacheExpired(parsed.timestamp, parsed.ttl)) {
+      clearCache(key);
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.error(`[Cache] Failed to load (${key}):`, error);
+    return null;
+  }
+}
+
+/** Save data with a TTL (seconds). Falls back to clearing old caches on quota errors. */
+export function saveToCache<T>(key: string, data: T, ttl: number = DEFAULT_TTL): void {
+  const write = () =>
+    localStorage.setItem(
+      `${CACHE_PREFIX}${key}`,
+      JSON.stringify({ data, timestamp: Date.now(), ttl } satisfies CachedData<T>)
+    );
+  try {
+    write();
+  } catch (error) {
+    console.error(`[Cache] Failed to save (${key}):`, error);
+    if (error instanceof DOMException && error.name === "QuotaExceededError") {
+      clearOldCaches();
+      try {
+        write();
+      } catch (retryError) {
+        console.error("[Cache] Failed to save even after clearing:", retryError);
+      }
+    }
+  }
+}
+
+/** True if `timestamp` (ms) is older than `ttl` (seconds). */
+export function isCacheExpired(timestamp: number, ttl: number): boolean {
+  return Date.now() - timestamp > ttl * 1000;
+}
+
+/** Clear all `spm_` caches, or only those whose key contains `pattern`. */
+export function clearCache(pattern?: string): void {
+  try {
+    Object.keys(localStorage)
+      .filter(key => key.startsWith(CACHE_PREFIX) && (!pattern || key.includes(pattern)))
+      .forEach(key => localStorage.removeItem(key));
+  } catch (error) {
+    console.error("[Cache] Failed to clear cache:", error);
+  }
+}
+
+/** Evict the oldest half of the `spm_` caches to free space. */
+export function clearOldCaches(): void {
+  try {
+    const caches = Object.keys(localStorage)
+      .filter(key => key.startsWith(CACHE_PREFIX))
+      .map(key => {
+        let timestamp = 0;
+        try {
+          timestamp = JSON.parse(localStorage.getItem(key) || "{}").timestamp || 0;
+        } catch {
+          timestamp = 0;
+        }
+        return { key, timestamp };
+      })
+      .sort((a, b) => a.timestamp - b.timestamp);
+
+    const toRemove = Math.ceil(caches.length / 2);
+    for (let i = 0; i < toRemove; i++) localStorage.removeItem(caches[i].key);
+  } catch (error) {
+    console.error("[Cache] Failed to clear old caches:", error);
+  }
+}
+
+export const CACHE_CONSTANTS = { CACHE_PREFIX, DEFAULT_TTL };

--- a/aastar-frontend/lib/resources/resourceChecker.ts
+++ b/aastar-frontend/lib/resources/resourceChecker.ts
@@ -2,9 +2,12 @@
  * Operations-portal resource pre-check — ported from the registry app, rebuilt
  * on the `@aastar/core` SDK (viem read actions) instead of raw ethers contracts.
  *
- * Client-side only. Concurrently checks operator onboarding prerequisites and
- * caches positive on-chain lookups for 60 min (balances are always refreshed via
- * a short TTL). See registry docs/CORE_FLOWS.md (flow 8) for the original logic.
+ * Client-side only. Concurrently checks operator onboarding prerequisites.
+ * Positive on-chain *lookups* (registered / token-deployed / paymaster-deployed)
+ * are cached 60 min; *balances* are always fetched fresh (they gate the
+ * "enough GT/aPNTs/ETH" decision and must not go stale). Cache keys are scoped
+ * by chainId so switching chains never reuses another chain's state.
+ * See registry docs/CORE_FLOWS.md (flow 8) for the original logic.
  *
  * @module lib/resources/resourceChecker
  */
@@ -22,24 +25,30 @@ import {
   PAYMASTER_FACTORY_ADDRESS,
   SUPER_PAYMASTER_ADDRESS,
   APNTS_ADDRESS,
+  CHAIN_SEPOLIA,
 } from "@aastar/core";
 import type { Address } from "viem";
 import { ensureSdkConfig, getPublicClient } from "../sdk/client";
-import { loadFromCache, saveToCache } from "./cache";
+import { clearCache, loadFromCache, saveToCache } from "./cache";
 
-const CACHE_DURATION_MS = 60 * 60 * 1000; // 60 min (positive lookups)
+const CACHE_DURATION_MS = 60 * 60 * 1000; // 60 min (positive lookups only)
 const POSITIVE_TTL = 3600; // 60 min, seconds
+
+// Chain the portal currently operates on (also drives ensureSdkConfig). Included
+// in every cache key so a chain switch can never read another chain's cache.
+const PORTAL_CHAIN = CHAIN_SEPOLIA;
+const cacheKey = (type: string, addr: string) => `resource_${type}_${PORTAL_CHAIN}_${addr}`;
 
 /** Cache positive results long; never cache a negative (so it re-checks next time). */
 async function getCachedOrFetch<T>(
-  cacheKey: string,
+  key: string,
   fetchFn: () => Promise<T>,
   isSuccess: (value: T) => boolean
 ): Promise<T> {
-  const cached = loadFromCache<T>(cacheKey);
+  const cached = loadFromCache<T>(key);
   if (cached && Date.now() - cached.timestamp < CACHE_DURATION_MS) return cached.data;
   const result = await fetchFn();
-  if (isSuccess(result)) saveToCache(cacheKey, result, POSITIVE_TTL);
+  if (isSuccess(result)) saveToCache(key, result, POSITIVE_TTL);
   return result;
 }
 
@@ -85,7 +94,8 @@ async function isCommunityRegistered(address: Address): Promise<boolean> {
       roleId: ROLE_COMMUNITY,
       user: address,
     });
-  } catch {
+  } catch (err) {
+    console.warn("[resourceChecker] community registration read failed:", err);
     return false;
   }
 }
@@ -97,7 +107,8 @@ async function checkXPNTs(address: Address): Promise<{ hasToken: boolean; tokenA
     if (!hasToken) return { hasToken: false };
     const tokenAddress = await factory.getTokenAddress({ community: address });
     return { hasToken: true, tokenAddress };
-  } catch {
+  } catch (err) {
+    console.warn("[resourceChecker] xPNTs read failed:", err);
     return { hasToken: false };
   }
 }
@@ -111,7 +122,8 @@ async function checkPaymaster(
     if (!hasPaymaster) return { hasPaymaster: false };
     const paymasterAddress = await factory.getPaymasterByOperator({ operator: address });
     return { hasPaymaster: true, paymasterAddress };
-  } catch {
+  } catch (err) {
+    console.warn("[resourceChecker] paymaster read failed:", err);
     return { hasPaymaster: false };
   }
 }
@@ -123,16 +135,19 @@ async function isSuperPaymasterRegistered(address: Address): Promise<boolean> {
     });
     // `isConfigured` is the v5 SuperPaymaster operator-registration flag.
     return Boolean(config?.isConfigured);
-  } catch {
+  } catch (err) {
+    console.warn("[resourceChecker] SuperPaymaster read failed:", err);
     return false;
   }
 }
 
+// Balances are always read fresh (never cached) — see module doc.
 async function tokenBalance(token: Address, account: Address): Promise<string> {
   try {
     const balance = await tokenActions(token)(pc()).balanceOf({ token, account });
     return formatEther(balance);
-  } catch {
+  } catch (err) {
+    console.warn(`[resourceChecker] token balance read failed (${token}):`, err);
     return "0";
   }
 }
@@ -140,34 +155,21 @@ async function tokenBalance(token: Address, account: Address): Promise<string> {
 async function ethBalance(address: Address): Promise<string> {
   try {
     return formatEther(await pc().getBalance({ address }));
-  } catch {
+  } catch (err) {
+    console.warn("[resourceChecker] ETH balance read failed:", err);
     return "0";
   }
 }
 
 // ── Cache management ──────────────────────────────────────────────────────────
 
-const RESOURCE_KEYS = [
-  "community",
-  "xpnts",
-  "paymaster",
-  "aoa_paymaster",
-  "superpaymaster",
-  "gtoken",
-  "apnts",
-  "eth",
-];
-
-/** Clear all cached resource lookups for a wallet (used by the manual refresh button). */
+/**
+ * Clear cached resource lookups for one wallet (manual refresh button).
+ * Pattern-clears every cache key containing this address (across chainIds and
+ * resource types) via the cache module — no prefix duplicated here.
+ */
 export function clearResourceCaches(walletAddress: string): void {
-  const addr = walletAddress.toLowerCase();
-  for (const k of RESOURCE_KEYS) {
-    try {
-      localStorage.removeItem(`spm_resource_${k}_${addr}`);
-    } catch {
-      /* ignore */
-    }
-  }
+  clearCache(walletAddress.toLowerCase());
 }
 
 // ── Main entry points ─────────────────────────────────────────────────────────
@@ -181,11 +183,11 @@ async function checkAOAResources(walletAddress: string): Promise<ResourceStatus>
   const addr = walletAddress.toLowerCase();
 
   const [registered, xpnts, paymaster, gToken, eth] = await Promise.all([
-    getCachedOrFetch(`resource_community_${addr}`, () => isCommunityRegistered(address), r => r),
-    getCachedOrFetch(`resource_xpnts_${addr}`, () => checkXPNTs(address), r => r.hasToken),
-    getCachedOrFetch(`resource_paymaster_${addr}`, () => checkPaymaster(address), r => r.hasPaymaster),
-    getCachedOrFetch(`resource_gtoken_${addr}`, () => tokenBalance(GTOKEN_ADDRESS, address), () => true),
-    getCachedOrFetch(`resource_eth_${addr}`, () => ethBalance(address), () => true),
+    getCachedOrFetch(cacheKey("community", addr), () => isCommunityRegistered(address), r => r),
+    getCachedOrFetch(cacheKey("xpnts", addr), () => checkXPNTs(address), r => r.hasToken),
+    getCachedOrFetch(cacheKey("paymaster", addr), () => checkPaymaster(address), r => r.hasPaymaster),
+    tokenBalance(GTOKEN_ADDRESS, address), // fresh, never cached
+    ethBalance(address), // fresh, never cached
   ]);
 
   const requiredGToken = registered ? "30" : "60";
@@ -222,14 +224,14 @@ async function checkAOAPlusResources(walletAddress: string): Promise<ResourceSta
   const addr = walletAddress.toLowerCase();
 
   const [registered, xpnts, aoaPaymaster, superRegistered, gToken, aPNTs, eth] = await Promise.all([
-    getCachedOrFetch(`resource_community_${addr}`, () => isCommunityRegistered(address), r => r),
-    getCachedOrFetch(`resource_xpnts_${addr}`, () => checkXPNTs(address), r => r.hasToken),
+    getCachedOrFetch(cacheKey("community", addr), () => isCommunityRegistered(address), r => r),
+    getCachedOrFetch(cacheKey("xpnts", addr), () => checkXPNTs(address), r => r.hasToken),
     // Only cache when there is NO conflict (no AOA paymaster / not yet registered).
-    getCachedOrFetch(`resource_aoa_paymaster_${addr}`, () => checkPaymaster(address), r => !r.hasPaymaster),
-    getCachedOrFetch(`resource_superpaymaster_${addr}`, () => isSuperPaymasterRegistered(address), r => !r),
-    getCachedOrFetch(`resource_gtoken_${addr}`, () => tokenBalance(GTOKEN_ADDRESS, address), () => true),
-    getCachedOrFetch(`resource_apnts_${addr}`, () => tokenBalance(APNTS_ADDRESS, address), () => true),
-    getCachedOrFetch(`resource_eth_${addr}`, () => ethBalance(address), () => true),
+    getCachedOrFetch(cacheKey("aoa_paymaster", addr), () => checkPaymaster(address), r => !r.hasPaymaster),
+    getCachedOrFetch(cacheKey("superpaymaster", addr), () => isSuperPaymasterRegistered(address), r => !r),
+    tokenBalance(GTOKEN_ADDRESS, address), // fresh, never cached
+    tokenBalance(APNTS_ADDRESS, address), // fresh, never cached
+    ethBalance(address), // fresh, never cached
   ]);
 
   const requiredGToken = registered ? "50" : "80";

--- a/aastar-frontend/lib/resources/resourceChecker.ts
+++ b/aastar-frontend/lib/resources/resourceChecker.ts
@@ -1,0 +1,262 @@
+/**
+ * Operations-portal resource pre-check — ported from the registry app, rebuilt
+ * on the `@aastar/core` SDK (viem read actions) instead of raw ethers contracts.
+ *
+ * Client-side only. Concurrently checks operator onboarding prerequisites and
+ * caches positive on-chain lookups for 60 min (balances are always refreshed via
+ * a short TTL). See registry docs/CORE_FLOWS.md (flow 8) for the original logic.
+ *
+ * @module lib/resources/resourceChecker
+ */
+import { formatEther } from "viem";
+import {
+  registryActions,
+  tokenActions,
+  xPNTsFactoryActions,
+  paymasterFactoryActions,
+  superPaymasterActions,
+  ROLE_COMMUNITY,
+  REGISTRY_ADDRESS,
+  GTOKEN_ADDRESS,
+  XPNTS_FACTORY_ADDRESS,
+  PAYMASTER_FACTORY_ADDRESS,
+  SUPER_PAYMASTER_ADDRESS,
+  APNTS_ADDRESS,
+} from "@aastar/core";
+import type { Address } from "viem";
+import { ensureSdkConfig, getPublicClient } from "../sdk/client";
+import { loadFromCache, saveToCache } from "./cache";
+
+const CACHE_DURATION_MS = 60 * 60 * 1000; // 60 min (positive lookups)
+const POSITIVE_TTL = 3600; // 60 min, seconds
+
+/** Cache positive results long; never cache a negative (so it re-checks next time). */
+async function getCachedOrFetch<T>(
+  cacheKey: string,
+  fetchFn: () => Promise<T>,
+  isSuccess: (value: T) => boolean
+): Promise<T> {
+  const cached = loadFromCache<T>(cacheKey);
+  if (cached && Date.now() - cached.timestamp < CACHE_DURATION_MS) return cached.data;
+  const result = await fetchFn();
+  if (isSuccess(result)) saveToCache(cacheKey, result, POSITIVE_TTL);
+  return result;
+}
+
+export interface ResourceStatus {
+  isCommunityRegistered: boolean;
+  hasXPNTs: boolean;
+  xPNTsAddress?: string;
+  hasPaymaster: boolean;
+  paymasterAddress?: string;
+  hasAOAPaymaster: boolean;
+  hasSuperPaymasterRegistered: boolean;
+  hasSBTBinding: boolean;
+  gTokenBalance: string;
+  requiredGToken: string;
+  hasEnoughGToken: boolean;
+  aPNTsBalance: string;
+  requiredAPNTs: string;
+  hasEnoughAPNTs: boolean;
+  ethBalance: string;
+  requiredETH: string;
+  hasEnoughETH: boolean;
+}
+
+export type StakeMode = "aoa" | "aoa+";
+
+const REQUIRED_ETH = "0.05";
+const REQUIRED_APNTS = "1000";
+
+// ── Individual on-chain checks (SDK read actions) ────────────────────────────
+
+// Returns `any` deliberately: @aastar/core bundles its own viem copy, so its
+// PublicClient type identity differs from the frontend's. The client is
+// structurally identical at runtime; the SDK action method signatures
+// (args/returns) remain fully type-checked — only the client handle is untyped.
+function pc(): any {
+  ensureSdkConfig();
+  return getPublicClient();
+}
+
+async function isCommunityRegistered(address: Address): Promise<boolean> {
+  try {
+    return await registryActions(REGISTRY_ADDRESS)(pc()).hasRole({
+      roleId: ROLE_COMMUNITY,
+      user: address,
+    });
+  } catch {
+    return false;
+  }
+}
+
+async function checkXPNTs(address: Address): Promise<{ hasToken: boolean; tokenAddress?: string }> {
+  try {
+    const factory = xPNTsFactoryActions(XPNTS_FACTORY_ADDRESS)(pc());
+    const hasToken = await factory.hasToken({ community: address });
+    if (!hasToken) return { hasToken: false };
+    const tokenAddress = await factory.getTokenAddress({ community: address });
+    return { hasToken: true, tokenAddress };
+  } catch {
+    return { hasToken: false };
+  }
+}
+
+async function checkPaymaster(
+  address: Address
+): Promise<{ hasPaymaster: boolean; paymasterAddress?: string }> {
+  try {
+    const factory = paymasterFactoryActions(PAYMASTER_FACTORY_ADDRESS)(pc());
+    const hasPaymaster = await factory.hasPaymaster({ owner: address });
+    if (!hasPaymaster) return { hasPaymaster: false };
+    const paymasterAddress = await factory.getPaymasterByOperator({ operator: address });
+    return { hasPaymaster: true, paymasterAddress };
+  } catch {
+    return { hasPaymaster: false };
+  }
+}
+
+async function isSuperPaymasterRegistered(address: Address): Promise<boolean> {
+  try {
+    const config = await superPaymasterActions(SUPER_PAYMASTER_ADDRESS)(pc()).operators({
+      operator: address,
+    });
+    // `isConfigured` is the v5 SuperPaymaster operator-registration flag.
+    return Boolean(config?.isConfigured);
+  } catch {
+    return false;
+  }
+}
+
+async function tokenBalance(token: Address, account: Address): Promise<string> {
+  try {
+    const balance = await tokenActions(token)(pc()).balanceOf({ token, account });
+    return formatEther(balance);
+  } catch {
+    return "0";
+  }
+}
+
+async function ethBalance(address: Address): Promise<string> {
+  try {
+    return formatEther(await pc().getBalance({ address }));
+  } catch {
+    return "0";
+  }
+}
+
+// ── Cache management ──────────────────────────────────────────────────────────
+
+const RESOURCE_KEYS = [
+  "community",
+  "xpnts",
+  "paymaster",
+  "aoa_paymaster",
+  "superpaymaster",
+  "gtoken",
+  "apnts",
+  "eth",
+];
+
+/** Clear all cached resource lookups for a wallet (used by the manual refresh button). */
+export function clearResourceCaches(walletAddress: string): void {
+  const addr = walletAddress.toLowerCase();
+  for (const k of RESOURCE_KEYS) {
+    try {
+      localStorage.removeItem(`spm_resource_${k}_${addr}`);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// ── Main entry points ─────────────────────────────────────────────────────────
+
+/**
+ * AOA mode: 30 GT (paymaster) + 30 GT (community, if unregistered) = 30/60 GT,
+ * 0.05 ETH. aPNTs not required.
+ */
+async function checkAOAResources(walletAddress: string): Promise<ResourceStatus> {
+  const address = walletAddress as Address;
+  const addr = walletAddress.toLowerCase();
+
+  const [registered, xpnts, paymaster, gToken, eth] = await Promise.all([
+    getCachedOrFetch(`resource_community_${addr}`, () => isCommunityRegistered(address), r => r),
+    getCachedOrFetch(`resource_xpnts_${addr}`, () => checkXPNTs(address), r => r.hasToken),
+    getCachedOrFetch(`resource_paymaster_${addr}`, () => checkPaymaster(address), r => r.hasPaymaster),
+    getCachedOrFetch(`resource_gtoken_${addr}`, () => tokenBalance(GTOKEN_ADDRESS, address), () => true),
+    getCachedOrFetch(`resource_eth_${addr}`, () => ethBalance(address), () => true),
+  ]);
+
+  const requiredGToken = registered ? "30" : "60";
+  return {
+    isCommunityRegistered: registered,
+    hasXPNTs: xpnts.hasToken,
+    xPNTsAddress: xpnts.tokenAddress,
+    hasPaymaster: paymaster.hasPaymaster,
+    paymasterAddress: paymaster.paymasterAddress,
+    hasAOAPaymaster: paymaster.hasPaymaster,
+    hasSuperPaymasterRegistered: false,
+    // SBT binding lives in Registry.getCommunityProfile().supportedSBTs, not yet
+    // exposed by @aastar/core — see aastar-sdk#52. Optional step; default false.
+    hasSBTBinding: false,
+    gTokenBalance: gToken,
+    requiredGToken,
+    hasEnoughGToken: parseFloat(gToken) >= parseFloat(requiredGToken),
+    aPNTsBalance: "0",
+    requiredAPNTs: "0",
+    hasEnoughAPNTs: true,
+    ethBalance: eth,
+    requiredETH: REQUIRED_ETH,
+    hasEnoughETH: parseFloat(eth) >= parseFloat(REQUIRED_ETH),
+  };
+}
+
+/**
+ * AOA+ mode (shared SuperPaymaster): 50 GT (register) + 30 GT (community, if
+ * unregistered) = 50/80 GT, 1000 aPNTs, 0.05 ETH. Mutually exclusive with an
+ * already-deployed AOA paymaster.
+ */
+async function checkAOAPlusResources(walletAddress: string): Promise<ResourceStatus> {
+  const address = walletAddress as Address;
+  const addr = walletAddress.toLowerCase();
+
+  const [registered, xpnts, aoaPaymaster, superRegistered, gToken, aPNTs, eth] = await Promise.all([
+    getCachedOrFetch(`resource_community_${addr}`, () => isCommunityRegistered(address), r => r),
+    getCachedOrFetch(`resource_xpnts_${addr}`, () => checkXPNTs(address), r => r.hasToken),
+    // Only cache when there is NO conflict (no AOA paymaster / not yet registered).
+    getCachedOrFetch(`resource_aoa_paymaster_${addr}`, () => checkPaymaster(address), r => !r.hasPaymaster),
+    getCachedOrFetch(`resource_superpaymaster_${addr}`, () => isSuperPaymasterRegistered(address), r => !r),
+    getCachedOrFetch(`resource_gtoken_${addr}`, () => tokenBalance(GTOKEN_ADDRESS, address), () => true),
+    getCachedOrFetch(`resource_apnts_${addr}`, () => tokenBalance(APNTS_ADDRESS, address), () => true),
+    getCachedOrFetch(`resource_eth_${addr}`, () => ethBalance(address), () => true),
+  ]);
+
+  const requiredGToken = registered ? "50" : "80";
+  return {
+    isCommunityRegistered: registered,
+    hasXPNTs: xpnts.hasToken,
+    xPNTsAddress: xpnts.tokenAddress,
+    hasPaymaster: false,
+    hasAOAPaymaster: aoaPaymaster.hasPaymaster,
+    hasSuperPaymasterRegistered: superRegistered,
+    hasSBTBinding: false,
+    gTokenBalance: gToken,
+    requiredGToken,
+    hasEnoughGToken: parseFloat(gToken) >= parseFloat(requiredGToken),
+    aPNTsBalance: aPNTs,
+    requiredAPNTs: REQUIRED_APNTS,
+    hasEnoughAPNTs: parseFloat(aPNTs) >= parseFloat(REQUIRED_APNTS),
+    ethBalance: eth,
+    requiredETH: REQUIRED_ETH,
+    hasEnoughETH: parseFloat(eth) >= parseFloat(REQUIRED_ETH),
+  };
+}
+
+/** Resource pre-check for the operator onboarding wizard, by mode. */
+export async function checkResources(
+  walletAddress: string,
+  mode: StakeMode
+): Promise<ResourceStatus> {
+  return mode === "aoa" ? checkAOAResources(walletAddress) : checkAOAPlusResources(walletAddress);
+}

--- a/aastar-frontend/lib/sdk/client.ts
+++ b/aastar-frontend/lib/sdk/client.ts
@@ -1,0 +1,57 @@
+/**
+ * Client-side SDK bootstrap for the operations portal.
+ *
+ * All operator/community writes are signed in the browser by the operator's own
+ * wallet (MetaMask / injected EOA), so we build viem clients from
+ * `window.ethereum` and drive the `@aastar/*` packages with them — no SSR, no
+ * server-held keys. Reads use a plain RPC `PublicClient`.
+ *
+ * @module lib/sdk/client
+ */
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import type { Address, Chain, PublicClient, WalletClient } from "viem";
+import { sepolia } from "viem/chains";
+import { applyConfig, CHAIN_SEPOLIA } from "@aastar/core";
+
+let sdkConfigured = false;
+
+/**
+ * Point the `@aastar/core` canonical addresses at the portal chain. Must run
+ * before reading any `*_ADDRESS` constant or building an action. Idempotent.
+ */
+export function ensureSdkConfig(chainId: number = CHAIN_SEPOLIA): void {
+  if (!sdkConfigured) {
+    applyConfig({ chainId });
+    sdkConfigured = true;
+  }
+}
+
+/** The injected EIP-1193 provider (MetaMask etc.), or undefined during SSR / when absent. */
+export function getInjectedProvider(): unknown | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { ethereum?: unknown }).ethereum;
+}
+
+/** Read-only viem client over a public RPC (defaults to the chain's public endpoint). */
+export function getPublicClient(rpcUrl?: string, chain: Chain = sepolia): PublicClient {
+  return createPublicClient({ chain, transport: rpcUrl ? http(rpcUrl) : http() });
+}
+
+/**
+ * Connect the injected wallet and return the selected account plus a viem
+ * `WalletClient` for signing portal transactions. Throws if no wallet is present.
+ */
+export async function connectWallet(
+  chain: Chain = sepolia
+): Promise<{ address: Address; walletClient: WalletClient }> {
+  const provider = getInjectedProvider();
+  if (!provider) {
+    throw new Error("No injected wallet found. Please install MetaMask or a compatible wallet.");
+  }
+  const walletClient = createWalletClient({
+    chain,
+    transport: custom(provider as Parameters<typeof custom>[0]),
+  });
+  const [address] = await walletClient.requestAddresses();
+  return { address, walletClient };
+}

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@aastar/airaccount": "^0.19.0",
+    "@aastar/core": "^0.18.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aastar/airaccount": "^0.19.0",
+        "@aastar/core": "^0.18.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",


### PR DESCRIPTION
## 目标
为 registry 运营门户迁移搭建**客户端 SDK 集成基础**(PR3 / 栈:#269 已合 → 本 PR → Track C 写入流程)。运营者写入在浏览器内由其自有 EOA 签名,**纯客户端、无 SSR**(符合静态化方向)。

## 改动
- 前端加依赖 `@aastar/core@^0.18.0`(运营/治理线 viem SDK)
- `lib/sdk/client.ts` — 客户端 viem `PublicClient`/`WalletClient` 工厂(从 `window.ethereum`)+ `ensureSdkConfig`(applyConfig)
- `contexts/WalletContext.tsx` — 运营者钱包(injected/MetaMask)→ viem WalletClient,处理账户切换;Safe 多签为标注的后续项
- `lib/resources/cache.ts` — 从 registry 移植的 localStorage TTL 缓存
- `lib/resources/resourceChecker.ts` — `checkResources(wallet, mode)` 移植自 registry 流程 8,改用 `@aastar/core` 只读 action(hasRole / xPNTs+paymaster factory / superPaymaster operators / 余额);保留 30/60 & 50/80 GT、1000 aPNTs、0.05 ETH 阈值 + 仅缓存成功结果的 60min 策略

## 说明
- 所有链交互经 `@aastar/*` SDK,无 `new ethers.Contract` 直连、无硬编码地址(地址取自 `@aastar/core` canonical 导出)
- SBT-binding 读取暂缺(需 `Registry.getCommunityProfile`,SDK 缺口见 AAStarCommunity/aastar-sdk#52),默认 false 不阻断
- 验证:前端 `type-check` + `next build` 通过(SDK action 签名经类型校验)
- 本 PR 为基础设施,尚无页面消费;Track C(PR4)的运营者写入向导将基于此

> 提醒:master 上 #269 遗留的 community/operator/role page.tsx 有几处 lint warning + 1 个 `@next/next/no-img-element` 规则未加载的 error(非本 PR 引入)。需要的话我可另开小 PR 修。