### PR TITLE
feat(portal): Track C — 运营者准入向导 + 管理/运营流程

### DIFF
--- a/aastar-frontend/app/operator/deploy/components/FormField.tsx
+++ b/aastar-frontend/app/operator/deploy/components/FormField.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+/**
+ * Labeled text/number input used across wizard step forms.
+ *
+ * @module app/operator/deploy/components/FormField
+ */
+interface FormFieldProps {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  type?: "text" | "number";
+  hint?: string;
+  mono?: boolean;
+  disabled?: boolean;
+}
+
+export default function FormField({
+  label,
+  value,
+  onChange,
+  placeholder,
+  type = "text",
+  hint,
+  mono,
+  disabled,
+}: FormFieldProps) {
+  return (
+    <label className="block">
+      <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</span>
+      <input
+        type={type}
+        value={value}
+        disabled={disabled}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={`w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:border-slate-500 dark:focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:focus:ring-emerald-500 disabled:opacity-60 ${
+          mono ? "font-mono" : ""
+        }`}
+      />
+      {hint && <span className="block text-xs text-gray-400 mt-1">{hint}</span>}
+    </label>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/components/StepCard.tsx
+++ b/aastar-frontend/app/operator/deploy/components/StepCard.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * Shared step shell: title + description, body, and a footer that surfaces the
+ * tx hash (Etherscan link) / error and the primary action button.
+ *
+ * @module app/operator/deploy/components/StepCard
+ */
+import type { ReactNode } from "react";
+import {
+  ArrowPathIcon,
+  ArrowTopRightOnSquareIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from "@heroicons/react/24/outline";
+import type { Hash } from "viem";
+import type { TxStatus } from "./useTxStep";
+
+const EXPLORER = "https://sepolia.etherscan.io";
+
+export function explorerTx(hash: string) {
+  return `${EXPLORER}/tx/${hash}`;
+}
+export function explorerAddr(addr: string) {
+  return `${EXPLORER}/address/${addr}`;
+}
+
+interface StepCardProps {
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  children?: ReactNode;
+  status?: TxStatus;
+  txHash?: Hash;
+  error?: string;
+  /** Footer action area (buttons). */
+  footer?: ReactNode;
+}
+
+export default function StepCard({
+  title,
+  description,
+  icon,
+  children,
+  status,
+  txHash,
+  error,
+  footer,
+}: StepCardProps) {
+  return (
+    <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-5">
+      <div className="flex items-start gap-3">
+        {icon && <div className="text-slate-700 dark:text-emerald-400 shrink-0 mt-0.5">{icon}</div>}
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+          {description && <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{description}</p>}
+        </div>
+      </div>
+
+      {children && <div className="space-y-4">{children}</div>}
+
+      {txHash && (
+        <div className="flex items-center gap-2 text-sm rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 px-3 py-2">
+          {status === "pending" ? (
+            <ArrowPathIcon className="h-4 w-4 animate-spin text-emerald-600 dark:text-emerald-400" />
+          ) : (
+            <CheckCircleIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+          )}
+          <span className="text-emerald-700 dark:text-emerald-300">
+            {status === "pending" ? "Pending" : "Confirmed"}
+          </span>
+          <a
+            href={explorerTx(txHash)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-auto inline-flex items-center gap-1 font-mono text-xs text-emerald-700 dark:text-emerald-300 hover:underline"
+          >
+            {txHash.slice(0, 10)}…{txHash.slice(-8)}
+            <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-start gap-2 text-sm rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-3 py-2 text-red-700 dark:text-red-300">
+          <ExclamationTriangleIcon className="h-4 w-4 shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {footer && <div className="flex items-center justify-between gap-3 pt-1">{footer}</div>}
+    </section>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/components/WizardButton.tsx
+++ b/aastar-frontend/app/operator/deploy/components/WizardButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+/**
+ * Primary / secondary wizard buttons with built-in loading + disabled states.
+ *
+ * @module app/operator/deploy/components/WizardButton
+ */
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+
+interface WizardButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  loading?: boolean;
+  variant?: "primary" | "secondary";
+  children: ReactNode;
+}
+
+export default function WizardButton({
+  loading = false,
+  variant = "primary",
+  children,
+  disabled,
+  className = "",
+  ...rest
+}: WizardButtonProps) {
+  const base =
+    "inline-flex items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed";
+  const styles =
+    variant === "primary"
+      ? "bg-slate-800 hover:bg-slate-700 text-white dark:bg-emerald-600 dark:hover:bg-emerald-500"
+      : "bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200";
+  return (
+    <button className={`${base} ${styles} ${className}`} disabled={disabled || loading} {...rest}>
+      {loading && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
+      {children}
+    </button>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/components/WizardProgress.tsx
+++ b/aastar-frontend/app/operator/deploy/components/WizardProgress.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+/**
+ * Horizontal step indicator for the onboarding wizard.
+ *
+ * @module app/operator/deploy/components/WizardProgress
+ */
+import { CheckIcon } from "@heroicons/react/24/outline";
+
+interface WizardProgressProps {
+  labels: string[];
+  current: number;
+}
+
+export default function WizardProgress({ labels, current }: WizardProgressProps) {
+  return (
+    <ol className="flex items-center w-full overflow-x-auto pb-2">
+      {labels.map((label, i) => {
+        const done = i < current;
+        const active = i === current;
+        return (
+          <li key={label} className="flex items-center shrink-0">
+            <div className="flex items-center gap-2">
+              <span
+                className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold ${
+                  done
+                    ? "bg-emerald-600 text-white"
+                    : active
+                      ? "bg-slate-800 text-white dark:bg-emerald-500"
+                      : "bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400"
+                }`}
+              >
+                {done ? <CheckIcon className="h-4 w-4" /> : i + 1}
+              </span>
+              <span
+                className={`text-xs font-medium whitespace-nowrap ${
+                  active
+                    ? "text-gray-900 dark:text-white"
+                    : "text-gray-400 dark:text-gray-500"
+                }`}
+              >
+                {label}
+              </span>
+            </div>
+            {i < labels.length - 1 && (
+              <span className="mx-3 h-px w-8 bg-gray-200 dark:bg-gray-700" aria-hidden />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/components/useTxStep.ts
+++ b/aastar-frontend/app/operator/deploy/components/useTxStep.ts
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * Transaction lifecycle hook for a single wizard step.
+ *
+ * Wraps a write action that returns a viem tx Hash, optionally waits for the
+ * receipt (so the next step can rely on the on-chain effect / read back the
+ * deployed address), and drives toast + button state. Errors are normalised to
+ * a human-readable string (wallet rejections collapse to "Transaction rejected").
+ *
+ * @module app/operator/deploy/components/useTxStep
+ */
+import { useCallback, useState } from "react";
+import type { Hash } from "viem";
+import toast from "react-hot-toast";
+import { getPublicClient } from "@/lib/sdk/client";
+
+export type TxStatus = "idle" | "pending" | "success" | "error";
+
+export interface UseTxStepResult {
+  status: TxStatus;
+  txHash?: Hash;
+  error?: string;
+  isBusy: boolean;
+  /**
+   * Run a write action. Returns the tx hash on success, or null on failure.
+   * @param action returns the tx hash (e.g. an @aastar/core action call)
+   * @param opts.waitReceipt await the receipt before resolving (default true)
+   * @param opts.loadingMsg / successMsg toast copy
+   */
+  run: (
+    action: () => Promise<Hash>,
+    opts?: { waitReceipt?: boolean; loadingMsg?: string; successMsg?: string }
+  ) => Promise<Hash | null>;
+  reset: () => void;
+}
+
+function humanizeError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  if (/user rejected|denied|rejected the request/i.test(raw)) return "Transaction rejected in wallet.";
+  if (/insufficient funds/i.test(raw)) return "Insufficient funds for gas.";
+  // viem stuffs the useful bit in the first line; keep it short for the UI.
+  return raw.split("\n")[0].slice(0, 200);
+}
+
+export function useTxStep(): UseTxStepResult {
+  const [status, setStatus] = useState<TxStatus>("idle");
+  const [txHash, setTxHash] = useState<Hash | undefined>();
+  const [error, setError] = useState<string | undefined>();
+
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setTxHash(undefined);
+    setError(undefined);
+  }, []);
+
+  const run = useCallback<UseTxStepResult["run"]>(async (action, opts) => {
+    const { waitReceipt = true, loadingMsg = "Confirm in your wallet…", successMsg = "Transaction confirmed" } =
+      opts ?? {};
+    setStatus("pending");
+    setError(undefined);
+    setTxHash(undefined);
+    const toastId = toast.loading(loadingMsg);
+    try {
+      const hash = await action();
+      setTxHash(hash);
+      if (waitReceipt) {
+        toast.loading("Waiting for confirmation…", { id: toastId });
+        const receipt = await getPublicClient().waitForTransactionReceipt({ hash });
+        if (receipt.status === "reverted") throw new Error("Transaction reverted on-chain.");
+      }
+      setStatus("success");
+      toast.success(successMsg, { id: toastId });
+      return hash;
+    } catch (err) {
+      const msg = humanizeError(err);
+      setError(msg);
+      setStatus("error");
+      toast.error(msg, { id: toastId });
+      return null;
+    }
+  }, []);
+
+  return { status, txHash, error, isBusy: status === "pending", run, reset };
+}

--- a/aastar-frontend/app/operator/deploy/page.tsx
+++ b/aastar-frontend/app/operator/deploy/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * Operator onboarding wizard — registry flow 1 ("AOA", self-hosted Paymaster V4)
+ * and flow 2 ("AOA+", shared SuperPaymaster).
+ *
+ * Fully client-side, no SSR: every transaction is signed in the operator's own
+ * browser wallet (viem WalletClient from WalletContext) against the @aastar/*
+ * SDK. The wizard threads a single `WizardData` object through ordered step
+ * components and re-runs the resource pre-check after each mutating step so
+ * already-satisfied prerequisites are skipped.
+ *
+ *   AOA : connect → resources → community → xPNTs → paymaster → entrypoint → done
+ *   AOA+: connect → resources → community → xPNTs → super → configure → aPNTs → done
+ *
+ * @module app/operator/deploy/page
+ */
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { RocketLaunchIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import Layout from "@/components/Layout";
+import { useWallet } from "@/contexts/WalletContext";
+import { checkResources, clearResourceCaches } from "@/lib/resources/resourceChecker";
+import type { Address } from "viem";
+
+import { initialWizardData, type StepProps, type WizardData } from "./steps/types";
+import WizardProgress from "./components/WizardProgress";
+import WizardButton from "./components/WizardButton";
+import Step1ConnectSelect from "./steps/Step1ConnectSelect";
+import Step2ResourceCheck from "./steps/Step2ResourceCheck";
+import Step3RegisterCommunity from "./steps/Step3RegisterCommunity";
+import Step4DeployXPNTs from "./steps/Step4DeployXPNTs";
+import Step5DeployPaymasterV4 from "./steps/Step5DeployPaymasterV4";
+import Step6EntryPointDeposit from "./steps/Step6EntryPointDeposit";
+import Step5RegisterSuper from "./steps/Step5RegisterSuper";
+import Step6ConfigureOperator from "./steps/Step6ConfigureOperator";
+import Step7DepositAPNTs from "./steps/Step7DepositAPNTs";
+import StepComplete from "./steps/StepComplete";
+
+const LABELS: Record<string, string> = {
+  connect: "Connect",
+  resources: "Resources",
+  community: "Community",
+  xpnts: "xPNTs",
+  paymaster: "Paymaster",
+  entrypoint: "EntryPoint",
+  "register-super": "SuperPaymaster",
+  configure: "Configure",
+  "deposit-apnts": "aPNTs",
+  done: "Done",
+};
+
+export default function OperatorDeployPage() {
+  const router = useRouter();
+  const { address, walletClient } = useWallet();
+  const [step, setStep] = useState(0);
+  const [data, setData] = useState<WizardData>(initialWizardData);
+
+  const update = useCallback((patch: Partial<WizardData>) => {
+    setData(prev => ({ ...prev, ...patch }));
+  }, []);
+
+  const stepKeys = useMemo(() => {
+    const head = ["connect", "resources", "community", "xpnts"];
+    return data.mode === "aoa+"
+      ? [...head, "register-super", "configure", "deposit-apnts", "done"]
+      : [...head, "paymaster", "entrypoint", "done"];
+  }, [data.mode]);
+
+  const onNext = useCallback(() => setStep(s => Math.min(s + 1, stepKeys.length - 1)), [stepKeys.length]);
+  const onBack = useCallback(() => setStep(s => Math.max(s - 1, 0)), []);
+
+  const refreshResources = useCallback(async () => {
+    if (!address || !data.mode) return;
+    clearResourceCaches(address);
+    const status = await checkResources(address, data.mode);
+    setData(prev => ({
+      ...prev,
+      resources: status,
+      xPNTsAddress: prev.xPNTsAddress ?? (status.xPNTsAddress as Address | undefined),
+      paymasterAddress: prev.paymasterAddress ?? (status.paymasterAddress as Address | undefined),
+    }));
+  }, [address, data.mode]);
+
+  const restart = useCallback(() => {
+    setData(initialWizardData);
+    setStep(0);
+  }, []);
+
+  const currentKey = stepKeys[step];
+
+  // Steps after connect require a live wallet client.
+  const needWallet = step > 0 && (!address || !walletClient);
+
+  const stepProps: StepProps | null =
+    address && walletClient
+      ? { address, walletClient, data, update, onNext, onBack, refreshResources }
+      : null;
+
+  const renderStep = () => {
+    if (currentKey === "connect") {
+      return <Step1ConnectSelect data={data} update={update} onNext={onNext} />;
+    }
+    if (needWallet || !stepProps) {
+      return (
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-4">
+          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+            <ExclamationTriangleIcon className="h-6 w-6" />
+            <span className="font-semibold">Wallet disconnected</span>
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            Reconnect your wallet to continue onboarding.
+          </p>
+          <WizardButton onClick={restart}>Back to start</WizardButton>
+        </section>
+      );
+    }
+    switch (currentKey) {
+      case "resources":
+        return <Step2ResourceCheck {...stepProps} />;
+      case "community":
+        return <Step3RegisterCommunity {...stepProps} />;
+      case "xpnts":
+        return <Step4DeployXPNTs {...stepProps} />;
+      case "paymaster":
+        return <Step5DeployPaymasterV4 {...stepProps} />;
+      case "entrypoint":
+        return <Step6EntryPointDeposit {...stepProps} />;
+      case "register-super":
+        return <Step5RegisterSuper {...stepProps} />;
+      case "configure":
+        return <Step6ConfigureOperator {...stepProps} />;
+      case "deposit-apnts":
+        return <Step7DepositAPNTs {...stepProps} />;
+      case "done":
+        return <StepComplete data={data} onDone={() => router.push("/operator")} onRestart={restart} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Layout requireAuth>
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <RocketLaunchIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+            Operator Onboarding
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Become a gas sponsor on the AAStar network — choose self-hosted (AOA) or shared (AOA+).
+          </p>
+        </div>
+
+        <WizardProgress labels={stepKeys.map(k => LABELS[k])} current={step} />
+
+        {renderStep()}
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step1ConnectSelect.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step1ConnectSelect.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Step 1 — connect the operator wallet and pick the onboarding mode.
+ *
+ *  - AOA  (flow 1): operator runs its own Paymaster V4 node.
+ *  - AOA+ (flow 2): operator shares the protocol SuperPaymaster (lower stake,
+ *    aPNTs collateral, no node to maintain).
+ *
+ * Sets `data.mode` and advances. No on-chain writes here.
+ *
+ * @module app/operator/deploy/steps/Step1ConnectSelect
+ */
+import { useState } from "react";
+import { ServerStackIcon, BoltIcon, WalletIcon } from "@heroicons/react/24/outline";
+import { useWallet } from "@/contexts/WalletContext";
+import type { StakeMode, WizardData } from "./types";
+import StepCard from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+
+interface Step1Props {
+  data: WizardData;
+  update: (patch: Partial<WizardData>) => void;
+  onNext: () => void;
+}
+
+interface ModeMeta {
+  id: StakeMode;
+  title: string;
+  subtitle: string;
+  bullets: string[];
+  icon: typeof ServerStackIcon;
+}
+
+const MODES: ModeMeta[] = [
+  {
+    id: "aoa",
+    title: "AOA — Self-hosted Paymaster",
+    subtitle: "Run your own Paymaster V4 node",
+    bullets: [
+      "Deploy & register a dedicated Paymaster V4",
+      "Stake 30 GT (+30 GT to register community)",
+      "Fund the paymaster on EntryPoint with ETH",
+      "Full control, you maintain the node",
+    ],
+    icon: ServerStackIcon,
+  },
+  {
+    id: "aoa+",
+    title: "AOA+ — Shared SuperPaymaster",
+    subtitle: "Use the protocol SuperPaymaster",
+    bullets: [
+      "No node to deploy or maintain",
+      "Stake 50 GT (+30 GT to register community)",
+      "Deposit aPNTs collateral (≥ 1000)",
+      "Lower entry barrier, protocol-managed",
+    ],
+    icon: BoltIcon,
+  },
+];
+
+export default function Step1ConnectSelect({ data, update, onNext }: Step1Props) {
+  const { address, isConnecting, hasInjectedWallet, connect } = useWallet();
+  const [selected, setSelected] = useState<StakeMode | null>(data.mode);
+
+  const handleContinue = () => {
+    if (!selected) return;
+    update({ mode: selected, treasury: data.treasury || (address ?? "") });
+    onNext();
+  };
+
+  return (
+    <StepCard
+      title="Connect wallet & choose mode"
+      description="Operator transactions are signed in your own browser wallet on Sepolia."
+      icon={<WalletIcon className="h-6 w-6" />}
+      footer={
+        <>
+          <span className="text-xs text-gray-400">
+            {address ? (
+              <span className="font-mono">
+                {address.slice(0, 6)}…{address.slice(-4)}
+              </span>
+            ) : (
+              "Wallet not connected"
+            )}
+          </span>
+          {address ? (
+            <WizardButton onClick={handleContinue} disabled={!selected}>
+              Continue
+            </WizardButton>
+          ) : (
+            <WizardButton onClick={connect} loading={isConnecting} disabled={!hasInjectedWallet}>
+              {hasInjectedWallet ? "Connect Wallet" : "No wallet found"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {MODES.map(m => {
+          const active = selected === m.id;
+          const Icon = m.icon;
+          return (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => setSelected(m.id)}
+              className={`text-left rounded-xl border p-4 transition ${
+                active
+                  ? "border-slate-700 dark:border-emerald-500 ring-2 ring-slate-200 dark:ring-emerald-500/30 bg-slate-50 dark:bg-emerald-900/10"
+                  : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+              }`}
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Icon className="h-5 w-5 text-slate-700 dark:text-emerald-400" />
+                <span className="font-semibold text-gray-900 dark:text-white">{m.title}</span>
+              </div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">{m.subtitle}</p>
+              <ul className="space-y-1">
+                {m.bullets.map(b => (
+                  <li key={b} className="text-xs text-gray-600 dark:text-gray-300 flex gap-1.5">
+                    <span className="text-slate-400 dark:text-emerald-500">•</span>
+                    {b}
+                  </li>
+                ))}
+              </ul>
+            </button>
+          );
+        })}
+      </div>
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step2ResourceCheck.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step2ResourceCheck.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+/**
+ * Step 2 — resource pre-check. Runs `checkResources(address, mode)` and renders
+ * a checklist of prerequisites (GT / aPNTs / ETH balances + existing
+ * community / xPNTs / paymaster state). Gates "Continue" on having enough
+ * balances; the per-resource on-chain state is surfaced so later steps can be
+ * skipped when already satisfied.
+ *
+ * @module app/operator/deploy/steps/Step2ResourceCheck
+ */
+import { useCallback, useEffect, useState } from "react";
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  ClipboardDocumentCheckIcon,
+} from "@heroicons/react/24/outline";
+import { checkResources, clearResourceCaches } from "@/lib/resources/resourceChecker";
+import type { StepProps } from "./types";
+import StepCard from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+
+function Row({ label, ok, detail }: { label: string; ok: boolean; detail?: string }) {
+  return (
+    <div className="flex items-center gap-2 py-1.5">
+      {ok ? (
+        <CheckCircleIcon className="h-5 w-5 text-emerald-500 shrink-0" />
+      ) : (
+        <XCircleIcon className="h-5 w-5 text-red-400 shrink-0" />
+      )}
+      <span className="text-sm text-gray-700 dark:text-gray-200">{label}</span>
+      {detail && <span className="ml-auto text-xs font-mono text-gray-400">{detail}</span>}
+    </div>
+  );
+}
+
+export default function Step2ResourceCheck({ address, data, update, onNext, onBack }: StepProps) {
+  const mode = data.mode!;
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const res = data.resources;
+
+  const run = useCallback(
+    async (clear = false) => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        if (clear) clearResourceCaches(address);
+        const status = await checkResources(address, mode);
+        update({
+          resources: status,
+          xPNTsAddress: (status.xPNTsAddress as `0x${string}` | undefined) ?? undefined,
+          paymasterAddress: (status.paymasterAddress as `0x${string}` | undefined) ?? undefined,
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Resource check failed");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [address, mode, update]
+  );
+
+  useEffect(() => {
+    if (!data.resources) void run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const balancesOk = !!res && res.hasEnoughGToken && res.hasEnoughETH && (mode === "aoa" || res.hasEnoughAPNTs);
+
+  return (
+    <StepCard
+      title="Resource pre-check"
+      description={`Verifying prerequisites for ${mode.toUpperCase()} onboarding.`}
+      icon={<ClipboardDocumentCheckIcon className="h-6 w-6" />}
+      error={error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack}>
+            Back
+          </WizardButton>
+          <div className="flex items-center gap-2">
+            <WizardButton variant="secondary" onClick={() => run(true)} loading={loading}>
+              <ArrowPathIcon className="h-4 w-4" />
+              Refresh
+            </WizardButton>
+            <WizardButton onClick={onNext} disabled={!balancesOk || loading}>
+              Continue
+            </WizardButton>
+          </div>
+        </>
+      }
+    >
+      {loading && !res ? (
+        <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 py-6 justify-center">
+          <ArrowPathIcon className="h-5 w-5 animate-spin" />
+          Checking on-chain resources…
+        </div>
+      ) : res ? (
+        <div className="space-y-4">
+          <div className="rounded-xl bg-gray-50 dark:bg-gray-900 p-4">
+            <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Balances</p>
+            <Row
+              label={`GToken (need ${res.requiredGToken})`}
+              ok={res.hasEnoughGToken}
+              detail={`${parseFloat(res.gTokenBalance).toFixed(2)} GT`}
+            />
+            {mode === "aoa+" && (
+              <Row
+                label={`aPNTs (need ${res.requiredAPNTs})`}
+                ok={res.hasEnoughAPNTs}
+                detail={`${parseFloat(res.aPNTsBalance).toFixed(2)} aPNTs`}
+              />
+            )}
+            <Row
+              label={`ETH (need ${res.requiredETH})`}
+              ok={res.hasEnoughETH}
+              detail={`${parseFloat(res.ethBalance).toFixed(4)} ETH`}
+            />
+          </div>
+
+          <div className="rounded-xl bg-gray-50 dark:bg-gray-900 p-4">
+            <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">On-chain state</p>
+            <Row label="Community registered (ROLE_COMMUNITY)" ok={res.isCommunityRegistered} />
+            <Row label="xPNTs token deployed" ok={res.hasXPNTs} />
+            {mode === "aoa" ? (
+              <Row label="AOA Paymaster deployed" ok={res.hasAOAPaymaster} />
+            ) : (
+              <Row label="Registered on SuperPaymaster" ok={res.hasSuperPaymasterRegistered} />
+            )}
+          </div>
+
+          {!balancesOk && (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              Top up the missing balances, then click Refresh. On-chain state that is already satisfied will be
+              skipped automatically in the next steps.
+            </p>
+          )}
+        </div>
+      ) : null}
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step3RegisterCommunity.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step3RegisterCommunity.tsx
@@ -43,11 +43,17 @@ export default function Step3RegisterCommunity({
       async () => {
         ensureSdkConfig();
         const pc = getPublicClient();
-        // 1) ensure GToken allowance to GTokenStaking covers minStake + entryBurn
-        const cfg = await registryActions(REGISTRY_ADDRESS)(pc as any).getRoleConfig({
+        // 1) ensure GToken allowance to GTokenStaking covers stake + entry fee.
+        // The @aastar/core RoleConfigDetailed type declares `entryBurn`, but the
+        // deployed registry returns the fee under `ticketPrice` — the SDK type is
+        // out of sync with the on-chain struct. Read whichever exists (guarding
+        // against undefined so `minStake + undefined` can't throw), summing both
+        // only if both were ever present. `minStake` is always returned.
+        const cfg = (await registryActions(REGISTRY_ADDRESS)(pc as any).getRoleConfig({
           roleId: ROLE_COMMUNITY,
-        });
-        const needed = cfg.minStake + cfg.entryBurn;
+        })) as { minStake?: bigint; entryBurn?: bigint; ticketPrice?: bigint };
+        const entryFee = (cfg.entryBurn ?? 0n) + (cfg.ticketPrice ?? 0n);
+        const needed = (cfg.minStake ?? 0n) + entryFee;
         const token = tokenActions(GTOKEN_ADDRESS)(walletClient as any);
         const allowance = await tokenActions(GTOKEN_ADDRESS)(pc as any).allowance({
           token: GTOKEN_ADDRESS,

--- a/aastar-frontend/app/operator/deploy/steps/Step3RegisterCommunity.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step3RegisterCommunity.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * Step 3 — register the connected wallet as a Community (ROLE_COMMUNITY) on the
+ * v5 Registry. Two tx: approve GToken to GTokenStaking (skipped if allowance
+ * already covers the role's stake) then `registerRole(ROLE_COMMUNITY, user,
+ * roleData)`. In v5 the Registry is role-based — there is no on-chain
+ * CommunityProfile struct; community metadata (name / ENS) lives on the xPNTs
+ * token deployed in the next step — so `roleData` is empty bytes.
+ *
+ * Skipped automatically when the resource check already found ROLE_COMMUNITY.
+ *
+ * @module app/operator/deploy/steps/Step3RegisterCommunity
+ */
+import { UserPlusIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import {
+  registryActions,
+  tokenActions,
+  ROLE_COMMUNITY,
+  REGISTRY_ADDRESS,
+  GTOKEN_ADDRESS,
+  GTOKEN_STAKING_ADDRESS,
+} from "@aastar/core";
+import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
+import type { StepProps } from "./types";
+import { useTxStep } from "../components/useTxStep";
+import StepCard from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+
+export default function Step3RegisterCommunity({
+  address,
+  walletClient,
+  data,
+  onNext,
+  onBack,
+  refreshResources,
+}: StepProps) {
+  const already = !!data.resources?.isCommunityRegistered;
+  const tx = useTxStep();
+
+  const register = async () => {
+    await tx.run(
+      async () => {
+        ensureSdkConfig();
+        const pc = getPublicClient();
+        // 1) ensure GToken allowance to GTokenStaking covers minStake + entryBurn
+        const cfg = await registryActions(REGISTRY_ADDRESS)(pc as any).getRoleConfig({
+          roleId: ROLE_COMMUNITY,
+        });
+        const needed = cfg.minStake + cfg.entryBurn;
+        const token = tokenActions(GTOKEN_ADDRESS)(walletClient as any);
+        const allowance = await tokenActions(GTOKEN_ADDRESS)(pc as any).allowance({
+          token: GTOKEN_ADDRESS,
+          owner: address,
+          spender: GTOKEN_STAKING_ADDRESS,
+        });
+        if (allowance < needed) {
+          const approveHash = await token.approve({
+            token: GTOKEN_ADDRESS,
+            spender: GTOKEN_STAKING_ADDRESS,
+            amount: needed,
+          });
+          await pc.waitForTransactionReceipt({ hash: approveHash });
+        }
+        // 2) register ROLE_COMMUNITY (empty roleData — metadata lives on xPNTs)
+        return registryActions(REGISTRY_ADDRESS)(walletClient as any).registerRole({
+          roleId: ROLE_COMMUNITY,
+          user: address,
+          data: "0x",
+        });
+      },
+      { loadingMsg: "Registering community…", successMsg: "Community registered" }
+    );
+    await refreshResources?.();
+  };
+
+  return (
+    <StepCard
+      title="Register community"
+      description="Stake GToken and register ROLE_COMMUNITY on the Registry."
+      icon={<UserPlusIcon className="h-6 w-6" />}
+      status={tx.status}
+      txHash={tx.txHash}
+      error={tx.error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack} disabled={tx.isBusy}>
+            Back
+          </WizardButton>
+          {already || tx.status === "success" ? (
+            <WizardButton onClick={onNext}>Continue</WizardButton>
+          ) : (
+            <WizardButton onClick={register} loading={tx.isBusy}>
+              {tx.status === "error" ? "Retry" : "Register Community"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      {already ? (
+        <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+          <CheckCircleIcon className="h-5 w-5" />
+          This wallet already holds ROLE_COMMUNITY — skipping.
+        </div>
+      ) : (
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Approves GToken to GTokenStaking (only if needed) then calls{" "}
+          <code className="px-1 rounded bg-gray-100 dark:bg-gray-700 text-xs">registerRole(ROLE_COMMUNITY)</code>.
+          Stake amount is read from the role config on-chain.
+        </p>
+      )}
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step4DeployXPNTs.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step4DeployXPNTs.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+/**
+ * Step 4 — deploy the community's xPNTs gas token via xPNTsFactory.
+ *
+ * `paymasterAOA` is set to the zero address: in the AOA flow the Paymaster V4 is
+ * deployed in a later step, and AOA+ uses the shared SuperPaymaster, so the
+ * token is not bound to a specific paymaster at creation. The deployed address
+ * is read back from the factory and stored for the configure step (AOA+).
+ *
+ * Skipped automatically when the resource check already found an xPNTs token.
+ *
+ * @module app/operator/deploy/steps/Step4DeployXPNTs
+ */
+import { useState } from "react";
+import { CurrencyDollarIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import { parseEther, zeroAddress, type Address } from "viem";
+import { xPNTsFactoryActions, XPNTS_FACTORY_ADDRESS } from "@aastar/core";
+import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
+import type { StepProps } from "./types";
+import { useTxStep } from "../components/useTxStep";
+import StepCard, { explorerAddr } from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+import FormField from "../components/FormField";
+
+export default function Step4DeployXPNTs({
+  address,
+  walletClient,
+  data,
+  update,
+  onNext,
+  onBack,
+  refreshResources,
+}: StepProps) {
+  const already = !!data.resources?.hasXPNTs;
+  const existing = data.xPNTsAddress;
+  const tx = useTxStep();
+  const [local, setLocal] = useState({
+    name: data.tokenName,
+    symbol: data.tokenSymbol,
+    communityName: data.communityName,
+    communityENS: data.communityENS,
+    rate: data.exchangeRate,
+  });
+
+  const valid = local.name.trim() && local.symbol.trim() && parseFloat(local.rate || "0") > 0;
+
+  const deploy = async () => {
+    update({
+      tokenName: local.name,
+      tokenSymbol: local.symbol,
+      communityName: local.communityName,
+      communityENS: local.communityENS,
+      exchangeRate: local.rate,
+    });
+    const hash = await tx.run(
+      async () => {
+        ensureSdkConfig();
+        return xPNTsFactoryActions(XPNTS_FACTORY_ADDRESS)(walletClient as any).deployxPNTsToken({
+          name: local.name,
+          symbol: local.symbol,
+          communityName: local.communityName || local.name,
+          communityENS: local.communityENS || "",
+          exchangeRate: parseEther(local.rate || "1"),
+          paymasterAOA: zeroAddress,
+        });
+      },
+      { loadingMsg: "Deploying xPNTs token…", successMsg: "xPNTs token deployed" }
+    );
+    if (hash) {
+      ensureSdkConfig();
+      try {
+        const tokenAddr = (await xPNTsFactoryActions(XPNTS_FACTORY_ADDRESS)(
+          getPublicClient() as any
+        ).getTokenAddress({ community: address })) as Address;
+        update({ xPNTsAddress: tokenAddr });
+      } catch {
+        /* address read best-effort; resource refresh below also captures it */
+      }
+      await refreshResources?.();
+    }
+  };
+
+  return (
+    <StepCard
+      title="Deploy xPNTs token"
+      description="Your community's gas token, deployed through the protocol factory."
+      icon={<CurrencyDollarIcon className="h-6 w-6" />}
+      status={tx.status}
+      txHash={tx.txHash}
+      error={tx.error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack} disabled={tx.isBusy}>
+            Back
+          </WizardButton>
+          {already || tx.status === "success" ? (
+            <WizardButton onClick={onNext}>Continue</WizardButton>
+          ) : (
+            <WizardButton onClick={deploy} loading={tx.isBusy} disabled={!valid}>
+              {tx.status === "error" ? "Retry" : "Deploy Token"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      {already ? (
+        <div className="space-y-1 text-sm text-emerald-600 dark:text-emerald-400">
+          <div className="flex items-center gap-2">
+            <CheckCircleIcon className="h-5 w-5" />
+            xPNTs token already deployed — skipping.
+          </div>
+          {existing && (
+            <a
+              href={explorerAddr(existing)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-xs hover:underline break-all"
+            >
+              {existing}
+            </a>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <FormField label="Token Name" value={local.name} onChange={v => setLocal(s => ({ ...s, name: v }))} placeholder="My Community Points" />
+          <FormField label="Token Symbol" value={local.symbol} onChange={v => setLocal(s => ({ ...s, symbol: v.toUpperCase() }))} placeholder="MCP" />
+          <FormField label="Community Name" value={local.communityName} onChange={v => setLocal(s => ({ ...s, communityName: v }))} placeholder="My Community" />
+          <FormField label="Community ENS (optional)" value={local.communityENS} onChange={v => setLocal(s => ({ ...s, communityENS: v }))} placeholder="mycommunity.aastar.eth" mono />
+          <FormField label="Exchange Rate (1 aPNTs = ? xPNTs)" type="number" value={local.rate} onChange={v => setLocal(s => ({ ...s, rate: v }))} hint="Default 1:1" />
+        </div>
+      )}
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step5DeployPaymasterV4.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step5DeployPaymasterV4.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Step 5 (AOA) — deploy a Paymaster V4 and register ROLE_PAYMASTER_AOA in one
+ * orchestrated call via the high-level PaymasterOperatorClient. The client
+ * predicts the address, deploys through the factory, and registers with the
+ * 30 GT stake (approving GToken internally). The returned paymaster address is
+ * stored for the EntryPoint deposit step.
+ *
+ * Skipped automatically when the resource check already found an AOA paymaster.
+ *
+ * @module app/operator/deploy/steps/Step5DeployPaymasterV4
+ */
+import { ServerStackIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import { parseEther, type Address } from "viem";
+import { buildPaymasterOperatorClient } from "@/lib/sdk/operator";
+import type { StepProps } from "./types";
+import { useTxStep } from "../components/useTxStep";
+import StepCard, { explorerAddr } from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+
+export default function Step5DeployPaymasterV4({
+  walletClient,
+  data,
+  update,
+  onNext,
+  onBack,
+  refreshResources,
+}: StepProps) {
+  const already = !!data.resources?.hasAOAPaymaster;
+  const tx = useTxStep();
+  const paymaster = data.paymasterAddress;
+
+  const deploy = async () => {
+    await tx.run(
+      async () => {
+        const client = buildPaymasterOperatorClient(walletClient);
+        const result = await client.deployAndRegisterPaymasterV4({ stakeAmount: parseEther("30") });
+        update({ paymasterAddress: result.paymasterAddress as Address });
+        return result.registerHash;
+      },
+      { loadingMsg: "Deploying & registering Paymaster V4…", successMsg: "Paymaster V4 deployed & registered" }
+    );
+    await refreshResources?.();
+  };
+
+  return (
+    <StepCard
+      title="Deploy & register Paymaster V4"
+      description="Deploy your own AOA paymaster node and register ROLE_PAYMASTER_AOA."
+      icon={<ServerStackIcon className="h-6 w-6" />}
+      status={tx.status}
+      txHash={tx.txHash}
+      error={tx.error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack} disabled={tx.isBusy}>
+            Back
+          </WizardButton>
+          {already || tx.status === "success" ? (
+            <WizardButton onClick={onNext}>Continue</WizardButton>
+          ) : (
+            <WizardButton onClick={deploy} loading={tx.isBusy}>
+              {tx.status === "error" ? "Retry" : "Deploy Paymaster"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      {already ? (
+        <div className="space-y-1 text-sm text-emerald-600 dark:text-emerald-400">
+          <div className="flex items-center gap-2">
+            <CheckCircleIcon className="h-5 w-5" />
+            AOA paymaster already deployed — skipping.
+          </div>
+          {paymaster && (
+            <a href={explorerAddr(paymaster)} target="_blank" rel="noopener noreferrer" className="font-mono text-xs hover:underline break-all">
+              {paymaster}
+            </a>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          One-stop deploy: predicts the paymaster address, deploys the V4 proxy via the factory, and registers it
+          on the Registry with a 30 GT stake.
+        </p>
+      )}
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step5RegisterSuper.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step5RegisterSuper.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+/**
+ * Step 5 (AOA+) — register as a SuperPaymaster operator (ROLE_PAYMASTER_SUPER)
+ * via the high-level PaymasterOperatorClient one-stop API. It checks the
+ * ROLE_COMMUNITY prerequisite, approves GToken to GTokenStaking, and registers
+ * with the 50 GT stake (the "lockForSuperPaymaster" stake step is handled
+ * inside this call). aPNTs collateral is deposited in a later step.
+ *
+ * Skipped automatically when the resource check already found a SuperPaymaster
+ * registration.
+ *
+ * @module app/operator/deploy/steps/Step5RegisterSuper
+ */
+import { BoltIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
+import { parseEther } from "viem";
+import { buildPaymasterOperatorClient } from "@/lib/sdk/operator";
+import type { StepProps } from "./types";
+import { useTxStep } from "../components/useTxStep";
+import StepCard from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+
+export default function Step5RegisterSuper({ walletClient, data, onNext, onBack, refreshResources }: StepProps) {
+  const already = !!data.resources?.hasSuperPaymasterRegistered;
+  const tx = useTxStep();
+
+  const register = async () => {
+    await tx.run(
+      async () => {
+        const client = buildPaymasterOperatorClient(walletClient);
+        return client.registerAsSuperPaymasterOperator({ stakeAmount: parseEther("50") });
+      },
+      { loadingMsg: "Registering on SuperPaymaster…", successMsg: "Registered as SuperPaymaster operator" }
+    );
+    await refreshResources?.();
+  };
+
+  return (
+    <StepCard
+      title="Register on SuperPaymaster"
+      description="Stake 50 GT and register ROLE_PAYMASTER_SUPER on the shared SuperPaymaster."
+      icon={<BoltIcon className="h-6 w-6" />}
+      status={tx.status}
+      txHash={tx.txHash}
+      error={tx.error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack} disabled={tx.isBusy}>
+            Back
+          </WizardButton>
+          {already || tx.status === "success" ? (
+            <WizardButton onClick={onNext}>Continue</WizardButton>
+          ) : (
+            <WizardButton onClick={register} loading={tx.isBusy}>
+              {tx.status === "error" ? "Retry" : "Register Operator"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      {already ? (
+        <div className="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-400">
+          <CheckCircleIcon className="h-5 w-5" />
+          Already registered on SuperPaymaster — skipping.
+        </div>
+      ) : (
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          One-stop API: verifies ROLE_COMMUNITY, approves GToken to GTokenStaking, and registers
+          ROLE_PAYMASTER_SUPER with the 50 GT stake.
+        </p>
+      )}
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step6ConfigureOperator.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step6ConfigureOperator.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * Step 6 (AOA+) — configure operator parameters on the SuperPaymaster: bind the
+ * xPNTs gas token, treasury, and exchange rate via
+ * PaymasterOperatorClient.configureOperator (which maps to
+ * SuperPaymaster.configureOperator).
+ *
+ * @module app/operator/deploy/steps/Step6ConfigureOperator
+ */
+import { useState } from "react";
+import { Cog6ToothIcon } from "@heroicons/react/24/outline";
+import { parseEther, isAddress, type Address } from "viem";
+import { buildPaymasterOperatorClient } from "@/lib/sdk/operator";
+import type { StepProps } from "./types";
+import { useTxStep } from "../components/useTxStep";
+import StepCard from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+import FormField from "../components/FormField";
+
+export default function Step6ConfigureOperator({ address, walletClient, data, update, onNext, onBack }: StepProps) {
+  const tx = useTxStep();
+  const [treasury, setTreasury] = useState(data.treasury || address);
+  const [rate, setRate] = useState(data.exchangeRate);
+  const xPNTs = data.xPNTsAddress;
+  const valid = !!xPNTs && isAddress(treasury) && parseFloat(rate || "0") > 0;
+
+  const configure = async () => {
+    update({ treasury, exchangeRate: rate });
+    await tx.run(
+      async () => {
+        const client = buildPaymasterOperatorClient(walletClient);
+        return client.configureOperator(xPNTs as Address, treasury as Address, parseEther(rate || "1"));
+      },
+      { loadingMsg: "Configuring operator…", successMsg: "Operator configured" }
+    );
+  };
+
+  return (
+    <StepCard
+      title="Configure operator"
+      description="Bind your xPNTs token, treasury, and exchange rate on the SuperPaymaster."
+      icon={<Cog6ToothIcon className="h-6 w-6" />}
+      status={tx.status}
+      txHash={tx.txHash}
+      error={tx.error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack} disabled={tx.isBusy}>
+            Back
+          </WizardButton>
+          {tx.status === "success" ? (
+            <WizardButton onClick={onNext}>Continue</WizardButton>
+          ) : (
+            <WizardButton onClick={configure} loading={tx.isBusy} disabled={!valid}>
+              {tx.status === "error" ? "Retry" : "Configure"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      {!xPNTs ? (
+        <p className="text-sm text-amber-600 dark:text-amber-400">
+          No xPNTs token address available. Complete the xPNTs deploy step first.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            xPNTs token: <span className="font-mono break-all">{xPNTs}</span>
+          </p>
+          <FormField label="Treasury Address" value={treasury} onChange={setTreasury} mono placeholder="0x…" hint="Receives operator service fees" />
+          <FormField label="Exchange Rate (1 aPNTs = ? xPNTs)" type="number" value={rate} onChange={setRate} hint="Default 1:1" />
+        </div>
+      )}
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step6EntryPointDeposit.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step6EntryPointDeposit.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * Step 6 (AOA) — fund the freshly-deployed Paymaster V4 on the EntryPoint so it
+ * can sponsor gas. Calls `entryPointActions.depositTo({ account: paymaster,
+ * amount })` (payable — `amount` is forwarded as msg.value).
+ *
+ * @module app/operator/deploy/steps/Step6EntryPointDeposit
+ */
+import { useState } from "react";
+import { BanknotesIcon } from "@heroicons/react/24/outline";
+import { parseEther } from "viem";
+import { entryPointActions, ENTRY_POINT_ADDRESS } from "@aastar/core";
+import { ensureSdkConfig } from "@/lib/sdk/client";
+import type { StepProps } from "./types";
+import { useTxStep } from "../components/useTxStep";
+import StepCard from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+import FormField from "../components/FormField";
+
+export default function Step6EntryPointDeposit({ data, walletClient, update, onNext, onBack }: StepProps) {
+  const paymaster = data.paymasterAddress;
+  const tx = useTxStep();
+  const [eth, setEth] = useState(data.ethDeposit);
+  const valid = !!paymaster && parseFloat(eth || "0") > 0;
+
+  const deposit = async () => {
+    update({ ethDeposit: eth });
+    await tx.run(
+      async () => {
+        ensureSdkConfig();
+        return entryPointActions(ENTRY_POINT_ADDRESS)(walletClient as any).depositTo({
+          account: paymaster!,
+          amount: parseEther(eth || "0"),
+        });
+      },
+      { loadingMsg: "Depositing to EntryPoint…", successMsg: "Paymaster funded on EntryPoint" }
+    );
+  };
+
+  return (
+    <StepCard
+      title="Fund paymaster on EntryPoint"
+      description="Deposit ETH so your paymaster can sponsor user operations."
+      icon={<BanknotesIcon className="h-6 w-6" />}
+      status={tx.status}
+      txHash={tx.txHash}
+      error={tx.error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack} disabled={tx.isBusy}>
+            Back
+          </WizardButton>
+          {tx.status === "success" ? (
+            <WizardButton onClick={onNext}>Finish</WizardButton>
+          ) : (
+            <WizardButton onClick={deposit} loading={tx.isBusy} disabled={!valid}>
+              {tx.status === "error" ? "Retry" : "Deposit ETH"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      {!paymaster ? (
+        <p className="text-sm text-amber-600 dark:text-amber-400">
+          No paymaster address available. Complete the deploy step first.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Paymaster: <span className="font-mono">{paymaster}</span>
+          </p>
+          <FormField label="Deposit amount (ETH)" type="number" value={eth} onChange={setEth} hint="Recommended ≥ 0.05 ETH" />
+        </div>
+      )}
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/Step7DepositAPNTs.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step7DepositAPNTs.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * Step 7 (AOA+) — deposit aPNTs collateral to the SuperPaymaster so the
+ * operator can sponsor gas. Uses PaymasterOperatorClient.depositCollateral,
+ * which approves aPNTs and calls SuperPaymaster.deposit under the hood.
+ *
+ * @module app/operator/deploy/steps/Step7DepositAPNTs
+ */
+import { useState } from "react";
+import { BanknotesIcon } from "@heroicons/react/24/outline";
+import { parseEther } from "viem";
+import { buildPaymasterOperatorClient } from "@/lib/sdk/operator";
+import type { StepProps } from "./types";
+import { useTxStep } from "../components/useTxStep";
+import StepCard from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+import FormField from "../components/FormField";
+
+export default function Step7DepositAPNTs({ walletClient, data, update, onNext, onBack, refreshResources }: StepProps) {
+  const tx = useTxStep();
+  const [amount, setAmount] = useState(data.aPNTsDeposit);
+  const valid = parseFloat(amount || "0") > 0;
+
+  const deposit = async () => {
+    update({ aPNTsDeposit: amount });
+    const hash = await tx.run(
+      async () => {
+        const client = buildPaymasterOperatorClient(walletClient);
+        return client.depositCollateral(parseEther(amount || "0"));
+      },
+      { loadingMsg: "Depositing aPNTs collateral…", successMsg: "aPNTs collateral deposited" }
+    );
+    if (hash) await refreshResources?.();
+  };
+
+  return (
+    <StepCard
+      title="Deposit aPNTs collateral"
+      description="Fund your SuperPaymaster balance so you can sponsor user operations."
+      icon={<BanknotesIcon className="h-6 w-6" />}
+      status={tx.status}
+      txHash={tx.txHash}
+      error={tx.error}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onBack} disabled={tx.isBusy}>
+            Back
+          </WizardButton>
+          {tx.status === "success" ? (
+            <WizardButton onClick={onNext}>Finish</WizardButton>
+          ) : (
+            <WizardButton onClick={deposit} loading={tx.isBusy} disabled={!valid}>
+              {tx.status === "error" ? "Retry" : "Deposit aPNTs"}
+            </WizardButton>
+          )}
+        </>
+      }
+    >
+      <FormField label="Deposit amount (aPNTs)" type="number" value={amount} onChange={setAmount} hint="Minimum 1000 aPNTs" />
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/StepComplete.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/StepComplete.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * Final step — onboarding summary with links to the deployed artifacts.
+ *
+ * @module app/operator/deploy/steps/StepComplete
+ */
+import { CheckBadgeIcon, ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
+import type { WizardData } from "./types";
+import StepCard, { explorerAddr } from "../components/StepCard";
+import WizardButton from "../components/WizardButton";
+
+interface StepCompleteProps {
+  data: WizardData;
+  onDone: () => void;
+  onRestart: () => void;
+}
+
+function AddrRow({ label, addr }: { label: string; addr?: string }) {
+  if (!addr) return null;
+  return (
+    <div className="flex items-center justify-between gap-2 text-sm py-1">
+      <span className="text-gray-500 dark:text-gray-400">{label}</span>
+      <a
+        href={explorerAddr(addr)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 font-mono text-xs text-slate-700 dark:text-emerald-400 hover:underline"
+      >
+        {addr.slice(0, 8)}…{addr.slice(-6)}
+        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+      </a>
+    </div>
+  );
+}
+
+export default function StepComplete({ data, onDone, onRestart }: StepCompleteProps) {
+  return (
+    <StepCard
+      title="Onboarding complete"
+      description={`Your ${data.mode?.toUpperCase()} operator setup is live on Sepolia.`}
+      icon={<CheckBadgeIcon className="h-6 w-6" />}
+      footer={
+        <>
+          <WizardButton variant="secondary" onClick={onRestart}>
+            Start over
+          </WizardButton>
+          <WizardButton onClick={onDone}>Go to Operator Portal</WizardButton>
+        </>
+      }
+    >
+      <div className="rounded-xl bg-gray-50 dark:bg-gray-900 p-4">
+        <AddrRow label="xPNTs token" addr={data.xPNTsAddress} />
+        {data.mode === "aoa" && <AddrRow label="Paymaster V4" addr={data.paymasterAddress} />}
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        {data.mode === "aoa"
+          ? "Your paymaster is funded on the EntryPoint and ready to sponsor gas."
+          : "Your SuperPaymaster collateral is funded and your operator is configured."}
+      </p>
+    </StepCard>
+  );
+}

--- a/aastar-frontend/app/operator/deploy/steps/types.ts
+++ b/aastar-frontend/app/operator/deploy/steps/types.ts
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * Shared types for the operator onboarding wizard (registry flow 1 "AOA" /
+ * flow 2 "AOA+"). All transactions are signed in the operator's own browser
+ * wallet (viem WalletClient from WalletContext); no SSR / backend keys.
+ *
+ * @module app/operator/deploy/steps/types
+ */
+import type { Address, WalletClient } from "viem";
+import type { ResourceStatus, StakeMode } from "@/lib/resources/resourceChecker";
+
+export type { ResourceStatus, StakeMode };
+
+/** Cross-step wizard state, owned by page.tsx and threaded into each step. */
+export interface WizardData {
+  mode: StakeMode | null;
+  resources: ResourceStatus | null;
+  /** xPNTs token address — read back from the factory after deploy (or pre-existing). */
+  xPNTsAddress?: Address;
+  /** AOA Paymaster V4 address — returned by deployAndRegisterPaymasterV4. */
+  paymasterAddress?: Address;
+  /** Treasury that receives operator service fees (defaults to the connected EOA). */
+  treasury: string;
+  /** xPNTs <-> aPNTs exchange rate, human units (parseEther on submit). */
+  exchangeRate: string;
+  /** New xPNTs token metadata (only used when no token exists yet). */
+  tokenName: string;
+  tokenSymbol: string;
+  communityName: string;
+  communityENS: string;
+  /** EntryPoint deposit for the AOA paymaster (ETH). */
+  ethDeposit: string;
+  /** aPNTs collateral deposited to SuperPaymaster (AOA+). */
+  aPNTsDeposit: string;
+}
+
+export const initialWizardData: WizardData = {
+  mode: null,
+  resources: null,
+  treasury: "",
+  exchangeRate: "1",
+  tokenName: "",
+  tokenSymbol: "",
+  communityName: "",
+  communityENS: "",
+  ethDeposit: "0.05",
+  aPNTsDeposit: "1000",
+};
+
+/** Props every step component receives from the wizard container. */
+export interface StepProps {
+  address: Address;
+  walletClient: WalletClient;
+  data: WizardData;
+  update: (patch: Partial<WizardData>) => void;
+  onNext: () => void;
+  onBack?: () => void;
+  /** Re-run the resource pre-check (used after a step mutates on-chain state). */
+  refreshResources?: () => Promise<void>;
+}

--- a/aastar-frontend/app/operator/layout.tsx
+++ b/aastar-frontend/app/operator/layout.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+/**
+ * Operator-segment layout. Mounts WalletProvider for all operator portal pages
+ * (dashboard, deploy onboarding wizard, manage flows) — the operator's own EOA
+ * signs every write in the browser. Client-only, no SSR (static-export ready).
+ */
+import { WalletProvider } from "@/contexts/WalletContext";
+
+export default function OperatorLayout({ children }: { children: React.ReactNode }) {
+  return <WalletProvider>{children}</WalletProvider>;
+}

--- a/aastar-frontend/app/operator/manage/_components/shared.tsx
+++ b/aastar-frontend/app/operator/manage/_components/shared.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * Shared primitives for the operator "Manage" flows.
+ *
+ * - `reader()` returns a viem PublicClient for @aastar/core read actions. Because
+ *   @aastar/core bundles its OWN viem copy, its PublicClient/WalletClient type
+ *   identities differ from the frontend's; the handles are structurally identical
+ *   at runtime, so we hand them in as `any` (see lib/resources/resourceChecker.ts
+ *   `pc()`). The SDK action arg/return signatures stay fully type-checked.
+ * - `ensureSdkConfig()` must run before touching any `*_ADDRESS` constant; `reader()`
+ *   does it for reads, and each write path calls it before reading address consts.
+ *
+ * Files in `_components` are underscore-prefixed → excluded from Next.js routing.
+ *
+ * @module app/operator/manage/_components/shared
+ */
+import { ReactNode } from "react";
+import { ArrowPathIcon, CheckBadgeIcon, XCircleIcon, WalletIcon } from "@heroicons/react/24/outline";
+import { useWallet } from "@/contexts/WalletContext";
+import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
+
+/** PublicClient handle for @aastar/core read actions (untyped on purpose — see module doc). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function reader(): any {
+  ensureSdkConfig();
+  return getPublicClient();
+}
+
+export const EXPLORER_BASE = "https://sepolia.etherscan.io";
+export const txUrl = (hash: string) => `${EXPLORER_BASE}/tx/${hash}`;
+export const addrUrl = (addr: string) => `${EXPLORER_BASE}/address/${addr}`;
+
+export function shortAddr(addr?: string | null): string {
+  if (!addr) return "—";
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+export function errMsg(e: unknown): string {
+  if (e && typeof e === "object") {
+    const anyE = e as { shortMessage?: string; message?: string };
+    return anyE.shortMessage || anyE.message || String(e);
+  }
+  return String(e);
+}
+
+export function eqAddr(a?: string | null, b?: string | null): boolean {
+  return !!a && !!b && a.toLowerCase() === b.toLowerCase();
+}
+
+// ── Presentational primitives ────────────────────────────────────────────────
+
+interface SectionProps {
+  title: string;
+  action?: ReactNode;
+  children: ReactNode;
+}
+
+export function Section({ title, action, children }: SectionProps) {
+  return (
+    <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
+        {action}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+  unit?: string;
+  sub?: string;
+  mono?: boolean;
+}
+
+export function MetricCard({ label, value, unit, sub, mono }: MetricCardProps) {
+  return (
+    <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+      <p className="text-xs text-gray-500 mb-1">{label}</p>
+      <p
+        className={`font-bold text-gray-900 dark:text-white break-all ${
+          mono ? "text-sm font-mono" : "text-xl"
+        }`}
+      >
+        {value}
+      </p>
+      {unit && <p className="text-xs text-gray-400">{unit}</p>}
+      {sub && <p className="text-xs text-gray-400 mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+interface StatusBadgeProps {
+  active: boolean;
+  label: string;
+}
+
+export function StatusBadge({ active, label }: StatusBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+        active
+          ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
+          : "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
+      }`}
+    >
+      {active ? <CheckBadgeIcon className="h-3.5 w-3.5" /> : <XCircleIcon className="h-3.5 w-3.5" />}
+      {label}
+    </span>
+  );
+}
+
+export function Spinner() {
+  return (
+    <div className="flex items-center justify-center min-h-[40vh]">
+      <ArrowPathIcon className="h-8 w-8 animate-spin text-slate-600 dark:text-emerald-400" />
+    </div>
+  );
+}
+
+interface ErrorBoxProps {
+  message: string;
+}
+
+export function ErrorBox({ message }: ErrorBoxProps) {
+  if (!message) return null;
+  return (
+    <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
+      {message}
+    </div>
+  );
+}
+
+interface TxLinkProps {
+  hash: string;
+}
+
+export function TxLink({ hash }: TxLinkProps) {
+  if (!hash) return null;
+  return (
+    <a
+      href={txUrl(hash)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-xs font-mono text-emerald-600 dark:text-emerald-400 hover:underline break-all"
+    >
+      Tx: {shortAddr(hash)} ↗
+    </a>
+  );
+}
+
+/**
+ * Gate that requires an injected EOA connection before rendering children.
+ * Renders a Connect button (or a "no wallet" notice) otherwise.
+ */
+export function ConnectGate({ children }: { children: ReactNode }) {
+  const { address, isConnecting, hasInjectedWallet, connect } = useWallet();
+
+  if (address) return <>{children}</>;
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-8 text-center space-y-4">
+      <WalletIcon className="h-10 w-10 mx-auto text-slate-400 dark:text-emerald-400" />
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Connect your operator wallet to manage on-chain resources.
+      </p>
+      {hasInjectedWallet ? (
+        <button
+          onClick={() => void connect()}
+          disabled={isConnecting}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-medium"
+        >
+          {isConnecting ? (
+            <ArrowPathIcon className="h-4 w-4 animate-spin" />
+          ) : (
+            <WalletIcon className="h-4 w-4" />
+          )}
+          {isConnecting ? "Connecting…" : "Connect Wallet"}
+        </button>
+      ) : (
+        <p className="text-xs text-amber-600 dark:text-amber-400">
+          No injected wallet found. Install MetaMask or a compatible wallet.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/aastar-frontend/app/operator/manage/page.tsx
+++ b/aastar-frontend/app/operator/manage/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * Operator "Manage" hub — entry point to the browser-signed management flows:
+ *   - xPNTs management (registry flow 3)
+ *   - AOA daily ops: PaymasterV4 (flow 6)
+ *   - AOA+ daily ops: SuperPaymaster operator account (flow 7)
+ *
+ * All transactions are signed by the operator's own injected EOA via WalletContext.
+ */
+import Link from "next/link";
+import {
+  Cog6ToothIcon,
+  CurrencyDollarIcon,
+  CreditCardIcon,
+  ServerStackIcon,
+  ArrowRightIcon,
+} from "@heroicons/react/24/outline";
+import Layout from "@/components/Layout";
+import { useWallet } from "@/contexts/WalletContext";
+import { ConnectGate, shortAddr, addrUrl } from "./_components/shared";
+
+interface FlowCardProps {
+  href: string;
+  title: string;
+  description: string;
+  flow: string;
+  icon: React.ReactNode;
+}
+
+function FlowCard({ href, title, description, flow, icon }: FlowCardProps) {
+  return (
+    <Link
+      href={href}
+      className="group block bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 hover:border-emerald-400 dark:hover:border-emerald-500 transition"
+    >
+      <div className="flex items-start justify-between">
+        <div className="h-10 w-10 rounded-xl bg-emerald-50 dark:bg-emerald-900/30 flex items-center justify-center text-emerald-600 dark:text-emerald-400">
+          {icon}
+        </div>
+        <span className="text-xs text-gray-400">{flow}</span>
+      </div>
+      <h3 className="mt-4 text-base font-semibold text-gray-900 dark:text-white flex items-center gap-1">
+        {title}
+        <ArrowRightIcon className="h-4 w-4 opacity-0 group-hover:opacity-100 transition" />
+      </h3>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+    </Link>
+  );
+}
+
+export default function OperatorManagePage() {
+  const { address } = useWallet();
+
+  return (
+    <Layout requireAuth>
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <Cog6ToothIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+            Operator Management
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Manage your community xPNTs token and run day-to-day paymaster operations.
+          </p>
+          {address && (
+            <p className="mt-2 text-xs text-gray-400">
+              Operator:{" "}
+              <a
+                href={addrUrl(address)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-emerald-600 dark:text-emerald-400 hover:underline"
+              >
+                {shortAddr(address)}
+              </a>
+            </p>
+          )}
+        </div>
+
+        <ConnectGate>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <FlowCard
+              href="/operator/manage/xpnts"
+              title="xPNTs Token"
+              description="Deploy your community points token or mint points to users."
+              flow="Flow 3"
+              icon={<CurrencyDollarIcon className="h-6 w-6" />}
+            />
+            <FlowCard
+              href="/operator/manage/paymaster"
+              title="AOA Paymaster"
+              description="PaymasterV4 status, EntryPoint top-up and configuration."
+              flow="Flow 6"
+              icon={<CreditCardIcon className="h-6 w-6" />}
+            />
+            <FlowCard
+              href="/operator/manage/superpaymaster"
+              title="AOA+ SuperPaymaster"
+              description="Shared SuperPaymaster operator account and aPNTs collateral."
+              flow="Flow 7"
+              icon={<ServerStackIcon className="h-6 w-6" />}
+            />
+          </div>
+        </ConnectGate>
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/app/operator/manage/paymaster/page.tsx
+++ b/aastar-frontend/app/operator/manage/paymaster/page.tsx
@@ -1,0 +1,417 @@
+"use client";
+
+/**
+ * AOA daily operations — PaymasterV4 (registry flow 6).
+ *
+ * Resolves the operator's deployed PaymasterV4 via PaymasterFactory, then shows
+ * its config (owner / treasury / serviceFeeRate / maxGasCostCap / paused) and
+ * EntryPoint deposit balance. Owner-only writes:
+ *   - EntryPoint top-up   → entryPointActions.depositTo
+ *   - setServiceFeeRate / setTreasury / setMaxGasCostCap / pause / unpause
+ *     (all exposed on PaymasterActions — confirmed against paymaster.d.ts).
+ *
+ * Reads use a PublicClient (`reader()`); writes use the WalletClient cast to `any`.
+ */
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { formatEther, isAddress, parseEther } from "viem";
+import type { Address } from "viem";
+import toast from "react-hot-toast";
+import {
+  ArrowLeftIcon,
+  CreditCardIcon,
+  ArrowPathIcon,
+  PlusCircleIcon,
+  PauseCircleIcon,
+  PlayCircleIcon,
+} from "@heroicons/react/24/outline";
+import {
+  paymasterActions,
+  entryPointActions,
+  paymasterFactoryActions,
+  PAYMASTER_FACTORY_ADDRESS,
+} from "@aastar/core";
+import Layout from "@/components/Layout";
+import { useWallet } from "@/contexts/WalletContext";
+import { ensureSdkConfig } from "@/lib/sdk/client";
+import {
+  ConnectGate,
+  Section,
+  MetricCard,
+  StatusBadge,
+  Spinner,
+  ErrorBox,
+  TxLink,
+  shortAddr,
+  addrUrl,
+  errMsg,
+  eqAddr,
+  reader,
+} from "../_components/shared";
+
+interface PaymasterState {
+  paymasterAddress: Address;
+  owner: Address;
+  treasury: Address;
+  serviceFeeRate: bigint;
+  maxGasCostCap: bigint;
+  paused: boolean;
+  entryPoint: Address;
+  entryPointBalance: string;
+}
+
+function AOAManager() {
+  const { address, walletClient } = useWallet();
+  const operator = address as Address;
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [state, setState] = useState<PaymasterState | null>(null);
+  const [noPaymaster, setNoPaymaster] = useState(false);
+
+  // Write form fields
+  const [depositAmount, setDepositAmount] = useState("");
+  const [feeRate, setFeeRate] = useState("");
+  const [treasury, setTreasury] = useState("");
+  const [gasCap, setGasCap] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [lastTx, setLastTx] = useState("");
+
+  const load = useCallback(async () => {
+    if (!operator) return;
+    setLoading(true);
+    setLoadError("");
+    setNoPaymaster(false);
+    try {
+      ensureSdkConfig();
+      const pf = paymasterFactoryActions(PAYMASTER_FACTORY_ADDRESS)(reader());
+      const has = await pf.hasPaymaster({ owner: operator });
+      if (!has) {
+        setState(null);
+        setNoPaymaster(true);
+        return;
+      }
+      const pmAddr = (await pf.getPaymasterByOperator({ operator })) as Address;
+      const pm = paymasterActions(pmAddr)(reader());
+      const [owner, treasuryAddr, serviceFeeRate, maxGasCostCap, paused, entryPoint] =
+        await Promise.all([
+          pm.owner(),
+          pm.treasury(),
+          pm.serviceFeeRate(),
+          pm.maxGasCostCap(),
+          pm.paused(),
+          pm.entryPoint(),
+        ]);
+      const epBal = await entryPointActions(entryPoint)(reader()).balanceOf({ account: pmAddr });
+      setState({
+        paymasterAddress: pmAddr,
+        owner,
+        treasury: treasuryAddr,
+        serviceFeeRate,
+        maxGasCostCap,
+        paused,
+        entryPoint,
+        entryPointBalance: formatEther(epBal),
+      });
+    } catch (e) {
+      setLoadError(errMsg(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [operator]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Generic write wrapper: confirm → submit → toast → reload.
+  const runWrite = async (key: string, label: string, fn: () => Promise<`0x${string}`>) => {
+    if (!walletClient) return;
+    setBusy(key);
+    setLastTx("");
+    const tid = toast.loading("Confirm in your wallet…");
+    try {
+      ensureSdkConfig();
+      const hash = await fn();
+      setLastTx(hash);
+      toast.success(`${label} submitted.`, { id: tid });
+      setTimeout(() => void load(), 4000);
+    } catch (e) {
+      toast.error(errMsg(e), { id: tid });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) return <Spinner />;
+
+  if (noPaymaster) {
+    return (
+      <Section title="No AOA Paymaster">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          This operator has not deployed a PaymasterV4 yet. Deploy one from the operator deploy flow
+          first, then return here to manage it.
+        </p>
+        <ErrorBox message={loadError} />
+      </Section>
+    );
+  }
+
+  if (!state) {
+    return <ErrorBox message={loadError || "Failed to load paymaster."} />;
+  }
+
+  const isOwner = eqAddr(state.owner, operator);
+  const pm = (client: unknown) => paymasterActions(state.paymasterAddress)(client as never);
+
+  return (
+    <div className="space-y-6">
+      <ErrorBox message={loadError} />
+
+      <Section
+        title="PaymasterV4 Status"
+        action={
+          <div className="flex items-center gap-2">
+            <StatusBadge active={!state.paused} label={state.paused ? "Paused" : "Active"} />
+            <button
+              onClick={() => void load()}
+              className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-emerald-600"
+            >
+              <ArrowPathIcon className="h-4 w-4" /> Refresh
+            </button>
+          </div>
+        }
+      >
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <MetricCard label="EntryPoint Balance" value={state.entryPointBalance} unit="ETH" />
+          <MetricCard label="Service Fee Rate" value={state.serviceFeeRate.toString()} unit="bps" />
+          <MetricCard
+            label="Max Gas Cost Cap"
+            value={formatEther(state.maxGasCostCap)}
+            unit="ETH"
+          />
+          <MetricCard label="Owner" value={shortAddr(state.owner)} mono />
+          <MetricCard label="Treasury" value={shortAddr(state.treasury)} mono />
+          <MetricCard label="EntryPoint" value={shortAddr(state.entryPoint)} mono />
+        </div>
+        <p className="mt-3 text-xs text-gray-400 font-mono break-all">
+          Paymaster:{" "}
+          <a
+            href={addrUrl(state.paymasterAddress)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-emerald-600 dark:text-emerald-400 hover:underline"
+          >
+            {state.paymasterAddress}
+          </a>
+        </p>
+      </Section>
+
+      {!isOwner && (
+        <div className="rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-3 text-xs text-amber-700 dark:text-amber-300">
+          Your wallet ({shortAddr(operator)}) is not the paymaster owner ({shortAddr(state.owner)}).
+          Configuration changes will revert. EntryPoint top-up is permissionless.
+        </div>
+      )}
+
+      <Section title="EntryPoint Top-up">
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+          Deposit ETH into the EntryPoint for this paymaster (anyone can fund).
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <input
+            type="text"
+            value={depositAmount}
+            onChange={e => setDepositAmount(e.target.value)}
+            placeholder="0.1"
+            className="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          />
+          <button
+            onClick={() => {
+              if (!depositAmount || parseFloat(depositAmount) <= 0) {
+                toast.error("Enter a positive ETH amount.");
+                return;
+              }
+              void runWrite("deposit", "EntryPoint deposit", () =>
+                entryPointActions(state.entryPoint)(walletClient as never).depositTo({
+                  account: state.paymasterAddress,
+                  amount: parseEther(depositAmount),
+                })
+              );
+            }}
+            disabled={busy === "deposit"}
+            className="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-medium"
+          >
+            {busy === "deposit" ? (
+              <ArrowPathIcon className="h-4 w-4 animate-spin" />
+            ) : (
+              <PlusCircleIcon className="h-4 w-4" />
+            )}
+            Deposit ETH
+          </button>
+        </div>
+      </Section>
+
+      <Section title="Configuration (owner only)">
+        <div className="space-y-4">
+          {/* Service fee rate */}
+          <ConfigRow
+            label="Service Fee Rate (bps)"
+            placeholder={state.serviceFeeRate.toString()}
+            value={feeRate}
+            onChange={setFeeRate}
+            busy={busy === "fee"}
+            disabled={!isOwner}
+            onSubmit={() => {
+              if (feeRate === "" || isNaN(Number(feeRate))) {
+                toast.error("Enter a fee rate in basis points.");
+                return;
+              }
+              void runWrite("fee", "Service fee rate", () =>
+                pm(walletClient).setServiceFeeRate({ _serviceFeeRate: BigInt(feeRate) })
+              );
+            }}
+          />
+          {/* Treasury */}
+          <ConfigRow
+            label="Treasury Address"
+            placeholder={state.treasury}
+            value={treasury}
+            onChange={setTreasury}
+            busy={busy === "treasury"}
+            disabled={!isOwner}
+            mono
+            onSubmit={() => {
+              if (!isAddress(treasury)) {
+                toast.error("Invalid treasury address.");
+                return;
+              }
+              void runWrite("treasury", "Treasury", () =>
+                pm(walletClient).setTreasury({ treasury: treasury as Address })
+              );
+            }}
+          />
+          {/* Max gas cost cap */}
+          <ConfigRow
+            label="Max Gas Cost Cap (ETH)"
+            placeholder={formatEther(state.maxGasCostCap)}
+            value={gasCap}
+            onChange={setGasCap}
+            busy={busy === "cap"}
+            disabled={!isOwner}
+            onSubmit={() => {
+              if (gasCap === "" || isNaN(Number(gasCap))) {
+                toast.error("Enter a cap in ETH.");
+                return;
+              }
+              void runWrite("cap", "Max gas cost cap", () =>
+                pm(walletClient).setMaxGasCostCap({ _maxGasCostCap: parseEther(gasCap) })
+              );
+            }}
+          />
+          {/* Pause / unpause */}
+          <div className="flex items-center justify-between pt-2 border-t border-gray-100 dark:border-gray-700">
+            <span className="text-sm text-gray-600 dark:text-gray-300">
+              Paymaster is currently {state.paused ? "paused" : "active"}.
+            </span>
+            <button
+              onClick={() =>
+                void runWrite(
+                  "pause",
+                  state.paused ? "Unpause" : "Pause",
+                  () => (state.paused ? pm(walletClient).unpause({}) : pm(walletClient).pause({}))
+                )
+              }
+              disabled={busy === "pause" || !isOwner}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {state.paused ? (
+                <PlayCircleIcon className="h-4 w-4" />
+              ) : (
+                <PauseCircleIcon className="h-4 w-4" />
+              )}
+              {state.paused ? "Unpause" : "Pause"}
+            </button>
+          </div>
+        </div>
+        {lastTx && (
+          <div className="mt-4">
+            <TxLink hash={lastTx} />
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+interface ConfigRowProps {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  busy: boolean;
+  disabled: boolean;
+  mono?: boolean;
+}
+
+function ConfigRow({
+  label,
+  placeholder,
+  value,
+  onChange,
+  onSubmit,
+  busy,
+  disabled,
+  mono,
+}: ConfigRowProps) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-end gap-3">
+      <label className="flex-1 block">
+        <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
+        <input
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          className={`mt-1 w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500 ${
+            mono ? "font-mono" : ""
+          }`}
+        />
+      </label>
+      <button
+        onClick={onSubmit}
+        disabled={busy || disabled}
+        className="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-800 dark:bg-emerald-600 dark:hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-medium"
+      >
+        {busy ? <ArrowPathIcon className="h-4 w-4 animate-spin" /> : null}
+        Update
+      </button>
+    </div>
+  );
+}
+
+export default function AOAPaymasterPage() {
+  return (
+    <Layout requireAuth>
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <Link
+            href="/operator/manage"
+            className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-emerald-600"
+          >
+            <ArrowLeftIcon className="h-4 w-4" /> Manage
+          </Link>
+          <h1 className="mt-2 text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <CreditCardIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+            AOA Paymaster
+            <span className="text-sm font-normal text-gray-400">Flow 6</span>
+          </h1>
+        </div>
+        <ConnectGate>
+          <AOAManager />
+        </ConnectGate>
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/app/operator/manage/superpaymaster/page.tsx
+++ b/aastar-frontend/app/operator/manage/superpaymaster/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+/**
+ * AOA+ daily operations — shared SuperPaymaster operator account (registry flow 7).
+ *
+ * Reads the operator's SuperPaymaster config via superPaymaster.operators({operator})
+ * (OperatorConfig: aPNTsBalance / isConfigured / isPaused / reputation / treasury /
+ * totalSpent / totalTxSponsored / exchangeRate / xPNTsToken). Supports topping up
+ * aPNTs collateral: ERC20 approve (if allowance insufficient) → superPaymaster.deposit.
+ *
+ * NOTE on deposit: we call superPaymasterActions(...).deposit({amount}) directly.
+ * The higher-level `buildPaymasterOperatorClient(walletClient).depositCollateral(amount)`
+ * (@aastar/operator) wraps the same approve+deposit and is an equivalent alternative.
+ *
+ * Reads use a PublicClient (`reader()`); writes use the WalletClient cast to `any`.
+ */
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { formatEther, parseEther } from "viem";
+import type { Address } from "viem";
+import toast from "react-hot-toast";
+import {
+  ArrowLeftIcon,
+  ServerStackIcon,
+  ArrowPathIcon,
+  PlusCircleIcon,
+} from "@heroicons/react/24/outline";
+import {
+  superPaymasterActions,
+  tokenActions,
+  SUPER_PAYMASTER_ADDRESS,
+  APNTS_ADDRESS,
+} from "@aastar/core";
+import Layout from "@/components/Layout";
+import { useWallet } from "@/contexts/WalletContext";
+import { ensureSdkConfig } from "@/lib/sdk/client";
+import {
+  ConnectGate,
+  Section,
+  MetricCard,
+  StatusBadge,
+  Spinner,
+  ErrorBox,
+  TxLink,
+  shortAddr,
+  errMsg,
+  reader,
+} from "../_components/shared";
+
+interface SPState {
+  isConfigured: boolean;
+  isPaused: boolean;
+  aPNTsBalance: string;
+  exchangeRate: string;
+  reputation: number;
+  treasury: Address;
+  xPNTsToken: Address;
+  totalSpent: string;
+  totalTxSponsored: string;
+  walletAPNTs: string;
+}
+
+function SuperPaymasterManager() {
+  const { address, walletClient } = useWallet();
+  const operator = address as Address;
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [state, setState] = useState<SPState | null>(null);
+
+  const [depositAmount, setDepositAmount] = useState("");
+  const [depositing, setDepositing] = useState(false);
+  const [lastTx, setLastTx] = useState("");
+
+  const load = useCallback(async () => {
+    if (!operator) return;
+    setLoading(true);
+    setLoadError("");
+    try {
+      ensureSdkConfig();
+      const sp = superPaymasterActions(SUPER_PAYMASTER_ADDRESS)(reader());
+      const cfg = await sp.operators({ operator });
+      const walletAPNTs = await tokenActions(APNTS_ADDRESS)(reader()).balanceOf({
+        token: APNTS_ADDRESS,
+        account: operator,
+      });
+      setState({
+        isConfigured: cfg.isConfigured,
+        isPaused: cfg.isPaused,
+        aPNTsBalance: formatEther(cfg.aPNTsBalance),
+        exchangeRate: formatEther(cfg.exchangeRate),
+        reputation: cfg.reputation,
+        treasury: cfg.treasury,
+        xPNTsToken: cfg.xPNTsToken,
+        totalSpent: formatEther(cfg.totalSpent),
+        totalTxSponsored: cfg.totalTxSponsored.toString(),
+        walletAPNTs: formatEther(walletAPNTs),
+      });
+    } catch (e) {
+      setLoadError(errMsg(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [operator]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleDeposit = async () => {
+    if (!walletClient) return;
+    if (!depositAmount || parseFloat(depositAmount) <= 0) {
+      toast.error("Enter a positive aPNTs amount.");
+      return;
+    }
+    setDepositing(true);
+    setLastTx("");
+    const amount = parseEther(depositAmount);
+    const tid = toast.loading("Checking aPNTs allowance…");
+    try {
+      ensureSdkConfig();
+      const apntsRead = tokenActions(APNTS_ADDRESS)(reader());
+      const allowance = await apntsRead.allowance({
+        token: APNTS_ADDRESS,
+        owner: operator,
+        spender: SUPER_PAYMASTER_ADDRESS,
+      });
+      if (allowance < amount) {
+        toast.loading("Approve aPNTs in your wallet…", { id: tid });
+        const apntsWrite = tokenActions(APNTS_ADDRESS)(walletClient as never);
+        await apntsWrite.approve({
+          token: APNTS_ADDRESS,
+          spender: SUPER_PAYMASTER_ADDRESS,
+          amount,
+        });
+      }
+      toast.loading("Confirm deposit in your wallet…", { id: tid });
+      const sp = superPaymasterActions(SUPER_PAYMASTER_ADDRESS)(walletClient as never);
+      const hash = await sp.deposit({ amount });
+      setLastTx(hash);
+      toast.success(`Deposited ${depositAmount} aPNTs.`, { id: tid });
+      setDepositAmount("");
+      setTimeout(() => void load(), 4000);
+    } catch (e) {
+      toast.error(errMsg(e), { id: tid });
+    } finally {
+      setDepositing(false);
+    }
+  };
+
+  if (loading) return <Spinner />;
+  if (!state) return <ErrorBox message={loadError || "Failed to load operator account."} />;
+
+  const lowBalance = parseFloat(state.aPNTsBalance) < 100;
+
+  return (
+    <div className="space-y-6">
+      <ErrorBox message={loadError} />
+
+      <Section
+        title="SuperPaymaster Account"
+        action={
+          <div className="flex items-center gap-2">
+            <StatusBadge active={state.isConfigured} label={state.isConfigured ? "Configured" : "Not configured"} />
+            <StatusBadge active={!state.isPaused} label={state.isPaused ? "Paused" : "Active"} />
+            <button
+              onClick={() => void load()}
+              className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-emerald-600"
+            >
+              <ArrowPathIcon className="h-4 w-4" /> Refresh
+            </button>
+          </div>
+        }
+      >
+        {!state.isConfigured && (
+          <div className="mb-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-3 text-xs text-blue-700 dark:text-blue-300">
+            This operator is not yet configured on the SuperPaymaster. Complete AOA+ registration
+            (deploy flow) first; this page manages the account once configured.
+          </div>
+        )}
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          <MetricCard
+            label="aPNTs Collateral"
+            value={state.aPNTsBalance}
+            unit="aPNTs"
+            sub={lowBalance ? "⚠ Low — top up" : undefined}
+          />
+          <MetricCard label="Exchange Rate" value={state.exchangeRate} unit="xPNTs / aPNTs" />
+          <MetricCard label="Reputation" value={state.reputation.toString()} />
+          <MetricCard label="Total Spent" value={state.totalSpent} unit="aPNTs" />
+          <MetricCard label="Tx Sponsored" value={state.totalTxSponsored} />
+          <MetricCard label="Treasury" value={shortAddr(state.treasury)} mono />
+        </div>
+        <p className="mt-3 text-xs text-gray-400 font-mono break-all">
+          xPNTs token: {shortAddr(state.xPNTsToken)} · Wallet aPNTs: {state.walletAPNTs}
+        </p>
+      </Section>
+
+      <Section title="Top up aPNTs Collateral">
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+          Approve (if needed) and deposit aPNTs collateral so the SuperPaymaster can keep sponsoring
+          your community&apos;s gas. Wallet balance: {state.walletAPNTs} aPNTs.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <input
+            type="text"
+            value={depositAmount}
+            onChange={e => setDepositAmount(e.target.value)}
+            placeholder="100"
+            className="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          />
+          <button
+            onClick={() => void handleDeposit()}
+            disabled={depositing}
+            className="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-medium"
+          >
+            {depositing ? (
+              <ArrowPathIcon className="h-4 w-4 animate-spin" />
+            ) : (
+              <PlusCircleIcon className="h-4 w-4" />
+            )}
+            {depositing ? "Depositing…" : "Deposit aPNTs"}
+          </button>
+        </div>
+        {lastTx && (
+          <div className="mt-3">
+            <TxLink hash={lastTx} />
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+export default function SuperPaymasterPage() {
+  return (
+    <Layout requireAuth>
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <Link
+            href="/operator/manage"
+            className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-emerald-600"
+          >
+            <ArrowLeftIcon className="h-4 w-4" /> Manage
+          </Link>
+          <h1 className="mt-2 text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <ServerStackIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+            AOA+ SuperPaymaster
+            <span className="text-sm font-normal text-gray-400">Flow 7</span>
+          </h1>
+        </div>
+        <ConnectGate>
+          <SuperPaymasterManager />
+        </ConnectGate>
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/app/operator/manage/xpnts/page.tsx
+++ b/aastar-frontend/app/operator/manage/xpnts/page.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+/**
+ * xPNTs management (registry flow 3).
+ *
+ * 1. Look up whether the connected community (operator EOA) already has an xPNTs
+ *    token via xPNTsFactory.hasToken / getTokenAddress.
+ * 2. If NOT deployed → deploy via xPNTsFactory.deployxPNTsToken.
+ * 3. If deployed → show token metadata + exchange rate, and let the token owner
+ *    mint points to a recipient (xPNTsToken.mint — caller must be the owner).
+ *
+ * Reads use a PublicClient (`reader()`); writes use the WalletContext WalletClient
+ * cast to `any` for @aastar/core actions (two viem copies — see shared.tsx).
+ */
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { formatEther, isAddress, parseEther } from "viem";
+import type { Address } from "viem";
+import toast from "react-hot-toast";
+import {
+  ArrowLeftIcon,
+  CurrencyDollarIcon,
+  ArrowPathIcon,
+  PaperAirplaneIcon,
+  RocketLaunchIcon,
+} from "@heroicons/react/24/outline";
+import {
+  xPNTsFactoryActions,
+  xPNTsTokenActions,
+  paymasterFactoryActions,
+  XPNTS_FACTORY_ADDRESS,
+  PAYMASTER_FACTORY_ADDRESS,
+} from "@aastar/core";
+import Layout from "@/components/Layout";
+import { useWallet } from "@/contexts/WalletContext";
+import { ensureSdkConfig } from "@/lib/sdk/client";
+import {
+  ConnectGate,
+  Section,
+  MetricCard,
+  Spinner,
+  ErrorBox,
+  TxLink,
+  shortAddr,
+  addrUrl,
+  errMsg,
+  eqAddr,
+  reader,
+} from "../_components/shared";
+
+interface TokenInfo {
+  address: Address;
+  name: string;
+  symbol: string;
+  communityName: string;
+  communityENS: string;
+  communityOwner: Address;
+  exchangeRate: string;
+  balance: string;
+}
+
+function XPNTsManager() {
+  const { address, walletClient } = useWallet();
+  const operator = address as Address;
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [token, setToken] = useState<TokenInfo | null>(null);
+
+  // Deploy form
+  const [name, setName] = useState("");
+  const [symbol, setSymbol] = useState("");
+  const [communityName, setCommunityName] = useState("");
+  const [communityENS, setCommunityENS] = useState("");
+  const [exchangeRate, setExchangeRate] = useState("1");
+  const [paymasterAOA, setPaymasterAOA] = useState("");
+  const [deploying, setDeploying] = useState(false);
+  const [deployTx, setDeployTx] = useState("");
+
+  // Mint form
+  const [mintTo, setMintTo] = useState("");
+  const [mintAmount, setMintAmount] = useState("");
+  const [minting, setMinting] = useState(false);
+  const [mintTx, setMintTx] = useState("");
+
+  const load = useCallback(async () => {
+    if (!operator) return;
+    setLoading(true);
+    setLoadError("");
+    try {
+      ensureSdkConfig();
+      const factory = xPNTsFactoryActions(XPNTS_FACTORY_ADDRESS)(reader());
+      const has = await factory.hasToken({ community: operator });
+      if (!has) {
+        setToken(null);
+        // Prefill the AOA paymaster field with the operator's deployed PaymasterV4
+        // (deployxPNTsToken auto-approves it as a spender). Falls back to manual.
+        try {
+          const pf = paymasterFactoryActions(PAYMASTER_FACTORY_ADDRESS)(reader());
+          if (await pf.hasPaymaster({ owner: operator })) {
+            const pm = await pf.getPaymasterByOperator({ operator });
+            setPaymasterAOA(pm);
+          }
+        } catch {
+          /* non-fatal: leave the field for manual entry */
+        }
+        return;
+      }
+      const tokenAddress = (await factory.getTokenAddress({ community: operator })) as Address;
+      const t = xPNTsTokenActions(tokenAddress)(reader());
+      const [meta, rate, balance] = await Promise.all([
+        t.getMetadata({ token: tokenAddress }),
+        t.exchangeRate({ token: tokenAddress }),
+        t.balanceOf({ token: tokenAddress, account: operator }),
+      ]);
+      setToken({
+        address: tokenAddress,
+        name: meta.name,
+        symbol: meta.symbol,
+        communityName: meta.communityName,
+        communityENS: meta.communityENS,
+        communityOwner: meta.communityOwner,
+        exchangeRate: formatEther(rate),
+        balance: formatEther(balance),
+      });
+    } catch (e) {
+      setLoadError(errMsg(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [operator]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleDeploy = async () => {
+    if (!walletClient) return;
+    if (!name || !symbol) {
+      toast.error("Name and symbol are required.");
+      return;
+    }
+    if (paymasterAOA && !isAddress(paymasterAOA)) {
+      toast.error("Invalid AOA paymaster address.");
+      return;
+    }
+    setDeploying(true);
+    setDeployTx("");
+    const tid = toast.loading("Confirm deployment in your wallet…");
+    try {
+      ensureSdkConfig();
+      const factory = xPNTsFactoryActions(XPNTS_FACTORY_ADDRESS)(walletClient as never);
+      const hash = await factory.deployxPNTsToken({
+        name,
+        symbol,
+        communityName: communityName || name,
+        communityENS: communityENS || "",
+        exchangeRate: parseEther(exchangeRate || "1"),
+        // Zero address = no AOA paymaster auto-approval yet (can bind later).
+        paymasterAOA: (paymasterAOA || "0x0000000000000000000000000000000000000000") as Address,
+      });
+      setDeployTx(hash);
+      toast.success("xPNTs token deployment submitted.", { id: tid });
+      // Re-read so the UI flips to the deployed view once mined.
+      setTimeout(() => void load(), 4000);
+    } catch (e) {
+      toast.error(errMsg(e), { id: tid });
+    } finally {
+      setDeploying(false);
+    }
+  };
+
+  const handleMint = async () => {
+    if (!walletClient || !token) return;
+    if (!isAddress(mintTo)) {
+      toast.error("Invalid recipient address.");
+      return;
+    }
+    if (!mintAmount || parseFloat(mintAmount) <= 0) {
+      toast.error("Enter a positive amount.");
+      return;
+    }
+    setMinting(true);
+    setMintTx("");
+    const tid = toast.loading("Confirm mint in your wallet…");
+    try {
+      ensureSdkConfig();
+      const t = xPNTsTokenActions(token.address)(walletClient as never);
+      const hash = await t.mint({
+        token: token.address,
+        to: mintTo as Address,
+        amount: parseEther(mintAmount),
+      });
+      setMintTx(hash);
+      toast.success(`Minted ${mintAmount} ${token.symbol}.`, { id: tid });
+      setMintTo("");
+      setMintAmount("");
+      setTimeout(() => void load(), 4000);
+    } catch (e) {
+      toast.error(errMsg(e), { id: tid });
+    } finally {
+      setMinting(false);
+    }
+  };
+
+  if (loading) return <Spinner />;
+
+  const isOwner = token ? eqAddr(token.communityOwner, operator) : false;
+
+  return (
+    <div className="space-y-6">
+      <ErrorBox message={loadError} />
+
+      {!token ? (
+        /* ── Not deployed → deploy form ─────────────────────────────────── */
+        <Section title="Deploy xPNTs Token">
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            Your community has no xPNTs token yet. Deploy one to start issuing points.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field label="Token Name" value={name} onChange={setName} placeholder="My Community Points" />
+            <Field label="Symbol" value={symbol} onChange={setSymbol} placeholder="MCP" />
+            <Field
+              label="Community Name"
+              value={communityName}
+              onChange={setCommunityName}
+              placeholder="My Community"
+            />
+            <Field
+              label="Community ENS (optional)"
+              value={communityENS}
+              onChange={setCommunityENS}
+              placeholder="mycommunity.eth"
+            />
+            <Field
+              label="Exchange Rate (xPNTs per aPNTs)"
+              value={exchangeRate}
+              onChange={setExchangeRate}
+              placeholder="1"
+            />
+            <Field
+              label="AOA Paymaster (optional)"
+              value={paymasterAOA}
+              onChange={setPaymasterAOA}
+              placeholder="0x… (auto-approved spender)"
+              mono
+            />
+          </div>
+          <button
+            onClick={() => void handleDeploy()}
+            disabled={deploying}
+            className="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-medium"
+          >
+            {deploying ? (
+              <ArrowPathIcon className="h-4 w-4 animate-spin" />
+            ) : (
+              <RocketLaunchIcon className="h-4 w-4" />
+            )}
+            {deploying ? "Deploying…" : "Deploy Token"}
+          </button>
+          {deployTx && (
+            <div className="mt-3">
+              <TxLink hash={deployTx} />
+            </div>
+          )}
+        </Section>
+      ) : (
+        /* ── Deployed → info + mint ─────────────────────────────────────── */
+        <>
+          <Section
+            title="xPNTs Token"
+            action={
+              <button
+                onClick={() => void load()}
+                className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-emerald-600"
+              >
+                <ArrowPathIcon className="h-4 w-4" /> Refresh
+              </button>
+            }
+          >
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <MetricCard label="Name" value={token.name} mono />
+              <MetricCard label="Symbol" value={token.symbol} mono />
+              <MetricCard label="Exchange Rate" value={token.exchangeRate} unit="xPNTs / aPNTs" />
+              <MetricCard label="Community" value={token.communityName} mono />
+              <MetricCard label="Your Balance" value={token.balance} unit={token.symbol} />
+              <MetricCard label="Owner" value={shortAddr(token.communityOwner)} mono />
+            </div>
+            <p className="mt-3 text-xs text-gray-400 font-mono break-all">
+              Token:{" "}
+              <a
+                href={addrUrl(token.address)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-600 dark:text-emerald-400 hover:underline"
+              >
+                {token.address}
+              </a>
+            </p>
+          </Section>
+
+          <Section title="Mint Points">
+            {!isOwner && (
+              <div className="mb-4 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-3 text-xs text-amber-700 dark:text-amber-300">
+                Only the token owner ({shortAddr(token.communityOwner)}) can mint. Your wallet is{" "}
+                {shortAddr(operator)}.
+              </div>
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <Field label="Recipient" value={mintTo} onChange={setMintTo} placeholder="0x…" mono />
+              <Field
+                label={`Amount (${token.symbol})`}
+                value={mintAmount}
+                onChange={setMintAmount}
+                placeholder="100"
+              />
+            </div>
+            <button
+              onClick={() => void handleMint()}
+              disabled={minting || !isOwner}
+              className="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white text-sm font-medium"
+            >
+              {minting ? (
+                <ArrowPathIcon className="h-4 w-4 animate-spin" />
+              ) : (
+                <PaperAirplaneIcon className="h-4 w-4" />
+              )}
+              {minting ? "Minting…" : "Mint"}
+            </button>
+            {mintTx && (
+              <div className="mt-3">
+                <TxLink hash={mintTx} />
+              </div>
+            )}
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  mono?: boolean;
+}
+
+function Field({ label, value, onChange, placeholder, mono }: FieldProps) {
+  return (
+    <label className="block">
+      <span className="text-xs text-gray-500 dark:text-gray-400">{label}</span>
+      <input
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={`mt-1 w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-emerald-500 ${
+          mono ? "font-mono" : ""
+        }`}
+      />
+    </label>
+  );
+}
+
+export default function XPNTsPage() {
+  return (
+    <Layout requireAuth>
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div>
+          <Link
+            href="/operator/manage"
+            className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-emerald-600"
+          >
+            <ArrowLeftIcon className="h-4 w-4" /> Manage
+          </Link>
+          <h1 className="mt-2 text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <CurrencyDollarIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+            xPNTs Token
+            <span className="text-sm font-normal text-gray-400">Flow 3</span>
+          </h1>
+        </div>
+        <ConnectGate>
+          <XPNTsManager />
+        </ConnectGate>
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/lib/sdk/operator.ts
+++ b/aastar-frontend/lib/sdk/operator.ts
@@ -1,0 +1,52 @@
+/**
+ * Track C write-flow SDK bootstrap for the operations portal.
+ *
+ * Operator onboarding / management transactions are signed in the browser by the
+ * operator's own EOA. This module turns the WalletContext `WalletClient` into the
+ * `@aastar/operator` orchestration clients, and re-exports the bits the flow
+ * pages need. Lower-level steps may instead call `@aastar/core` actions
+ * (registryActions / stakingActions / xPNTsFactoryActions / superPaymasterActions /
+ * sbtActions) directly with the same WalletClient.
+ *
+ * NOTE: `@aastar/community@0.18.0` is intentionally NOT used — its npm publish is
+ * missing `dist/` (tracked in aastar-sdk#52). Community/registry writes go through
+ * `@aastar/core` actions instead.
+ *
+ * @module lib/sdk/operator
+ */
+import type { WalletClient } from "viem";
+import { OperatorLifecycle, PaymasterOperatorClient } from "@aastar/operator";
+import { SUPER_PAYMASTER_ADDRESS, GTOKEN_ADDRESS } from "@aastar/core";
+import { ensureSdkConfig, getPublicClient } from "./client";
+
+// @aastar/* bundles its own viem copy, so its WalletClient/PublicClient type
+// identities differ from the frontend's. The clients are structurally identical
+// at runtime; we cast the config and keep the SDK method signatures type-checked.
+type AnyClientConfig = {
+  client: unknown;
+  publicClient?: unknown;
+  superPaymasterAddress: unknown;
+  tokenAddress?: unknown;
+};
+
+function baseConfig(walletClient: WalletClient): AnyClientConfig {
+  ensureSdkConfig();
+  return {
+    client: walletClient,
+    publicClient: getPublicClient(),
+    superPaymasterAddress: SUPER_PAYMASTER_ADDRESS,
+    tokenAddress: GTOKEN_ADDRESS,
+  };
+}
+
+/** High-level paymaster-operator client (register / deploy V4 / deposit / configure). */
+export function buildPaymasterOperatorClient(walletClient: WalletClient): PaymasterOperatorClient {
+  return new PaymasterOperatorClient(baseConfig(walletClient) as never);
+}
+
+/** Lifecycle orchestrator (setupNode / withdrawAllFunds). */
+export function buildOperatorLifecycle(walletClient: WalletClient): OperatorLifecycle {
+  return new OperatorLifecycle(baseConfig(walletClient) as never);
+}
+
+export { ensureSdkConfig, getPublicClient } from "./client";

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@aastar/airaccount": "^0.19.0",
     "@aastar/core": "^0.18.0",
+    "@aastar/operator": "^0.18.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",
@@ -25,10 +26,13 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "axios": "^1.13.1",
+    "i18next": "^25.10.10",
+    "i18next-browser-languagedetector": "^8.2.1",
     "next": "^16.1.1",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-hot-toast": "^2.6.0",
+    "react-i18next": "^16.6.6",
     "react-qr-code": "^2.0.18",
     "typescript": "^5",
     "viem": "^2.47.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "dependencies": {
         "@aastar/airaccount": "^0.19.0",
         "@aastar/core": "^0.18.0",
+        "@aastar/operator": "^0.18.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -91,10 +92,13 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "axios": "^1.13.1",
+        "i18next": "^25.10.10",
+        "i18next-browser-languagedetector": "^8.2.1",
         "next": "^16.1.1",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-hot-toast": "^2.6.0",
+        "react-i18next": "^16.6.6",
         "react-qr-code": "^2.0.18",
         "typescript": "^5",
         "viem": "^2.47.6"
@@ -1717,6 +1721,130 @@
         }
       }
     },
+    "node_modules/@aastar/operator": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/operator/-/operator-0.18.0.tgz",
+      "integrity": "sha512-7S7UBDVtTAhOBurCo2A4TGB8BE2kLxsNNhkRfwjFkRf5dJqpBZRXhSue6aPc/tZtYUjDQ+P2X8+4sCrEz28azA==",
+      "license": "MIT",
+      "dependencies": {
+        "@aastar/core": "0.18.0",
+        "viem": "2.43.3"
+      }
+    },
+    "node_modules/@aastar/operator/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmmirror.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@aastar/operator/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aastar/operator/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmmirror.com/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aastar/operator/node_modules/ox": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmmirror.com/ox/-/ox-0.11.1.tgz",
+      "integrity": "sha512-1l1gOLAqg0S0xiN1dH5nkPna8PucrZgrIJOfS49MLNiMevxu07Iz4ZjuJS9N+xifvT+PsZyIptS7WHM8nC+0+A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aastar/operator/node_modules/viem": {
+      "version": "2.43.3",
+      "resolved": "https://registry.npmmirror.com/viem/-/viem-2.43.3.tgz",
+      "integrity": "sha512-zM251fspfSjENCtfmT7cauuD+AA/YAlkFU7cksdEQJxj7wDuO0XFRWRH+RMvfmTFza88B9kug5cKU+Wk2nAjJg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.11.1",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aastar/operator/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
@@ -2339,6 +2467,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -12662,6 +12799,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmmirror.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -12716,6 +12862,46 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.10.10",
+      "resolved": "https://registry.npmmirror.com/i18next/-/i18next-25.10.10.tgz",
+      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmmirror.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+      "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -16920,6 +17106,33 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.6.6",
+      "resolved": "https://registry.npmmirror.com/react-i18next/-/react-i18next-16.6.6.tgz",
+      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.10.9",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -19656,6 +19869,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/walker": {


### PR DESCRIPTION
## 目标
registry 运营门户迁移 PR4(栈:#269/#301/#302/#303 已合 → 本 PR)。把 registry 的运营者写入流程迁入 YAA,**全部经 `@aastar/core` actions + `@aastar/operator` 客户端**(无 ethers 直连、无硬编码地址),纯客户端、浏览器内运营者 EOA 签名、**无 SSR(静态化就绪)**。

## 改动
- `app/operator/deploy/` — **AOA/AOA+ 准入向导**(多步状态机):连钱包+选模式 → 资源前置检查(复用 Track B `checkResources`)→ registerCommunity → 部署 xPNTs →【AOA】deployAndRegisterPaymasterV4 + EntryPoint 充值 /【AOA+】registerAsSuperPaymasterOperator + configureOperator + depositCollateral
- `app/operator/manage/` — **xPNTs 管理**(部署/铸造)、**AOA 日常运营**(PaymasterV4 配置 + EntryPoint 充值)、**AOA+ 日常运营**(SuperPaymaster 账户 + aPNTs 充值)
- `app/operator/layout.tsx` — 为 operator 段挂 `WalletProvider`

## 基座(已在 master / 本 PR base commit)
依赖 Track B 的 `WalletContext` / `lib/sdk/client` / `resourceChecker`,以及本 PR base 的 `lib/sdk/operator.ts`(`@aastar/operator` 客户端工厂)。

## 说明
- **未使用 `@aastar/community`**:其 npm 发布损坏(缺 dist,见 aastar-sdk#52);社区/registry 写入改走 `@aastar/core` actions。
- walletClient 传 `@aastar/core` action 时按既有约定 cast(两份 viem 类型身份)。
- 验证:`type-check` 0 错误、`next build` 全部路由静态、`lint:check` 干净。
- 待人工/PK review 重点核:registerRole 的 roleData 与质押来源(v5 纯角色制,详见代码注释存疑点)、各写操作的真实 testnet 行为(本地未连测试网跑链上)。

i18n(Track D)将作为 PR5 单独提。