### PR TITLE
feat(portal): Track D — i18next 中英双语基建

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,12 @@ jobs:
             cd ${{ matrix.project }} && npx eslint . --ext .js,.jsx,.ts,.tsx
           fi
 
+      - name: Check i18n locale parity
+        run: |
+          if [ -f ${{ matrix.project }}/package.json ] && jq -e '.scripts["i18n:check"]' ${{ matrix.project }}/package.json > /dev/null; then
+            npm run i18n:check --workspace=${{ matrix.project }}
+          fi
+
   # Job 3: Build all projects
   build:
     name: Build

--- a/aastar-frontend/app/layout.tsx
+++ b/aastar-frontend/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "react-hot-toast";
 import { ThemeProvider } from "@/lib/theme";
 import { DashboardProvider } from "@/contexts/DashboardContext";
 import { TaskProvider } from "@/contexts/TaskContext";
+import I18nProvider from "@/lib/i18n/I18nProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -46,14 +47,16 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <ThemeProvider>
-          <DashboardProvider>
-            <TaskProvider>
-              {children}
-              <Toaster position="top-right" />
-            </TaskProvider>
-          </DashboardProvider>
-        </ThemeProvider>
+        <I18nProvider>
+          <ThemeProvider>
+            <DashboardProvider>
+              <TaskProvider>
+                {children}
+                <Toaster position="top-right" />
+              </TaskProvider>
+            </DashboardProvider>
+          </ThemeProvider>
+        </I18nProvider>
       </body>
     </html>
   );

--- a/aastar-frontend/lib/i18n/I18nProvider.tsx
+++ b/aastar-frontend/lib/i18n/I18nProvider.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+/**
+ * I18nProvider — client-only i18next provider for the App Router.
+ *
+ * Integration (do NOT let me edit app/layout.tsx — wire it yourself):
+ *
+ *   // app/layout.tsx
+ *   import I18nProvider from "@/lib/i18n/I18nProvider";
+ *
+ *   export default function RootLayout({ children }: { children: React.ReactNode }) {
+ *     return (
+ *       <html lang="en">
+ *         <body>
+ *           <I18nProvider>{children}</I18nProvider>
+ *         </body>
+ *       </html>
+ *     );
+ *   }
+ *
+ * Place <I18nProvider> as high as possible (just inside <body>) so every client
+ * component below it can call useTranslation(). Keep it a client boundary — the
+ * i18next instance is initialized only on the client to avoid hydration drift.
+ */
+
+import { I18nextProvider } from "react-i18next";
+
+import i18n from "./config";
+
+export default function I18nProvider({ children }: { children: React.ReactNode }) {
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}

--- a/aastar-frontend/lib/i18n/LanguageSwitcher.tsx
+++ b/aastar-frontend/lib/i18n/LanguageSwitcher.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+/**
+ * LanguageSwitcher — EN / 中文 toggle for the operator portal header.
+ *
+ * Usage: import LanguageSwitcher from "@/lib/i18n/LanguageSwitcher";
+ *        <LanguageSwitcher />
+ *
+ * Renders nothing meaningful until mounted on the client to avoid a hydration
+ * mismatch on the active-language highlight (i18n is client-only).
+ */
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const LANGUAGES = [
+  { code: "en", label: "EN" },
+  { code: "zh", label: "中文" },
+] as const;
+
+type LangCode = (typeof LANGUAGES)[number]["code"];
+
+export default function LanguageSwitcher({ className = "" }: { className?: string }) {
+  const { i18n } = useTranslation();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const active: LangCode = i18n.resolvedLanguage?.startsWith("zh") ? "zh" : "en";
+
+  const changeLanguage = (code: LangCode) => {
+    if (code !== active) {
+      void i18n.changeLanguage(code);
+    }
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label="Language"
+      className={`inline-flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-0.5 text-sm font-medium dark:border-gray-700 dark:bg-gray-800 ${className}`}
+    >
+      {LANGUAGES.map((lang) => {
+        const isActive = mounted && active === lang.code;
+        return (
+          <button
+            key={lang.code}
+            type="button"
+            onClick={() => changeLanguage(lang.code)}
+            aria-pressed={isActive}
+            className={`rounded-md px-2.5 py-1 transition-colors ${
+              isActive
+                ? "bg-indigo-600 text-white shadow-sm"
+                : "text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+            }`}
+          >
+            {lang.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/aastar-frontend/lib/i18n/config.ts
+++ b/aastar-frontend/lib/i18n/config.ts
@@ -1,0 +1,46 @@
+/**
+ * i18next configuration for aastar-frontend (Next.js App Router, client-only).
+ *
+ * IMPORTANT: This module initializes i18next on the client only. Do NOT import
+ * it from a Server Component or from a module that runs during SSR, otherwise
+ * the server/client markup can diverge (hydration mismatch). It is consumed
+ * exclusively through `I18nProvider` ("use client"), which is the only place
+ * that should import this file.
+ *
+ * Ported/trimmed from registry: /Users/jason/Dev/aastar/registry/src/i18n/config.ts
+ */
+
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+
+import en from "./locales/en.json";
+import zh from "./locales/zh.json";
+
+// Guard against double init under React Strict Mode / Fast Refresh.
+if (!i18n.isInitialized) {
+  i18n
+    .use(LanguageDetector) // detect language from localStorage / navigator
+    .use(initReactI18next) // wire i18next into react-i18next
+    .init({
+      fallbackLng: "en",
+      resources: {
+        en: { translation: en },
+        zh: { translation: zh },
+      },
+      detection: {
+        order: ["localStorage", "navigator"],
+        caches: ["localStorage"],
+        lookupLocalStorage: "i18nextLng",
+      },
+      interpolation: {
+        escapeValue: false, // React already escapes values
+      },
+      react: {
+        // Render content immediately; resources are bundled so there is no async load.
+        useSuspense: false,
+      },
+    });
+}
+
+export default i18n;

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -1,0 +1,336 @@
+{
+  "common": {
+    "back": "Back",
+    "next": "Next",
+    "continue": "Continue",
+    "skip": "Skip",
+    "loading": "Loading...",
+    "refresh": "Refresh",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "get": "Get",
+    "retry": "Retry",
+    "close": "Close",
+    "save": "Save",
+    "submit": "Submit"
+  },
+  "header": {
+    "home": "Home",
+    "operators": "Operators",
+    "explorer": "Explorer",
+    "developers": "Developers",
+    "github": "GitHub",
+    "launchPaymaster": "Launch Wizard"
+  },
+  "portal": {
+    "wallet": {
+      "connect": "Connect Wallet",
+      "connecting": "Connecting...",
+      "connected": "Wallet Connected",
+      "disconnect": "Disconnect",
+      "notConnected": "Wallet not connected",
+      "wrongNetwork": "Wrong network",
+      "switchNetwork": "Switch Network",
+      "installMetaMask": "Please install MetaMask"
+    },
+    "resourceCheck": {
+      "title": "Resource Check",
+      "checking": "Checking resources...",
+      "ready": "Ready",
+      "notReady": "Not ready",
+      "sufficient": "Sufficient",
+      "insufficient": "Insufficient",
+      "recheck": "Re-check",
+      "balance": "Balance",
+      "required": "Required"
+    },
+    "deploy": {
+      "title": "Deploy",
+      "deploying": "Deploying...",
+      "deployed": "Deployed",
+      "notDeployed": "Not deployed",
+      "confirmInWallet": "Please confirm the transaction in your wallet",
+      "waitingConfirmation": "Waiting for on-chain confirmation...",
+      "viewTx": "View Transaction",
+      "viewExplorer": "View on Explorer"
+    },
+    "status": {
+      "success": "Success",
+      "failed": "Failed",
+      "pending": "Pending",
+      "submitted": "Transaction submitted"
+    },
+    "toast": {
+      "successTitle": "Success!",
+      "successMessage": "Operation completed successfully.",
+      "errorTitle": "Something went wrong",
+      "errorMessage": "The operation failed. Please try again.",
+      "txSubmitted": "Transaction submitted, waiting for confirmation."
+    }
+  },
+  "wizard": {
+    "title": "Deploy Your Paymaster",
+    "subtitle": "Complete {{totalSteps}}-step wizard to deploy and register your community Paymaster",
+    "selectNetwork": "Select Network:",
+    "chainId": "Chain ID",
+    "testnetBadge": "TESTNET",
+    "mainnetBadge": "MAINNET",
+    "needHelp": "Need Help?",
+    "deploymentGuide": "Read the Deployment Guide",
+    "steps": {
+      "connectAndSelect": "Connect & Select Mode",
+      "registerCommunity": "Register Community",
+      "resources": "Deploy Resources",
+      "config": "Configuration",
+      "deploy": "Deploy Paymaster",
+      "stake": "Stake",
+      "updateRegistry": "Update Registry",
+      "complete": "Complete"
+    },
+    "step2": {
+      "title": "Register Your Community",
+      "subtitle": "Lock GToken and register your community, then bind MySBT contract"
+    }
+  },
+  "step1": {
+    "substep1": {
+      "title": "Connect Your Wallet",
+      "description": "Please connect your MetaMask wallet to get started. Make sure you're on the correct network.",
+      "connectPrompt": "Please connect your MetaMask wallet to get started",
+      "connectButton": "Connect MetaMask",
+      "connecting": "Connecting...",
+      "connectHint": "Make sure you have MetaMask installed and are on the correct network"
+    },
+    "substep2": {
+      "title": "Choose Your Deployment Mode",
+      "description": "Select the deployment mode that best fits your needs.",
+      "modeNames": {
+        "standard": "Enhanced ERC-4337",
+        "standardSubtitle": "AOA (Asset Oriented Abstraction) optimizes traditional ERC-4337 by eliminating off-chain signature servers and on-chain verify cost.",
+        "super": "Super Mode: AOA+",
+        "superSubtitle": "Based on AOA, supports custom gas token and no individual contract deployment needed."
+      },
+      "selectButton": {
+        "standard": "Select Enhanced ERC-4337 (AOA)",
+        "super": "Select Super Mode (AOA+)"
+      }
+    },
+    "substep3": {
+      "title": "Verify Resource Requirements",
+      "description": "Based on your selection, verify that you have the necessary resources.",
+      "walletConnected": "Wallet Connected",
+      "selectedMode": "Selected Mode:",
+      "modeStandard": "Standard",
+      "modeSuper": "Super Mode",
+      "resourceCheck": "Resource Check",
+      "checkingWallet": "Checking wallet resources...",
+      "proceedButton": "Next → Configuration",
+      "notReady": "Please ensure all required resources are met"
+    }
+  },
+  "step2ResourceCheck": {
+    "header": {
+      "checking": "Check Resource Status",
+      "checkingSubtitle": "Detecting deployed resources...",
+      "failed": "Detection Failed",
+      "failedSubtitle": "Unable to detect resource status",
+      "title": "Resource Detection",
+      "aoaMode": "AOA Mode - Independent Paymaster",
+      "aoaPlusMode": "AOA+ Mode - SuperPaymaster"
+    },
+    "loading": {
+      "spinner": "Loading..."
+    },
+    "error": {
+      "button": "Retry Detection"
+    },
+    "resources": {
+      "community": {
+        "title": "Community Registration",
+        "registered": "Registered:",
+        "notRegistered": "Not Registered",
+        "action": "Register Now →"
+      },
+      "xpnts": {
+        "title": "xPNTs Token",
+        "deployed": "Deployed",
+        "address": "Address:",
+        "exchangeRate": "Rate: 1 xPNT =",
+        "exchangeRateSuffix": "aPNTs",
+        "notDeployed": "Not Deployed",
+        "action": "Deploy Now →"
+      },
+      "paymaster": {
+        "title": "Paymaster Deployment",
+        "deployed": "Deployed",
+        "address": "Address:",
+        "notDeployed": "Not Deployed",
+        "action": "Deploy Now →"
+      },
+      "sbt": {
+        "title": "MySBT Binding",
+        "requirePaymaster": "Deploy Paymaster first",
+        "bound": "Bound",
+        "notBound": "Not Bound",
+        "action": "Bind Now →"
+      },
+      "gtoken": {
+        "title": "GToken Balance",
+        "balance": "Balance:",
+        "suffix": "GT",
+        "required": "Required:",
+        "action": "Get GToken →"
+      },
+      "apnts": {
+        "title": "aPNTs Balance",
+        "balance": "Balance:",
+        "suffix": "aPNTs",
+        "required": "Required:",
+        "action": "Get aPNTs →"
+      },
+      "eth": {
+        "title": "ETH Balance",
+        "balance": "Balance:",
+        "suffix": "ETH",
+        "required": "Required:",
+        "requiredSuffix": "ETH (for gas)",
+        "faucetNote": "Please get Sepolia ETH from faucet"
+      }
+    },
+    "summary": {
+      "allReady": "All Resources Ready!",
+      "allReadyDescription": "You can proceed to the next step to complete the deployment.",
+      "notReady": "Some Resources Not Ready",
+      "notReadyDescription": "Please complete the missing resource deployments above, then click \"Re-detect\"."
+    },
+    "actions": {
+      "recheck": "Re-detect",
+      "back": "← Back",
+      "continue": "Continue →"
+    }
+  },
+  "registerCommunity": {
+    "title": "Register Community",
+    "subtitle": "Create and register your community on the AAstar Network",
+    "loading": "Loading...",
+    "connectWallet": "Connect Wallet",
+    "form": {
+      "basicInfo": "Basic Information",
+      "tokenSection": "Token",
+      "paymasterSection": "Paymaster",
+      "sbtSection": "MySBT",
+      "communityName": "Community Name",
+      "communityNamePlaceholder": "Enter community name",
+      "stakeAmount": "Stake Amount (GToken)",
+      "stakeAmountPlaceholder": "Minimum 30 GToken",
+      "stakeAmountHint": "Minimum stake",
+      "allowPermissionlessMint": "Allow Permissionless Mint",
+      "allowPermissionlessMintHint": "When enabled, users can mint community MySBT without invitation",
+      "deployXPNTs": "Deploy xPNTs Token →",
+      "deployPaymaster": "Deploy Paymaster →",
+      "unifiedMySBT": "All communities use unified MySBT white-label SBT"
+    },
+    "balance": {
+      "title": "Current Balance",
+      "gtoken": "GToken"
+    },
+    "insufficientBalance": {
+      "title": "Insufficient GToken Balance",
+      "required": "Required stake:",
+      "current": "Current balance:",
+      "message": "Please get enough GToken before registering community.",
+      "linkText": "Get GToken →"
+    },
+    "button": {
+      "registering": "Registering...",
+      "register": "Register"
+    },
+    "success": {
+      "title": "Transaction Submitted!",
+      "message": "Your community has been successfully registered!",
+      "txHash": "Transaction Hash",
+      "viewInExplorer": "View in Explorer",
+      "backToWizard": "Back to Wizard",
+      "viewTx": "View Transaction"
+    },
+    "errors": {
+      "walletNotConnected": "Please connect your wallet first",
+      "communityNameRequired": "Please enter community name",
+      "stakeAmountRequired": "Please enter stake amount",
+      "insufficientBalance": "Insufficient GToken balance!\nRequired: {{required}} GToken\nCurrent balance: {{current}} GToken",
+      "insufficientToStake": "Insufficient GToken balance! Need to stake {{need}} GToken, but you only have {{current}} GToken",
+      "alreadyRegistered": "This address is already registered as community: {{name}}",
+      "registrationFailed": "Community registration failed"
+    }
+  },
+  "getGToken": {
+    "title": "Get GToken",
+    "description": "Get protocol access permission GToken, become protocol member, join permissionless, quit anytime freely"
+  },
+  "getXPNTs": {
+    "title": "Deploy xPNTs",
+    "description": "Create your community gas token for payment abstraction",
+    "action": "Deploy"
+  },
+  "launchPaymaster": {
+    "title": "Launch Paymaster",
+    "description": "Deploy your Paymaster contract and start serving gasless transactions to your community",
+    "action": "Launch Paymaster →"
+  },
+  "operationGuide": {
+    "title": "Community Operator Guide",
+    "subtitle": "Master the SuperPaymaster ecosystem and build a thriving Web3 community economy",
+    "tabs": {
+      "overview": "Overview",
+      "gasToken": "Gas Token",
+      "revenue": "Revenue Model",
+      "tasks": "Task System",
+      "events": "Event Operations",
+      "analytics": "Data Analytics"
+    },
+    "overview": {
+      "title": "Community Operator Guide",
+      "description": "SuperPaymaster provides a complete toolset for community operators to build a prosperous Web3 community economy.",
+      "stats": {
+        "lowerBarrier": {
+          "title": "Lower Participation Barrier",
+          "description": "Members don't need to hold ETH to participate in on-chain activities, increasing community engagement"
+        },
+        "createValue": {
+          "title": "Create Economic Value",
+          "description": "Transform gas costs into community revenue, building a sustainable economic model"
+        },
+        "positiveCycle": {
+          "title": "Form Positive Cycle",
+          "description": "Task-points-consumption loop incentivizes continuous member contributions"
+        }
+      },
+      "quickStart": {
+        "title": "Quick Start",
+        "steps": {
+          "register": {
+            "title": "Register Community",
+            "description": "Register your community on-chain with basic information and governance tokens",
+            "link": "Register Now →"
+          },
+          "deploy": {
+            "title": "Deploy Tokens",
+            "description": "Issue community-exclusive xPNTs points tokens and MySBT identity tokens",
+            "link": "Issue Tokens →"
+          },
+          "launch": {
+            "title": "Launch Paymaster",
+            "description": "One-click deploy gas sponsorship contract and configure sponsorship rules",
+            "link": "Start Service →"
+          }
+        }
+      }
+    },
+    "footer": {
+      "title": "Need More Help?",
+      "description": "Contact our technical support team for professional community operation guidance",
+      "contactSupport": "Contact Support",
+      "viewDocs": "View Documentation"
+    }
+  }
+}

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -1,0 +1,336 @@
+{
+  "common": {
+    "back": "返回",
+    "next": "下一步",
+    "continue": "继续",
+    "skip": "跳过",
+    "loading": "加载中...",
+    "refresh": "刷新",
+    "cancel": "取消",
+    "confirm": "确认",
+    "get": "获取",
+    "retry": "重试",
+    "close": "关闭",
+    "save": "保存",
+    "submit": "提交"
+  },
+  "header": {
+    "home": "首页",
+    "operators": "运营商",
+    "explorer": "浏览器",
+    "developers": "开发者",
+    "github": "GitHub",
+    "launchPaymaster": "启动向导"
+  },
+  "portal": {
+    "wallet": {
+      "connect": "连接钱包",
+      "connecting": "连接中...",
+      "connected": "钱包已连接",
+      "disconnect": "断开连接",
+      "notConnected": "钱包未连接",
+      "wrongNetwork": "网络错误",
+      "switchNetwork": "切换网络",
+      "installMetaMask": "请安装 MetaMask"
+    },
+    "resourceCheck": {
+      "title": "资源检查",
+      "checking": "正在检查资源...",
+      "ready": "已就绪",
+      "notReady": "未就绪",
+      "sufficient": "充足",
+      "insufficient": "不足",
+      "recheck": "重新检查",
+      "balance": "余额",
+      "required": "需要"
+    },
+    "deploy": {
+      "title": "部署",
+      "deploying": "部署中...",
+      "deployed": "已部署",
+      "notDeployed": "未部署",
+      "confirmInWallet": "请在钱包中确认交易",
+      "waitingConfirmation": "等待链上确认...",
+      "viewTx": "查看交易",
+      "viewExplorer": "在浏览器中查看"
+    },
+    "status": {
+      "success": "成功",
+      "failed": "失败",
+      "pending": "处理中",
+      "submitted": "交易已提交"
+    },
+    "toast": {
+      "successTitle": "成功！",
+      "successMessage": "操作已成功完成。",
+      "errorTitle": "出错了",
+      "errorMessage": "操作失败，请重试。",
+      "txSubmitted": "交易已提交，等待确认。"
+    }
+  },
+  "wizard": {
+    "title": "部署您的 Paymaster",
+    "subtitle": "完成 {{totalSteps}} 步向导以部署和注册您的社区 Paymaster",
+    "selectNetwork": "选择网络：",
+    "chainId": "链 ID",
+    "testnetBadge": "测试网",
+    "mainnetBadge": "主网",
+    "needHelp": "需要帮助？",
+    "deploymentGuide": "阅读部署指南",
+    "steps": {
+      "connectAndSelect": "连接并选择模式",
+      "registerCommunity": "注册社区",
+      "resources": "部署资源",
+      "config": "配置",
+      "deploy": "部署 Paymaster",
+      "stake": "质押",
+      "updateRegistry": "更新 Registry",
+      "complete": "完成"
+    },
+    "step2": {
+      "title": "注册您的社区",
+      "subtitle": "锁定 GToken 并注册社区，然后绑定 MySBT 合约"
+    }
+  },
+  "step1": {
+    "substep1": {
+      "title": "连接您的钱包",
+      "description": "请连接您的 MetaMask 钱包以开始。确保您在正确的网络上。",
+      "connectPrompt": "请连接您的 MetaMask 钱包以开始",
+      "connectButton": "连接 MetaMask",
+      "connecting": "连接中...",
+      "connectHint": "确保您已安装 MetaMask 并且在正确的网络上"
+    },
+    "substep2": {
+      "title": "选择您的部署模式",
+      "description": "选择最适合您需求的部署模式。",
+      "modeNames": {
+        "standard": "增强型 ERC-4337",
+        "standardSubtitle": "AOA（资产导向抽象）通过消除离线签名服务器和链上验证成本来优化传统 ERC-4337。",
+        "super": "超级模式: AOA+",
+        "superSubtitle": "基于 AOA，支持自定义 gas token，无需单独合约部署。"
+      },
+      "selectButton": {
+        "standard": "选择增强型 ERC-4337（AOA）",
+        "super": "选择超级模式（AOA+）"
+      }
+    },
+    "substep3": {
+      "title": "验证资源要求",
+      "description": "基于您的选择，验证您拥有必需的资源。",
+      "walletConnected": "钱包已连接",
+      "selectedMode": "已选择模式：",
+      "modeStandard": "标准",
+      "modeSuper": "超级模式",
+      "resourceCheck": "资源检查",
+      "checkingWallet": "正在检查钱包资源...",
+      "proceedButton": "继续配置 →",
+      "notReady": "请确保满足所有必需资源"
+    }
+  },
+  "step2ResourceCheck": {
+    "header": {
+      "checking": "检查资源状态",
+      "checkingSubtitle": "正在检测已部署的资源...",
+      "failed": "检测失败",
+      "failedSubtitle": "无法检测资源状态",
+      "title": "资源检测",
+      "aoaMode": "AOA 模式 - 独立 Paymaster",
+      "aoaPlusMode": "AOA+ 模式 - SuperPaymaster"
+    },
+    "loading": {
+      "spinner": "加载中..."
+    },
+    "error": {
+      "button": "重新检测"
+    },
+    "resources": {
+      "community": {
+        "title": "社区注册",
+        "registered": "已注册:",
+        "notRegistered": "未注册",
+        "action": "立即注册 →"
+      },
+      "xpnts": {
+        "title": "xPNTs Token",
+        "deployed": "已部署",
+        "address": "地址:",
+        "exchangeRate": "汇率: 1 xPNT =",
+        "exchangeRateSuffix": "aPNTs",
+        "notDeployed": "未部署",
+        "action": "立即部署 →"
+      },
+      "paymaster": {
+        "title": "Paymaster 部署",
+        "deployed": "已部署",
+        "address": "地址:",
+        "notDeployed": "未部署",
+        "action": "立即部署 →"
+      },
+      "sbt": {
+        "title": "MySBT 绑定",
+        "requirePaymaster": "需先部署 Paymaster",
+        "bound": "已绑定",
+        "notBound": "未绑定",
+        "action": "立即绑定 →"
+      },
+      "gtoken": {
+        "title": "GToken 余额",
+        "balance": "余额:",
+        "suffix": "GT",
+        "required": "需要:",
+        "action": "获取 GToken →"
+      },
+      "apnts": {
+        "title": "aPNTs 余额",
+        "balance": "余额:",
+        "suffix": "aPNTs",
+        "required": "需要:",
+        "action": "获取 aPNTs →"
+      },
+      "eth": {
+        "title": "ETH 余额",
+        "balance": "余额:",
+        "suffix": "ETH",
+        "required": "需要:",
+        "requiredSuffix": "ETH (用于 gas)",
+        "faucetNote": "请从水龙头获取 Sepolia ETH"
+      }
+    },
+    "summary": {
+      "allReady": "所有资源已就绪！",
+      "allReadyDescription": "您可以继续下一步完成部署流程。",
+      "notReady": "还有资源未准备好",
+      "notReadyDescription": "请完成上述缺失的资源部署，然后点击\"重新检测\"。"
+    },
+    "actions": {
+      "recheck": "重新检测",
+      "back": "← 返回",
+      "continue": "继续 →"
+    }
+  },
+  "registerCommunity": {
+    "title": "注册社区",
+    "subtitle": "在 AAstar 网络上创建并注册您的社区",
+    "loading": "加载中...",
+    "connectWallet": "连接钱包",
+    "form": {
+      "basicInfo": "基本信息",
+      "tokenSection": "代币",
+      "paymasterSection": "Paymaster",
+      "sbtSection": "MySBT",
+      "communityName": "社区名称",
+      "communityNamePlaceholder": "请输入社区名称",
+      "stakeAmount": "质押金额 (GToken)",
+      "stakeAmountPlaceholder": "最少 30 GToken",
+      "stakeAmountHint": "最小质押",
+      "allowPermissionlessMint": "允许无许可铸造",
+      "allowPermissionlessMintHint": "启用后，用户无需邀请即可铸造社区 MySBT",
+      "deployXPNTs": "部署 xPNTs Token →",
+      "deployPaymaster": "去部署 Paymaster →",
+      "unifiedMySBT": "所有社区使用统一的 MySBT 白标 SBT"
+    },
+    "balance": {
+      "title": "当前余额",
+      "gtoken": "GToken"
+    },
+    "insufficientBalance": {
+      "title": "GToken 余额不足",
+      "required": "需要质押:",
+      "current": "当前余额:",
+      "message": "请先获取足够的 GToken 再注册社区。",
+      "linkText": "前往获取 GToken →"
+    },
+    "button": {
+      "registering": "注册中...",
+      "register": "注册"
+    },
+    "success": {
+      "title": "交易已提交!",
+      "message": "您的社区已成功注册！",
+      "txHash": "交易哈希",
+      "viewInExplorer": "在浏览器中查看",
+      "backToWizard": "返回向导",
+      "viewTx": "查看交易"
+    },
+    "errors": {
+      "walletNotConnected": "请先连接钱包",
+      "communityNameRequired": "请输入社区名称",
+      "stakeAmountRequired": "请输入质押金额",
+      "insufficientBalance": "GToken 余额不足！\n需要: {{required}} GToken\n当前余额: {{current}} GToken",
+      "insufficientToStake": "GToken 余额不足！需要质押 {{need}} GToken，但你只有 {{current}} GToken",
+      "alreadyRegistered": "该地址已作为社区注册: {{name}}",
+      "registrationFailed": "社区注册失败"
+    }
+  },
+  "getGToken": {
+    "title": "获取 GToken",
+    "description": "获得协议准入许可 GToken，成为协议成员，自由加入随时退出"
+  },
+  "getXPNTs": {
+    "title": "部署 xPNTs",
+    "description": "为您的社区创建用于支付抽象的 gas 代币",
+    "action": "部署"
+  },
+  "launchPaymaster": {
+    "title": "启动 Paymaster",
+    "description": "部署您的 Paymaster 合约并开始为您的社区提供无 Gas 交易服务",
+    "action": "启动 Paymaster →"
+  },
+  "operationGuide": {
+    "title": "社区运营商指南",
+    "subtitle": "掌握 SuperPaymaster 生态，构建繁荣的 Web3 社区经济",
+    "tabs": {
+      "overview": "概览",
+      "gasToken": "Gas 代币",
+      "revenue": "收入模型",
+      "tasks": "任务系统",
+      "events": "活动运营",
+      "analytics": "数据分析"
+    },
+    "overview": {
+      "title": "社区运营商指南",
+      "description": "SuperPaymaster 为社区运营商提供完整的工具栈，帮助您构建繁荣的 Web3 社区经济。",
+      "stats": {
+        "lowerBarrier": {
+          "title": "降低参与门槛",
+          "description": "成员无需持有 ETH 即可参与链上活动，提升社区活跃度"
+        },
+        "createValue": {
+          "title": "创造经济价值",
+          "description": "将 Gas 成本转化为社区收入，构建可持续经济模型"
+        },
+        "positiveCycle": {
+          "title": "形成正循环",
+          "description": "任务-积分-消费闭环，激励成员持续贡献"
+        }
+      },
+      "quickStart": {
+        "title": "快速开始",
+        "steps": {
+          "register": {
+            "title": "注册社区",
+            "description": "在链上注册您的社区，配置基本信息和治理代币",
+            "link": "立即注册 →"
+          },
+          "deploy": {
+            "title": "部署代币",
+            "description": "发行社区专属的 xPNTs 积分代币和 MySBT 身份代币",
+            "link": "发行代币 →"
+          },
+          "launch": {
+            "title": "启动 Paymaster",
+            "description": "一键部署 Gas 赞助合约，配置赞助规则",
+            "link": "启动服务 →"
+          }
+        }
+      }
+    },
+    "footer": {
+      "title": "需要更多帮助？",
+      "description": "联系我们的技术支持团队，获取专业的社区运营指导",
+      "contactSupport": "联系支持",
+      "viewDocs": "查看文档"
+    }
+  }
+}

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "type-check": "tsc --noEmit",
+    "i18n:check": "node scripts/check-i18n-parity.mjs",
     "test": "echo \"⚠️  No tests yet - skipping\"",
     "test:ci": "echo \"⚠️  No tests yet - skipping\""
   },

--- a/aastar-frontend/scripts/check-i18n-parity.mjs
+++ b/aastar-frontend/scripts/check-i18n-parity.mjs
@@ -1,0 +1,36 @@
+/**
+ * i18n locale key-parity check.
+ *
+ * Fails (exit 1) if en.json and zh.json don't have an identical set of leaf
+ * keys, so EN/ZH translations can't silently drift apart. Run in CI and via
+ * `npm run i18n:check -w aastar-frontend`.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const localesDir = join(dirname(fileURLToPath(import.meta.url)), "../lib/i18n/locales");
+const load = file => JSON.parse(readFileSync(join(localesDir, file), "utf8"));
+
+/** Flatten to dotted leaf-key paths. */
+function leafKeys(obj, prefix = "") {
+  return Object.entries(obj).flatMap(([k, v]) => {
+    const path = prefix ? `${prefix}.${k}` : k;
+    return v && typeof v === "object" && !Array.isArray(v) ? leafKeys(v, path) : [path];
+  });
+}
+
+const en = new Set(leafKeys(load("en.json")));
+const zh = new Set(leafKeys(load("zh.json")));
+
+const missingInZh = [...en].filter(k => !zh.has(k)).sort();
+const missingInEn = [...zh].filter(k => !en.has(k)).sort();
+
+if (missingInZh.length || missingInEn.length) {
+  if (missingInZh.length) console.error(`Missing in zh.json (${missingInZh.length}):\n  ${missingInZh.join("\n  ")}`);
+  if (missingInEn.length) console.error(`Missing in en.json (${missingInEn.length}):\n  ${missingInEn.join("\n  ")}`);
+  console.error("\ni18n locale parity check FAILED — keep en.json and zh.json in sync.");
+  process.exit(1);
+}
+
+console.log(`i18n locale parity OK — ${en.size} keys match across en/zh.`);


### PR DESCRIPTION
## 目标
registry 门户迁移 PR5(栈在 #304 Track C 之上;i18n 依赖在 Track C base)。引入 i18next 中英双语基建。

## 改动
- `lib/i18n/config.ts` — i18next 客户端初始化(LanguageDetector + initReactI18next,fallbackLng en,localStorage 检测,useSuspense:false 避免 SSR/hydration 不一致)
- `lib/i18n/I18nProvider.tsx` — client Provider
- `lib/i18n/LanguageSwitcher.tsx` — 中英切换组件(纯 Tailwind 文字按钮)
- `lib/i18n/locales/{en,zh}.json` — 从 registry 移植/裁剪,280 个 key 结构 1:1 对齐,11 组(common/header/portal/wizard/step*/registerCommunity/getXPNTs/launchPaymaster/operationGuide)
- `app/layout.tsx` — 包裹 `<I18nProvider>`

## 说明
- 纯客户端、静态化就绪;基建就位,后续把门户页文案逐步换成 `useTranslation` key(增量,可后续 PR)。
- 验证:`type-check` 0 错误、`lint:check` 干净、`next build` 通过。
- base 指向 #304(Track C):因 i18n 依赖随 Track C base 引入;#304 合并后本 PR 自动 rebase 到 master。