### PR TITLE
feat(backend): 跟随 SDK 0.20.x 同步迁移到 @aastar/sdk@0.20.9 (P1 后端)

### DIFF
--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,8 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/airaccount": "^0.19.0",
-    "@aastar/core": "^0.18.0",
+    "@aastar/sdk": "^0.20.9",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, NotFoundException, BadRequestException } from "@nestjs/common";
-import { YAAAServerClient } from "@aastar/airaccount/server";
+import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 import { CreateAccountDto, EntryPointVersionDto } from "./dto/create-account.dto";
 import { GuardianSetupPrepareDto, CreateWithGuardiansDto } from "./dto/guardian-setup.dto";
@@ -87,6 +87,7 @@ export class AccountService {
     factoryAddress: string;
     acceptanceHash: string;
     qrPayload: string;
+    dailyLimit: string;
   }> {
     const versionDto = dto.entryPointVersion || EntryPointVersionDto.V0_7;
     const versionMap: Record<string, "0.6" | "0.7" | "0.8"> = {
@@ -106,24 +107,40 @@ export class AccountService {
     // Determine salt (use provided or generate random)
     const salt = dto.salt ?? Math.floor(Math.random() * 1_000_000);
 
+    // SDK 0.20.x binds dailyLimit into the acceptance hash — it MUST equal the
+    // value submitted in createWithGuardians, so compute it the same way here.
+    const dailyLimitWei = this.parseDailyLimitToWei(dto.dailyLimit) ?? 0n;
+
     // Build acceptance hash
     const acceptanceHash = this.client.accounts.buildGuardianAcceptanceHash(
       owner,
       salt,
       factoryAddress,
-      chainId
+      chainId,
+      dailyLimitWei
     );
 
-    // Build QR payload — everything guardian phone needs to reconstruct and sign
+    // Build QR payload — everything guardian phone needs to reconstruct and sign.
+    // dailyLimit is echoed (as wei string) so the create step submits the exact
+    // same value the hash was built with.
     const qrPayload = JSON.stringify({
       acceptanceHash,
       factory: factoryAddress,
       chainId,
       owner,
       salt,
+      dailyLimit: dailyLimitWei.toString(),
     });
 
-    return { owner, salt, chainId, factoryAddress, acceptanceHash, qrPayload };
+    return {
+      owner,
+      salt,
+      chainId,
+      factoryAddress,
+      acceptanceHash,
+      qrPayload,
+      dailyLimit: dailyLimitWei.toString(),
+    };
   }
 
   /**

--- a/aastar/src/account/dto/guardian-setup.dto.ts
+++ b/aastar/src/account/dto/guardian-setup.dto.ts
@@ -17,6 +17,16 @@ export class GuardianSetupPrepareDto {
   @IsOptional()
   @IsNumber()
   salt?: number;
+
+  @ApiProperty({
+    description:
+      "Daily spending limit (string). Bound into the guardian acceptance hash since SDK 0.20.x, " +
+      "so it MUST match the value submitted in the create step. Default: 0 (no limit).",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  dailyLimit?: string;
 }
 
 export class CreateWithGuardiansDto {

--- a/aastar/src/admin/admin.service.spec.ts
+++ b/aastar/src/admin/admin.service.spec.ts
@@ -4,7 +4,7 @@ import { AdminService } from "./admin.service";
 
 const mockRoleConfig = {
   minStake: BigInt("30000000000000000000"),
-  entryBurn: BigInt("0"),
+  ticketPrice: BigInt("0"),
   slashThreshold: 3,
   slashBase: 1,
   slashInc: 1,
@@ -17,20 +17,24 @@ const mockRoleConfig = {
   roleLockDuration: BigInt(86400),
 };
 
-jest.mock("@aastar/core", () => ({
-  registryActions: jest.fn(() => jest.fn(() => ({
-    hasRole: jest.fn().mockResolvedValue(false),
-    getRoleConfig: jest.fn().mockResolvedValue(mockRoleConfig),
-    getRoleUserCount: jest.fn().mockResolvedValue(BigInt(10)),
-    owner: jest.fn().mockResolvedValue("0xowner"),
-    version: jest.fn().mockResolvedValue("1.0.0"),
-  }))),
-  tokenActions: jest.fn(() => jest.fn(() => ({
-    totalSupply: jest.fn().mockResolvedValue(BigInt("21000000000000000000000000")),
-    name: jest.fn().mockResolvedValue("GToken"),
-    symbol: jest.fn().mockResolvedValue("GT"),
-    balanceOf: jest.fn().mockResolvedValue(BigInt("1000000000000000000000")),
-  }))),
+jest.mock("@aastar/sdk/core", () => ({
+  registryActions: jest.fn(() =>
+    jest.fn(() => ({
+      hasRole: jest.fn().mockResolvedValue(false),
+      getRoleConfig: jest.fn().mockResolvedValue(mockRoleConfig),
+      getRoleUserCount: jest.fn().mockResolvedValue(BigInt(10)),
+      owner: jest.fn().mockResolvedValue("0xowner"),
+      version: jest.fn().mockResolvedValue("1.0.0"),
+    }))
+  ),
+  tokenActions: jest.fn(() =>
+    jest.fn(() => ({
+      totalSupply: jest.fn().mockResolvedValue(BigInt("21000000000000000000000000")),
+      name: jest.fn().mockResolvedValue("GToken"),
+      symbol: jest.fn().mockResolvedValue("GT"),
+      balanceOf: jest.fn().mockResolvedValue(BigInt("1000000000000000000000")),
+    }))
+  ),
   applyConfig: jest.fn(),
   CHAIN_SEPOLIA: 11155111,
   REGISTRY_ADDRESS: "0xregistry",

--- a/aastar/src/admin/admin.service.ts
+++ b/aastar/src/admin/admin.service.ts
@@ -18,13 +18,13 @@ import {
   ROLE_PAYMASTER_AOA,
   ROLE_PAYMASTER_SUPER,
   ROLE_ENDUSER,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import type { Address, Hex } from "viem";
 
 @Injectable()
 export class AdminService implements OnModuleInit {
   private readonly logger = new Logger(AdminService.name);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private publicClient: any;
   private registryAddress: Address;
   private gtokenAddress: Address;
@@ -81,7 +81,9 @@ export class AdminService implements OnModuleInit {
     });
     return {
       minStake: formatUnits(cfg.minStake, 18),
-      entryBurn: formatUnits(cfg.entryBurn, 18),
+      // SDK 0.20.x renamed RoleConfigDetailed.entryBurn → ticketPrice; keep the
+      // API field name `entryBurn` for the frontend contract.
+      entryBurn: formatUnits(cfg.ticketPrice, 18),
       exitFeePercent: cfg.exitFeePercent.toString(),
       isActive: cfg.isActive,
       description: cfg.description,

--- a/aastar/src/bls/bls.service.ts
+++ b/aastar/src/bls/bls.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject } from "@nestjs/common";
-import { YAAAServerClient } from "@aastar/airaccount/server";
+import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
-import { BLSSignatureData as BlsSignatureData } from "@aastar/airaccount/server";
+import { BLSSignatureData as BlsSignatureData } from "@aastar/sdk/kms";
 
 @Injectable()
 export class BlsService {

--- a/aastar/src/common/constants/entrypoint.constants.ts
+++ b/aastar/src/common/constants/entrypoint.constants.ts
@@ -9,5 +9,5 @@ export {
   ACCOUNT_ABI,
   VALIDATOR_ABI,
   ERC20_ABI,
-} from "@aastar/airaccount/server";
-export type { EntryPointConfig } from "@aastar/airaccount/server";
+} from "@aastar/sdk/kms";
+export type { EntryPointConfig } from "@aastar/sdk/kms";

--- a/aastar/src/common/interfaces/erc4337-v7.interface.ts
+++ b/aastar/src/common/interfaces/erc4337-v7.interface.ts
@@ -1,4 +1,4 @@
-import { ERC4337Utils, PackedUserOperation } from "@aastar/airaccount";
+import { ERC4337Utils, PackedUserOperation } from "@aastar/sdk/kms";
 
 // Export type from SDK
 export { PackedUserOperation };

--- a/aastar/src/common/interfaces/erc4337.interface.ts
+++ b/aastar/src/common/interfaces/erc4337.interface.ts
@@ -1,3 +1,3 @@
 // Re-export types from SDK
-export type { UserOperation, GasEstimate } from "@aastar/airaccount/server";
-export type { BLSSignatureData as BlsSignatureData } from "@aastar/airaccount/server";
+export type { UserOperation, GasEstimate } from "@aastar/sdk/kms";
+export type { BLSSignatureData as BlsSignatureData } from "@aastar/sdk/kms";

--- a/aastar/src/community/community.service.spec.ts
+++ b/aastar/src/community/community.service.spec.ts
@@ -2,29 +2,35 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ConfigService } from "@nestjs/config";
 import { CommunityService } from "./community.service";
 
-jest.mock("@aastar/core", () => ({
-  registryActions: jest.fn(() => jest.fn(() => ({
-    getRoleMembers: jest.fn().mockResolvedValue(["0xadmin1", "0xadmin2"]),
-    hasRole: jest.fn().mockResolvedValue(true),
-    roleMetadata: jest.fn().mockResolvedValue("0x"),
-    getRoleUserCount: jest.fn().mockResolvedValue(BigInt(5)),
-  }))),
-  tokenActions: jest.fn(() => jest.fn(() => ({
-    balanceOf: jest.fn().mockResolvedValue(BigInt("5000000000000000000")), // 5 tokens
-    name: jest.fn().mockResolvedValue("TestToken"),
-    symbol: jest.fn().mockResolvedValue("TST"),
-    totalSupply: jest.fn().mockResolvedValue(BigInt("1000000000000000000000")),
-    getMetadata: jest.fn().mockResolvedValue({
-      name: "TestToken",
-      symbol: "TST",
-      communityName: "TestCommunity",
-      communityENS: "test.eth",
-      communityOwner: "0xadmin1",
-    }),
-  }))),
-  xPNTsFactoryActions: jest.fn(() => jest.fn(() => ({
-    getTokenAddress: jest.fn().mockResolvedValue("0x0000000000000000000000000000000000000000"),
-  }))),
+jest.mock("@aastar/sdk/core", () => ({
+  registryActions: jest.fn(() =>
+    jest.fn(() => ({
+      getRoleMembers: jest.fn().mockResolvedValue(["0xadmin1", "0xadmin2"]),
+      hasRole: jest.fn().mockResolvedValue(true),
+      roleMetadata: jest.fn().mockResolvedValue("0x"),
+      getRoleUserCount: jest.fn().mockResolvedValue(BigInt(5)),
+    }))
+  ),
+  tokenActions: jest.fn(() =>
+    jest.fn(() => ({
+      balanceOf: jest.fn().mockResolvedValue(BigInt("5000000000000000000")), // 5 tokens
+      name: jest.fn().mockResolvedValue("TestToken"),
+      symbol: jest.fn().mockResolvedValue("TST"),
+      totalSupply: jest.fn().mockResolvedValue(BigInt("1000000000000000000000")),
+      getMetadata: jest.fn().mockResolvedValue({
+        name: "TestToken",
+        symbol: "TST",
+        communityName: "TestCommunity",
+        communityENS: "test.eth",
+        communityOwner: "0xadmin1",
+      }),
+    }))
+  ),
+  xPNTsFactoryActions: jest.fn(() =>
+    jest.fn(() => ({
+      getTokenAddress: jest.fn().mockResolvedValue("0x0000000000000000000000000000000000000000"),
+    }))
+  ),
   applyConfig: jest.fn(),
   CHAIN_SEPOLIA: 11155111,
   REGISTRY_ADDRESS: "0xregistry",

--- a/aastar/src/community/community.service.ts
+++ b/aastar/src/community/community.service.ts
@@ -17,13 +17,13 @@ import {
   GTOKEN_ADDRESS as CORE_GTOKEN_ADDRESS,
   XPNTS_FACTORY_ADDRESS as CORE_XPNTS_FACTORY_ADDRESS,
   ROLE_COMMUNITY,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import type { Address, Hex } from "viem";
 
 @Injectable()
 export class CommunityService implements OnModuleInit {
   private readonly logger = new Logger(CommunityService.name);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private publicClient: any;
   private registryAddress: Address;
   private gtokenAddress: Address;

--- a/aastar/src/ethereum/ethereum.service.ts
+++ b/aastar/src/ethereum/ethereum.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Inject } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { ethers } from "ethers";
-import { YAAAServerClient } from "@aastar/airaccount/server";
+import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 import { EntryPointVersion } from "../common/constants/entrypoint.constants";
 
@@ -12,28 +11,8 @@ export class EthereumService {
     private configService: ConfigService
   ) {}
 
-  getProvider(): ethers.JsonRpcProvider {
+  getProvider() {
     return this.client.ethereum.getProvider();
-  }
-
-  getBundlerProvider(): ethers.JsonRpcProvider {
-    return this.client.ethereum.getBundlerProvider();
-  }
-
-  getFactoryContract(version: EntryPointVersion = EntryPointVersion.V0_6): ethers.Contract {
-    return this.client.ethereum.getFactoryContract(version);
-  }
-
-  getEntryPointContract(version: EntryPointVersion = EntryPointVersion.V0_6): ethers.Contract {
-    return this.client.ethereum.getEntryPointContract(version);
-  }
-
-  getValidatorContract(version: EntryPointVersion = EntryPointVersion.V0_6): ethers.Contract {
-    return this.client.ethereum.getValidatorContract(version);
-  }
-
-  getAccountContract(address: string): ethers.Contract {
-    return this.client.ethereum.getAccountContract(address);
   }
 
   async getBalance(address: string): Promise<string> {
@@ -88,7 +67,9 @@ export class EthereumService {
   async detectAccountVersion(accountAddress: string): Promise<EntryPointVersion> {
     try {
       const provider = this.getProvider();
-      const code = await provider.getCode(accountAddress);
+      // viem PublicClient.getCode takes { address } (not a bare string) and
+      // returns Hex | undefined.
+      const code = await provider.getCode({ address: accountAddress as `0x${string}` });
       if (code && code !== "0x") {
         return EntryPointVersion.V0_6;
       }

--- a/aastar/src/kms/kms.service.ts
+++ b/aastar/src/kms/kms.service.ts
@@ -1,8 +1,7 @@
 import { createHash } from "crypto";
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { KmsManager, KmsSigner, LegacyPasskeyAssertion } from "@aastar/airaccount/server";
-import { ethers } from "ethers";
+import { KmsManager, KmsSigner, LegacyPasskeyAssertion } from "@aastar/sdk/kms";
 
 export type { LegacyPasskeyAssertion };
 
@@ -116,14 +115,13 @@ export class KmsService {
   createKmsSigner(
     keyId: string,
     address: string,
-    assertionProvider?: () => Promise<LegacyPasskeyAssertion>,
-    provider?: ethers.Provider
+    assertionProvider?: () => Promise<LegacyPasskeyAssertion>
   ): KmsSigner {
     const ap =
       assertionProvider ??
       (() => {
         throw new Error("Passkey assertion is required for signing. Provide an assertionProvider.");
       });
-    return this.kmsManager.createKmsSigner(keyId, address, ap, provider as any);
+    return this.kmsManager.createKmsSigner(keyId, address, ap);
   }
 }

--- a/aastar/src/operator/operator.service.spec.ts
+++ b/aastar/src/operator/operator.service.spec.ts
@@ -2,18 +2,26 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { ConfigService } from "@nestjs/config";
 import { OperatorService } from "./operator.service";
 
-jest.mock("@aastar/core", () => ({
-  registryActions: jest.fn(() => jest.fn(() => ({
-    hasRole: jest.fn().mockResolvedValue(false),
-    getRoleMembers: jest.fn().mockResolvedValue(["0xop1"]),
-  }))),
-  stakingActions: jest.fn(() => jest.fn(() => ({
-    getStakeInfo: jest.fn().mockResolvedValue({ amount: BigInt("30000000000000000000"), lockedUntil: BigInt(0) }),
-  }))),
+jest.mock("@aastar/sdk/core", () => ({
+  registryActions: jest.fn(() =>
+    jest.fn(() => ({
+      hasRole: jest.fn().mockResolvedValue(false),
+      getRoleMembers: jest.fn().mockResolvedValue(["0xop1"]),
+    }))
+  ),
+  stakingActions: jest.fn(() =>
+    jest.fn(() => ({
+      getStakeInfo: jest
+        .fn()
+        .mockResolvedValue({ amount: BigInt("30000000000000000000"), lockedUntil: BigInt(0) }),
+    }))
+  ),
   superPaymasterActions: jest.fn(() => jest.fn(() => ({}))),
-  tokenActions: jest.fn(() => jest.fn(() => ({
-    balanceOf: jest.fn().mockResolvedValue(BigInt("10000000000000000000")),
-  }))),
+  tokenActions: jest.fn(() =>
+    jest.fn(() => ({
+      balanceOf: jest.fn().mockResolvedValue(BigInt("10000000000000000000")),
+    }))
+  ),
   applyConfig: jest.fn(),
   CHAIN_SEPOLIA: 11155111,
   REGISTRY_ADDRESS: "0xregistry",
@@ -27,14 +35,14 @@ jest.mock("@aastar/core", () => ({
 
 const mockReadContract = jest.fn().mockResolvedValue([
   BigInt("1000000000000000000"), // balance
-  BigInt("1000"),                // exchangeRate
-  true,                          // isConfigured
-  false,                         // isPaused
-  "0xtoken",                     // token
-  100,                           // reputation
-  "0xtreasury",                  // treasury
-  BigInt(0),                     // spent
-  BigInt(100),                   // txSponsored
+  BigInt("1000"), // exchangeRate
+  true, // isConfigured
+  false, // isPaused
+  "0xtoken", // token
+  100, // reputation
+  "0xtreasury", // treasury
+  BigInt(0), // spent
+  BigInt(100), // txSponsored
 ]);
 
 const mockGetBalance = jest.fn().mockResolvedValue(BigInt("500000000000000000")); // 0.5 ETH

--- a/aastar/src/operator/operator.service.ts
+++ b/aastar/src/operator/operator.service.ts
@@ -15,13 +15,13 @@ import {
   PAYMASTER_FACTORY_ADDRESS as CORE_PAYMASTER_FACTORY_ADDRESS,
   ROLE_PAYMASTER_AOA,
   ROLE_PAYMASTER_SUPER,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import type { Address } from "viem";
 
 @Injectable()
 export class OperatorService implements OnModuleInit {
   private readonly logger = new Logger(OperatorService.name);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private publicClient: any;
   private registryAddress: Address;
   private gtokenAddress: Address;

--- a/aastar/src/paymaster/paymaster.service.ts
+++ b/aastar/src/paymaster/paymaster.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
-import { YAAAServerClient } from "@aastar/airaccount/server";
+import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 
 @Injectable()

--- a/aastar/src/registry/registry.service.spec.ts
+++ b/aastar/src/registry/registry.service.spec.ts
@@ -3,31 +3,35 @@ import { ConfigService } from "@nestjs/config";
 import { RegistryService } from "./registry.service";
 
 // Mock @aastar/core to avoid real blockchain calls
-jest.mock("@aastar/core", () => ({
-  registryActions: jest.fn(() => jest.fn(() => ({
-    hasRole: jest.fn().mockResolvedValue(true),
-    getUserRoles: jest.fn().mockResolvedValue(["0xrole1"]),
-    getRoleConfig: jest.fn().mockResolvedValue({
-      minStake: BigInt("30000000000000000000"),
-      entryBurn: BigInt("0"),
-      slashThreshold: 3,
-      slashBase: 1,
-      slashInc: 1,
-      slashMax: 10,
-      exitFeePercent: 5,
-      isActive: true,
-      minExitFee: BigInt("0"),
-      description: "Community Admin",
-      owner: "0xowner",
-      roleLockDuration: BigInt(86400),
-    }),
-    getRoleMembers: jest.fn().mockResolvedValue(["0xmember1", "0xmember2"]),
-    getRoleUserCount: jest.fn().mockResolvedValue(BigInt(42)),
-    communityByName: jest.fn().mockResolvedValue("0xcommunity"),
-  }))),
-  tokenActions: jest.fn(() => jest.fn(() => ({
-    balanceOf: jest.fn().mockResolvedValue(BigInt("1000000000000000000")), // 1 GToken
-  }))),
+jest.mock("@aastar/sdk/core", () => ({
+  registryActions: jest.fn(() =>
+    jest.fn(() => ({
+      hasRole: jest.fn().mockResolvedValue(true),
+      getUserRoles: jest.fn().mockResolvedValue(["0xrole1"]),
+      getRoleConfig: jest.fn().mockResolvedValue({
+        minStake: BigInt("30000000000000000000"),
+        ticketPrice: BigInt("0"),
+        slashThreshold: 3,
+        slashBase: 1,
+        slashInc: 1,
+        slashMax: 10,
+        exitFeePercent: 5,
+        isActive: true,
+        minExitFee: BigInt("0"),
+        description: "Community Admin",
+        owner: "0xowner",
+        roleLockDuration: BigInt(86400),
+      }),
+      getRoleMembers: jest.fn().mockResolvedValue(["0xmember1", "0xmember2"]),
+      getRoleUserCount: jest.fn().mockResolvedValue(BigInt(42)),
+      communityByName: jest.fn().mockResolvedValue("0xcommunity"),
+    }))
+  ),
+  tokenActions: jest.fn(() =>
+    jest.fn(() => ({
+      balanceOf: jest.fn().mockResolvedValue(BigInt("1000000000000000000")), // 1 GToken
+    }))
+  ),
   applyConfig: jest.fn(),
   CHAIN_SEPOLIA: 11155111,
   REGISTRY_ADDRESS: "0xregistry",

--- a/aastar/src/registry/registry.service.ts
+++ b/aastar/src/registry/registry.service.ts
@@ -13,13 +13,13 @@ import {
   ROLE_PAYMASTER_SUPER,
   DEFAULT_ADMIN_ROLE,
   ROLE_ENDUSER,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import type { Address, Hex } from "viem";
 
 @Injectable()
 export class RegistryService implements OnModuleInit {
   private readonly logger = new Logger(RegistryService.name);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private publicClient: any;
   private registryAddress: Address;
   private gtokenAddress: Address;

--- a/aastar/src/sale/sale.service.ts
+++ b/aastar/src/sale/sale.service.ts
@@ -31,7 +31,7 @@ const APNTS_SALE_ABI = parseAbi([
 @Injectable()
 export class SaleService implements OnModuleInit {
   private readonly logger = new Logger(SaleService.name);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private publicClient: any;
 
   // Contract addresses from env

--- a/aastar/src/sdk/backend-signer.adapter.ts
+++ b/aastar/src/sdk/backend-signer.adapter.ts
@@ -1,29 +1,38 @@
 import { Injectable } from "@nestjs/common";
-import { ISignerAdapter, PasskeyAssertionContext } from "@aastar/airaccount/server";
+import { ISignerAdapter, PasskeyAssertionContext } from "@aastar/sdk/kms";
 import { AuthService } from "../auth/auth.service";
-import { ethers } from "ethers";
 
+/**
+ * SDK 0.20.x ISignerAdapter — narrowed to EIP-191 personal-sign + address read
+ * (the ethers Signer surface was dropped in the SDK's ethers→viem migration).
+ *
+ * Backed by the KMS: signing requires a Passkey assertion, threaded through the
+ * optional PasskeyAssertionContext into the KmsSigner's assertionProvider.
+ */
 @Injectable()
 export class BackendSignerAdapter implements ISignerAdapter {
   constructor(private authService: AuthService) {}
 
-  async getAddress(userId: string): Promise<string> {
-    const wallet = await this.authService.getUserWallet(userId);
-    return wallet.address || (await wallet.getAddress());
+  async getAddress(userId: string): Promise<`0x${string}`> {
+    // No assertion needed: KmsSigner.getAddress() just returns the bound address.
+    const signer = await this.authService.getUserWallet(userId);
+    return (await signer.getAddress()) as `0x${string}`;
   }
 
-  async getSigner(userId: string, ctx?: PasskeyAssertionContext): Promise<ethers.Signer> {
-    if (ctx?.assertion) {
-      // Create a KmsSigner with the provided assertion
-      const assertionProvider = () => Promise.resolve(ctx.assertion);
-      return this.authService.getUserWallet(userId, assertionProvider);
-    }
-    return this.authService.getUserWallet(userId);
+  async signMessage(
+    userId: string,
+    message: `0x${string}` | Uint8Array,
+    ctx?: PasskeyAssertionContext
+  ): Promise<`0x${string}`> {
+    // Callers pass a 32-byte digest (raw bytes / 0x hex); KmsSigner.signMessage
+    // applies EIP-191 personal-sign semantics. The assertion gates the KMS sign.
+    const assertionProvider = ctx?.assertion ? () => Promise.resolve(ctx.assertion) : undefined;
+    const signer = await this.authService.getUserWallet(userId, assertionProvider);
+    return (await signer.signMessage(message)) as `0x${string}`;
   }
 
-  async ensureSigner(userId: string): Promise<{ signer: ethers.Signer; address: string }> {
-    const wallet = await this.authService.ensureUserWallet(userId);
-    const address = wallet.address || (await wallet.getAddress());
-    return { signer: wallet, address };
+  async ensureSigner(userId: string): Promise<{ address: `0x${string}` }> {
+    const signer = await this.authService.ensureUserWallet(userId);
+    return { address: (await signer.getAddress()) as `0x${string}` };
   }
 }

--- a/aastar/src/sdk/backend-storage.adapter.ts
+++ b/aastar/src/sdk/backend-storage.adapter.ts
@@ -5,7 +5,7 @@ import {
   TransferRecord,
   PaymasterRecord,
   BlsConfigRecord,
-} from "@aastar/airaccount/server";
+} from "@aastar/sdk/kms";
 import { DatabaseService } from "../database/database.service";
 import * as fs from "fs";
 import * as path from "path";

--- a/aastar/src/sdk/sdk.providers.ts
+++ b/aastar/src/sdk/sdk.providers.ts
@@ -1,6 +1,6 @@
 import { Provider } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { YAAAServerClient, ServerConfig } from "@aastar/airaccount/server";
+import { AirAccountServerClient as YAAAServerClient, ServerConfig } from "@aastar/sdk/kms";
 import { BackendStorageAdapter } from "./backend-storage.adapter";
 import { BackendSignerAdapter } from "./backend-signer.adapter";
 

--- a/aastar/src/token/token.service.ts
+++ b/aastar/src/token/token.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
-import { YAAAServerClient } from "@aastar/airaccount/server";
+import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 
 export enum TokenCategory {

--- a/aastar/src/transfer/transfer.service.ts
+++ b/aastar/src/transfer/transfer.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, BadRequestException } from "@nestjs/common";
-import { YAAAServerClient } from "@aastar/airaccount/server";
+import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 import { AddressBookService } from "./address-book.service";
 import { ExecuteTransferDto } from "./dto/execute-transfer.dto";

--- a/aastar/tsconfig.build.json
+++ b/aastar/tsconfig.build.json
@@ -5,8 +5,14 @@
     "paths": {
       "ox": ["./node_modules/ox/_types/index.d.ts"],
       "ox/*": ["./node_modules/ox/_types/*.d.ts"],
-      "@aastar/sdk/kms": ["./node_modules/@aastar/sdk/dist/kms.d.ts"],
-      "@aastar/sdk/core": ["./node_modules/@aastar/sdk/dist/core.d.ts"]
+      "@aastar/sdk/kms": [
+        "./node_modules/@aastar/sdk/dist/kms.d.ts",
+        "../node_modules/@aastar/sdk/dist/kms.d.ts"
+      ],
+      "@aastar/sdk/core": [
+        "./node_modules/@aastar/sdk/dist/core.d.ts",
+        "../node_modules/@aastar/sdk/dist/core.d.ts"
+      ]
     }
   },
   "include": ["src/**/*.ts"],

--- a/aastar/tsconfig.build.json
+++ b/aastar/tsconfig.build.json
@@ -4,9 +4,17 @@
     "noEmitOnError": false,
     "paths": {
       "ox": ["./node_modules/ox/_types/index.d.ts"],
-      "ox/*": ["./node_modules/ox/_types/*.d.ts"]
+      "ox/*": ["./node_modules/ox/_types/*.d.ts"],
+      "@aastar/sdk/kms": ["./node_modules/@aastar/sdk/dist/kms.d.ts"],
+      "@aastar/sdk/core": ["./node_modules/@aastar/sdk/dist/core.d.ts"]
     }
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "../node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+  "exclude": [
+    "node_modules",
+    "../node_modules",
+    "dist",
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
 }

--- a/aastar/tsconfig.json
+++ b/aastar/tsconfig.json
@@ -11,8 +11,14 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "paths": {
-      "@aastar/sdk/kms": ["./node_modules/@aastar/sdk/dist/kms.d.ts"],
-      "@aastar/sdk/core": ["./node_modules/@aastar/sdk/dist/core.d.ts"]
+      "@aastar/sdk/kms": [
+        "./node_modules/@aastar/sdk/dist/kms.d.ts",
+        "../node_modules/@aastar/sdk/dist/kms.d.ts"
+      ],
+      "@aastar/sdk/core": [
+        "./node_modules/@aastar/sdk/dist/core.d.ts",
+        "../node_modules/@aastar/sdk/dist/core.d.ts"
+      ]
     },
     "incremental": true,
     "skipLibCheck": true,

--- a/aastar/tsconfig.json
+++ b/aastar/tsconfig.json
@@ -10,6 +10,10 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@aastar/sdk/kms": ["./node_modules/@aastar/sdk/dist/kms.d.ts"],
+      "@aastar/sdk/core": ["./node_modules/@aastar/sdk/dist/core.d.ts"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/airaccount": "^0.19.0",
-        "@aastar/core": "^0.18.0",
+        "@aastar/sdk": "^0.20.9",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -330,6 +329,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "aastar/node_modules/@aastar/sdk": {
+      "version": "0.20.9",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.20.9.tgz",
+      "integrity": "sha512-/hIToT8IWzZjqSTDSOrVl1vnYJ9Rin/uyT61NWYTP/p6LPaN0WrLA5LZi0s2Afw93NDg9mLW9AYOdGSFDzwE6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@simplewebauthn/browser": "^13.2.2",
+        "axios": "^1.12.2",
+        "viem": "2.43.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "aastar/node_modules/@adraffy/ens-normalize": {
@@ -1393,6 +1415,35 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "aastar/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "aastar/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "aastar/node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-5.0.0.tgz",
@@ -1407,6 +1458,17 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "aastar/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "aastar/node_modules/supports-color": {


### PR DESCRIPTION
阶段一(P1)后端块。单包 `@aastar/sdk@0.20.9`(dual esm+cjs,100% viem)替代 `@aastar/airaccount`+`@aastar/core`。

## 改动
- **依赖+import**:三旧包 → `@aastar/sdk`;`airaccount/server`→`/kms`(16)、`core`→`/core`(8);tsconfig 加 paths shim 解 exports-map 子路径(沿用仓内 `ox` 同款模式)。
- **ISignerAdapter** 重写:`getSigner`→`signMessage`(EIP-191,32B digest 原始字节)、`ensureSigner`→`{address}`。
- **kms.service**:`createKmsSigner` 去第4参 provider;移除 ethers。
- `YAAAServerClient` 现为 value-only 别名 → `import { AirAccountServerClient as YAAAServerClient }`。
- `RoleConfigDetailed.entryBurn`→`ticketPrice`(admin 保留对外 `entryBurn` 字段名)。
- `buildGuardianAcceptanceHash` 新增第5参 `dailyLimit` → 在 prepare + QR payload 透传,保证 step1 hash 与 step2 提交一致(guardian 签名正确性)。
- `ethereum.service`:删 5 个无人调用的 passthrough(避免未导出 `ViemContract` 触发 TS4053);`getProvider` 现为 viem `PublicClient`,`getCode({address})`。

## 验证(本地)
- `tsc -p tsconfig.build.json` ✅  `tsc --noEmit`(含 spec)✅  **34/34 单测** ✅  lint ✅  prettier(改动文件)✅

## 背景
SDK 0.20.8 曾因 esm-only 缺 `require`/.cjs 卡住后端(aastar-sdk#104),0.20.9 已恢复 dual build。

后续:P1-D 前端、P1-E 地址清理(支付敏感,独立 PR),最后完整链路回归。roadmap: #315。