### PR TITLE
feat(portal): operator dashboard 加入口到 deploy/manage 流程

### DIFF
--- a/aastar-frontend/app/operator/page.tsx
+++ b/aastar-frontend/app/operator/page.tsx
@@ -7,7 +7,10 @@ import {
   CheckBadgeIcon,
   XCircleIcon,
   ArrowPathIcon,
+  RocketLaunchIcon,
+  WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline";
+import { useTranslation } from "react-i18next";
 import Layout from "@/components/Layout";
 import { operatorAPI } from "@/lib/api";
 
@@ -87,6 +90,7 @@ function MetricCard({
 
 export default function OperatorPage() {
   const router = useRouter();
+  const { t } = useTranslation();
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [spoList, setSpoList] = useState<string[]>([]);
   const [v4List, setV4List] = useState<string[]>([]);
@@ -129,6 +133,38 @@ export default function OperatorPage() {
           {error}
         </div>
       )}
+
+      {/* Quick Actions — entry points to the operator write flows */}
+      <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <button
+          onClick={() => router.push("/operator/deploy")}
+          className="text-left bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 hover:border-emerald-400 dark:hover:border-emerald-500 transition-colors"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <RocketLaunchIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            <span className="font-semibold text-gray-900 dark:text-white">
+              {t("operatorHub.onboard.title")}
+            </span>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t("operatorHub.onboard.desc")}
+          </p>
+        </button>
+        <button
+          onClick={() => router.push("/operator/manage")}
+          className="text-left bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 hover:border-emerald-400 dark:hover:border-emerald-500 transition-colors"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <WrenchScrewdriverIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            <span className="font-semibold text-gray-900 dark:text-white">
+              {t("operatorHub.manage.title")}
+            </span>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t("operatorHub.manage.desc")}
+          </p>
+        </button>
+      </section>
 
       {/* My Operator Status */}
       {dashboard && (

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -760,5 +760,15 @@
     "quote": "Quote",
     "quoting": "…",
     "apntsNotConfigured": "aPNTs sale contract not configured. Set {{env}} in env."
+  },
+  "operatorHub": {
+    "onboard": {
+      "title": "Onboard a Community",
+      "desc": "Register your community and deploy a Paymaster (AOA / AOA+), step by step."
+    },
+    "manage": {
+      "title": "Manage Operations",
+      "desc": "Manage xPNTs, top up your Paymaster, and view operator status."
+    }
   }
 }

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -760,5 +760,15 @@
     "quote": "报价",
     "quoting": "…",
     "apntsNotConfigured": "aPNTs 销售合约未配置。请在环境变量中设置 {{env}}。"
+  },
+  "operatorHub": {
+    "onboard": {
+      "title": "社区准入",
+      "desc": "分步注册社区并部署 Paymaster(AOA / AOA+)。"
+    },
+    "manage": {
+      "title": "运营管理",
+      "desc": "管理 xPNTs、为 Paymaster 充值、查看运营者状态。"
+    }
   }
 }


### PR DESCRIPTION
新建的 /operator/deploy(准入向导)和 /operator/manage(运营管理)页此前没有导航入口、用户到不了。本 PR 在运营者 dashboard 顶部加 Quick Actions 两个 CTA 卡片链到这两个流程,i18n 接线(新 operatorHub 命名空间,en/zh 各 482 key 一致)。独立小 PR,base master,与 #308 命名空间不重叠。验证:type-check 0、i18n:check 482 key、lint 干净、next build 通过。