### PR TITLE
fix(portal): 清理 #269 遗留的 lint error/warning

### DIFF
--- a/aastar-frontend/app/community/page.tsx
+++ b/aastar-frontend/app/community/page.tsx
@@ -63,7 +63,6 @@ function CommunityCard({ entry }: { entry: CommunityEntry }) {
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
       <div className="flex items-start gap-3">
         {entry.metadata?.logoURI ? (
-          // eslint-disable-next-line @next/next/no-img-element
           <img src={resolveImageUrl(entry.metadata.logoURI)} alt={name} className="w-10 h-10 rounded-full" />
         ) : (
           <div className="w-10 h-10 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center">

--- a/aastar-frontend/app/operator/page.tsx
+++ b/aastar-frontend/app/operator/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   ServerStackIcon,
-  CurrencyDollarIcon,
   CheckBadgeIcon,
   XCircleIcon,
   ArrowPathIcon,

--- a/aastar-frontend/app/role/page.tsx
+++ b/aastar-frontend/app/role/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Layout from "@/components/Layout";
 import { registryAPI } from "@/lib/api";
-import { getStoredAuth } from "@/lib/auth";
 import toast from "react-hot-toast";
 import {
   ShieldCheckIcon,
@@ -94,7 +93,7 @@ export default function RolePage() {
       ]);
       if (roleRes) setRoleInfo(roleRes.data);
       setRegistryInfo(infoRes.data);
-    } catch (err) {
+    } catch {
       toast.error("Failed to load registry data");
     } finally {
       setLoading(false);
@@ -107,7 +106,7 @@ export default function RolePage() {
     try {
       const res = await registryAPI.getRole(queryAddress);
       setRoleInfo(res.data);
-    } catch (err) {
+    } catch {
       toast.error("Failed to query role for address");
     } finally {
       setQuerying(false);


### PR DESCRIPTION
清理 #269 合并后 master 上的 lint 问题(`npm run lint:check -w aastar-frontend` 现已干净):
- `community/page.tsx`:删除孤儿 `eslint-disable @next/next/no-img-element`(该规则未加载——`.eslintrc.json` 未 extend eslint-config-next,导致 'rule not found' error)。保留 `<img>`(也更利于后续静态导出)
- `operator/page.tsx`:删除未使用的 `CurrencyDollarIcon` 导入
- `role/page.tsx`:删除未使用的 `getStoredAuth` 导入;两处未用的 `catch (err)` 改裸 `catch`

纯 lint 清理,无逻辑改动。