### PR TITLE
feat(frontend): 跟随 SDK 0.20.x 迁移到 @aastar/sdk@0.20.9 (P1-D 前端)

### DIFF
--- a/aastar-frontend/app/operator/deploy/steps/Step3RegisterCommunity.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step3RegisterCommunity.tsx
@@ -21,7 +21,7 @@ import {
   REGISTRY_ADDRESS,
   GTOKEN_ADDRESS,
   GTOKEN_STAKING_ADDRESS,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
 import type { StepProps } from "./types";
 import { useTxStep } from "../components/useTxStep";
@@ -118,7 +118,9 @@ export default function Step3RegisterCommunity({
       ) : (
         <p className="text-sm text-gray-600 dark:text-gray-300">
           {t("operatorDeploy.step3.explainerPrefix")}{" "}
-          <code className="px-1 rounded bg-gray-100 dark:bg-gray-700 text-xs">registerRole(ROLE_COMMUNITY)</code>
+          <code className="px-1 rounded bg-gray-100 dark:bg-gray-700 text-xs">
+            registerRole(ROLE_COMMUNITY)
+          </code>
           {t("operatorDeploy.step3.explainerSuffix")}
         </p>
       )}

--- a/aastar-frontend/app/operator/deploy/steps/Step4DeployXPNTs.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step4DeployXPNTs.tsx
@@ -16,7 +16,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CurrencyDollarIcon, CheckCircleIcon } from "@heroicons/react/24/outline";
 import { parseEther, zeroAddress, type Address } from "viem";
-import { xPNTsFactoryActions, XPNTS_FACTORY_ADDRESS } from "@aastar/core";
+import { xPNTsFactoryActions, XPNTS_FACTORY_ADDRESS } from "@aastar/sdk/core";
 import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
 import type { StepProps } from "./types";
 import { useTxStep } from "../components/useTxStep";
@@ -130,11 +130,38 @@ export default function Step4DeployXPNTs({
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <FormField label={t("operatorDeploy.step4.tokenName")} value={local.name} onChange={v => setLocal(s => ({ ...s, name: v }))} placeholder={t("operatorDeploy.step4.tokenNamePlaceholder")} />
-          <FormField label={t("operatorDeploy.step4.tokenSymbol")} value={local.symbol} onChange={v => setLocal(s => ({ ...s, symbol: v.toUpperCase() }))} placeholder={t("operatorDeploy.step4.tokenSymbolPlaceholder")} />
-          <FormField label={t("operatorDeploy.step4.communityName")} value={local.communityName} onChange={v => setLocal(s => ({ ...s, communityName: v }))} placeholder={t("operatorDeploy.step4.communityNamePlaceholder")} />
-          <FormField label={t("operatorDeploy.step4.communityENS")} value={local.communityENS} onChange={v => setLocal(s => ({ ...s, communityENS: v }))} placeholder={t("operatorDeploy.step4.communityENSPlaceholder")} mono />
-          <FormField label={t("operatorDeploy.step4.exchangeRate")} type="number" value={local.rate} onChange={v => setLocal(s => ({ ...s, rate: v }))} hint={t("operatorDeploy.step4.exchangeRateHint")} />
+          <FormField
+            label={t("operatorDeploy.step4.tokenName")}
+            value={local.name}
+            onChange={v => setLocal(s => ({ ...s, name: v }))}
+            placeholder={t("operatorDeploy.step4.tokenNamePlaceholder")}
+          />
+          <FormField
+            label={t("operatorDeploy.step4.tokenSymbol")}
+            value={local.symbol}
+            onChange={v => setLocal(s => ({ ...s, symbol: v.toUpperCase() }))}
+            placeholder={t("operatorDeploy.step4.tokenSymbolPlaceholder")}
+          />
+          <FormField
+            label={t("operatorDeploy.step4.communityName")}
+            value={local.communityName}
+            onChange={v => setLocal(s => ({ ...s, communityName: v }))}
+            placeholder={t("operatorDeploy.step4.communityNamePlaceholder")}
+          />
+          <FormField
+            label={t("operatorDeploy.step4.communityENS")}
+            value={local.communityENS}
+            onChange={v => setLocal(s => ({ ...s, communityENS: v }))}
+            placeholder={t("operatorDeploy.step4.communityENSPlaceholder")}
+            mono
+          />
+          <FormField
+            label={t("operatorDeploy.step4.exchangeRate")}
+            type="number"
+            value={local.rate}
+            onChange={v => setLocal(s => ({ ...s, rate: v }))}
+            hint={t("operatorDeploy.step4.exchangeRateHint")}
+          />
         </div>
       )}
     </StepCard>

--- a/aastar-frontend/app/operator/deploy/steps/Step6ConfigureOperator.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step6ConfigureOperator.tsx
@@ -11,7 +11,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Cog6ToothIcon } from "@heroicons/react/24/outline";
-import { parseEther, isAddress, type Address } from "viem";
+import { isAddress, type Address } from "viem";
 import { buildPaymasterOperatorClient } from "@/lib/sdk/operator";
 import type { StepProps } from "./types";
 import { useTxStep } from "../components/useTxStep";
@@ -19,7 +19,14 @@ import StepCard from "../components/StepCard";
 import WizardButton from "../components/WizardButton";
 import FormField from "../components/FormField";
 
-export default function Step6ConfigureOperator({ address, walletClient, data, update, onNext, onBack }: StepProps) {
+export default function Step6ConfigureOperator({
+  address,
+  walletClient,
+  data,
+  update,
+  onNext,
+  onBack,
+}: StepProps) {
   const { t } = useTranslation();
   const tx = useTxStep();
   const [treasury, setTreasury] = useState(data.treasury || address);
@@ -32,7 +39,9 @@ export default function Step6ConfigureOperator({ address, walletClient, data, up
     await tx.run(
       async () => {
         const client = buildPaymasterOperatorClient(walletClient);
-        return client.configureOperator(xPNTs as Address, treasury as Address, parseEther(rate || "1"));
+        // SDK 0.20.x: exchange rate is no longer set here — it's read live from
+        // xPNTsToken.exchangeRate() at runtime, so configureOperator drops the rate arg.
+        return client.configureOperator(xPNTs as Address, treasury as Address);
       },
       {
         loadingMsg: t("operatorDeploy.tx.configuringOperator"),
@@ -73,10 +82,24 @@ export default function Step6ConfigureOperator({ address, walletClient, data, up
       ) : (
         <div className="space-y-3">
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            {t("operatorDeploy.step6Configure.xpntsToken")} <span className="font-mono break-all">{xPNTs}</span>
+            {t("operatorDeploy.step6Configure.xpntsToken")}{" "}
+            <span className="font-mono break-all">{xPNTs}</span>
           </p>
-          <FormField label={t("operatorDeploy.step6Configure.treasuryAddress")} value={treasury} onChange={setTreasury} mono placeholder="0x…" hint={t("operatorDeploy.step6Configure.treasuryHint")} />
-          <FormField label={t("operatorDeploy.step6Configure.exchangeRate")} type="number" value={rate} onChange={setRate} hint={t("operatorDeploy.step6Configure.exchangeRateHint")} />
+          <FormField
+            label={t("operatorDeploy.step6Configure.treasuryAddress")}
+            value={treasury}
+            onChange={setTreasury}
+            mono
+            placeholder="0x…"
+            hint={t("operatorDeploy.step6Configure.treasuryHint")}
+          />
+          <FormField
+            label={t("operatorDeploy.step6Configure.exchangeRate")}
+            type="number"
+            value={rate}
+            onChange={setRate}
+            hint={t("operatorDeploy.step6Configure.exchangeRateHint")}
+          />
         </div>
       )}
     </StepCard>

--- a/aastar-frontend/app/operator/deploy/steps/Step6EntryPointDeposit.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step6EntryPointDeposit.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BanknotesIcon } from "@heroicons/react/24/outline";
 import { parseEther } from "viem";
-import { entryPointActions, ENTRY_POINT_ADDRESS } from "@aastar/core";
+import { entryPointActions, ENTRY_POINT_ADDRESS } from "@aastar/sdk/core";
 import { ensureSdkConfig } from "@/lib/sdk/client";
 import type { StepProps } from "./types";
 import { useTxStep } from "../components/useTxStep";
@@ -19,7 +19,13 @@ import StepCard from "../components/StepCard";
 import WizardButton from "../components/WizardButton";
 import FormField from "../components/FormField";
 
-export default function Step6EntryPointDeposit({ data, walletClient, update, onNext, onBack }: StepProps) {
+export default function Step6EntryPointDeposit({
+  data,
+  walletClient,
+  update,
+  onNext,
+  onBack,
+}: StepProps) {
   const { t } = useTranslation();
   const paymaster = data.paymasterAddress;
   const tx = useTxStep();
@@ -75,9 +81,16 @@ export default function Step6EntryPointDeposit({ data, walletClient, update, onN
       ) : (
         <div className="space-y-3">
           <p className="text-xs text-gray-500 dark:text-gray-400">
-            {t("operatorDeploy.step6Entrypoint.paymaster")} <span className="font-mono">{paymaster}</span>
+            {t("operatorDeploy.step6Entrypoint.paymaster")}{" "}
+            <span className="font-mono">{paymaster}</span>
           </p>
-          <FormField label={t("operatorDeploy.step6Entrypoint.depositAmount")} type="number" value={eth} onChange={setEth} hint={t("operatorDeploy.step6Entrypoint.depositHint")} />
+          <FormField
+            label={t("operatorDeploy.step6Entrypoint.depositAmount")}
+            type="number"
+            value={eth}
+            onChange={setEth}
+            hint={t("operatorDeploy.step6Entrypoint.depositHint")}
+          />
         </div>
       )}
     </StepCard>

--- a/aastar-frontend/app/operator/manage/paymaster/page.tsx
+++ b/aastar-frontend/app/operator/manage/paymaster/page.tsx
@@ -31,7 +31,7 @@ import {
   entryPointActions,
   paymasterFactoryActions,
   PAYMASTER_FACTORY_ADDRESS,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import Layout from "@/components/Layout";
 import { useWallet } from "@/contexts/WalletContext";
 import { ensureSdkConfig } from "@/lib/sdk/client";
@@ -175,7 +175,11 @@ function AOAManager() {
           <div className="flex items-center gap-2">
             <StatusBadge
               active={!state.paused}
-              label={state.paused ? t("operatorManage.paymaster.paused") : t("operatorManage.paymaster.active")}
+              label={
+                state.paused
+                  ? t("operatorManage.paymaster.paused")
+                  : t("operatorManage.paymaster.active")
+              }
             />
             <button
               onClick={() => void load()}
@@ -187,16 +191,36 @@ function AOAManager() {
         }
       >
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-          <MetricCard label={t("operatorManage.paymaster.entryPointBalance")} value={state.entryPointBalance} unit="ETH" />
-          <MetricCard label={t("operatorManage.paymaster.serviceFeeRate")} value={state.serviceFeeRate.toString()} unit="bps" />
+          <MetricCard
+            label={t("operatorManage.paymaster.entryPointBalance")}
+            value={state.entryPointBalance}
+            unit="ETH"
+          />
+          <MetricCard
+            label={t("operatorManage.paymaster.serviceFeeRate")}
+            value={state.serviceFeeRate.toString()}
+            unit="bps"
+          />
           <MetricCard
             label={t("operatorManage.paymaster.maxGasCostCap")}
             value={formatEther(state.maxGasCostCap)}
             unit="ETH"
           />
-          <MetricCard label={t("operatorManage.paymaster.owner")} value={shortAddr(state.owner)} mono />
-          <MetricCard label={t("operatorManage.paymaster.treasury")} value={shortAddr(state.treasury)} mono />
-          <MetricCard label={t("operatorManage.paymaster.entryPoint")} value={shortAddr(state.entryPoint)} mono />
+          <MetricCard
+            label={t("operatorManage.paymaster.owner")}
+            value={shortAddr(state.owner)}
+            mono
+          />
+          <MetricCard
+            label={t("operatorManage.paymaster.treasury")}
+            value={shortAddr(state.treasury)}
+            mono
+          />
+          <MetricCard
+            label={t("operatorManage.paymaster.entryPoint")}
+            value={shortAddr(state.entryPoint)}
+            mono
+          />
         </div>
         <p className="mt-3 text-xs text-gray-400 font-mono break-all">
           {t("operatorManage.paymaster.paymasterLabel")}{" "}
@@ -340,7 +364,9 @@ function AOAManager() {
               ) : (
                 <PauseCircleIcon className="h-4 w-4" />
               )}
-              {state.paused ? t("operatorManage.paymaster.unpause") : t("operatorManage.paymaster.pause")}
+              {state.paused
+                ? t("operatorManage.paymaster.unpause")
+                : t("operatorManage.paymaster.pause")}
             </button>
           </div>
         </div>

--- a/aastar-frontend/app/operator/manage/superpaymaster/page.tsx
+++ b/aastar-frontend/app/operator/manage/superpaymaster/page.tsx
@@ -29,9 +29,10 @@ import {
 import {
   superPaymasterActions,
   tokenActions,
+  xPNTsTokenActions,
   SUPER_PAYMASTER_ADDRESS,
   APNTS_ADDRESS,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import Layout from "@/components/Layout";
 import { useWallet } from "@/contexts/WalletContext";
 import { ensureSdkConfig } from "@/lib/sdk/client";
@@ -86,11 +87,20 @@ function SuperPaymasterManager() {
         token: APNTS_ADDRESS,
         account: operator,
       });
+      // SDK 0.20.x dropped exchangeRate from OperatorConfig — it's now read live
+      // from the configured xPNTs token (zero address when none set yet).
+      const ZERO = "0x0000000000000000000000000000000000000000";
+      const exchangeRate =
+        cfg.xPNTsToken && cfg.xPNTsToken.toLowerCase() !== ZERO
+          ? await xPNTsTokenActions(cfg.xPNTsToken)(reader()).exchangeRate({
+              token: cfg.xPNTsToken,
+            })
+          : 0n;
       setState({
         isConfigured: cfg.isConfigured,
         isPaused: cfg.isPaused,
         aPNTsBalance: formatEther(cfg.aPNTsBalance),
-        exchangeRate: formatEther(cfg.exchangeRate),
+        exchangeRate: formatEther(exchangeRate),
         reputation: cfg.reputation,
         treasury: cfg.treasury,
         xPNTsToken: cfg.xPNTsToken,
@@ -140,7 +150,9 @@ function SuperPaymasterManager() {
       const sp = superPaymasterActions(SUPER_PAYMASTER_ADDRESS)(walletClient as never);
       const hash = await sp.deposit({ amount });
       setLastTx(hash);
-      toast.success(t("operatorManage.super.toastDeposited", { amount: depositAmount }), { id: tid });
+      toast.success(t("operatorManage.super.toastDeposited", { amount: depositAmount }), {
+        id: tid,
+      });
       setDepositAmount("");
       setTimeout(() => void load(), 4000);
     } catch (e) {
@@ -165,11 +177,17 @@ function SuperPaymasterManager() {
           <div className="flex items-center gap-2">
             <StatusBadge
               active={state.isConfigured}
-              label={state.isConfigured ? t("operatorManage.super.configured") : t("operatorManage.super.notConfigured")}
+              label={
+                state.isConfigured
+                  ? t("operatorManage.super.configured")
+                  : t("operatorManage.super.notConfigured")
+              }
             />
             <StatusBadge
               active={!state.isPaused}
-              label={state.isPaused ? t("operatorManage.super.paused") : t("operatorManage.super.active")}
+              label={
+                state.isPaused ? t("operatorManage.super.paused") : t("operatorManage.super.active")
+              }
             />
             <button
               onClick={() => void load()}
@@ -192,11 +210,29 @@ function SuperPaymasterManager() {
             unit="aPNTs"
             sub={lowBalance ? t("operatorManage.super.lowTopUp") : undefined}
           />
-          <MetricCard label={t("operatorManage.super.exchangeRate")} value={state.exchangeRate} unit={t("operatorManage.super.exchangeRateUnit")} />
-          <MetricCard label={t("operatorManage.super.reputation")} value={state.reputation.toString()} />
-          <MetricCard label={t("operatorManage.super.totalSpent")} value={state.totalSpent} unit="aPNTs" />
-          <MetricCard label={t("operatorManage.super.txSponsored")} value={state.totalTxSponsored} />
-          <MetricCard label={t("operatorManage.super.treasury")} value={shortAddr(state.treasury)} mono />
+          <MetricCard
+            label={t("operatorManage.super.exchangeRate")}
+            value={state.exchangeRate}
+            unit={t("operatorManage.super.exchangeRateUnit")}
+          />
+          <MetricCard
+            label={t("operatorManage.super.reputation")}
+            value={state.reputation.toString()}
+          />
+          <MetricCard
+            label={t("operatorManage.super.totalSpent")}
+            value={state.totalSpent}
+            unit="aPNTs"
+          />
+          <MetricCard
+            label={t("operatorManage.super.txSponsored")}
+            value={state.totalTxSponsored}
+          />
+          <MetricCard
+            label={t("operatorManage.super.treasury")}
+            value={shortAddr(state.treasury)}
+            mono
+          />
         </div>
         <p className="mt-3 text-xs text-gray-400 font-mono break-all">
           {t("operatorManage.super.tokenAndWallet", {
@@ -228,7 +264,9 @@ function SuperPaymasterManager() {
             ) : (
               <PlusCircleIcon className="h-4 w-4" />
             )}
-            {depositing ? t("operatorManage.super.depositing") : t("operatorManage.super.depositApnts")}
+            {depositing
+              ? t("operatorManage.super.depositing")
+              : t("operatorManage.super.depositApnts")}
           </button>
         </div>
         {lastTx && (

--- a/aastar-frontend/app/operator/manage/xpnts/page.tsx
+++ b/aastar-frontend/app/operator/manage/xpnts/page.tsx
@@ -31,7 +31,7 @@ import {
   paymasterFactoryActions,
   XPNTS_FACTORY_ADDRESS,
   PAYMASTER_FACTORY_ADDRESS,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import Layout from "@/components/Layout";
 import { useWallet } from "@/contexts/WalletContext";
 import { ensureSdkConfig } from "@/lib/sdk/client";
@@ -194,9 +194,12 @@ function XPNTsManager() {
         amount: parseEther(mintAmount),
       });
       setMintTx(hash);
-      toast.success(t("operatorManage.xpnts.toastMinted", { amount: mintAmount, symbol: token.symbol }), {
-        id: tid,
-      });
+      toast.success(
+        t("operatorManage.xpnts.toastMinted", { amount: mintAmount, symbol: token.symbol }),
+        {
+          id: tid,
+        }
+      );
       setMintTo("");
       setMintAmount("");
       setTimeout(() => void load(), 4000);
@@ -222,8 +225,18 @@ function XPNTsManager() {
             {t("operatorManage.xpnts.deployPrompt")}
           </p>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Field label={t("operatorManage.xpnts.tokenName")} value={name} onChange={setName} placeholder={t("operatorManage.xpnts.tokenNamePlaceholder")} />
-            <Field label={t("operatorManage.xpnts.symbol")} value={symbol} onChange={setSymbol} placeholder={t("operatorManage.xpnts.symbolPlaceholder")} />
+            <Field
+              label={t("operatorManage.xpnts.tokenName")}
+              value={name}
+              onChange={setName}
+              placeholder={t("operatorManage.xpnts.tokenNamePlaceholder")}
+            />
+            <Field
+              label={t("operatorManage.xpnts.symbol")}
+              value={symbol}
+              onChange={setSymbol}
+              placeholder={t("operatorManage.xpnts.symbolPlaceholder")}
+            />
             <Field
               label={t("operatorManage.xpnts.communityName")}
               value={communityName}
@@ -260,7 +273,9 @@ function XPNTsManager() {
             ) : (
               <RocketLaunchIcon className="h-4 w-4" />
             )}
-            {deploying ? t("operatorManage.xpnts.deploying") : t("operatorManage.xpnts.deployToken")}
+            {deploying
+              ? t("operatorManage.xpnts.deploying")
+              : t("operatorManage.xpnts.deployToken")}
           </button>
           {deployTx && (
             <div className="mt-3">
@@ -285,10 +300,26 @@ function XPNTsManager() {
             <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
               <MetricCard label={t("operatorManage.xpnts.name")} value={token.name} mono />
               <MetricCard label={t("operatorManage.xpnts.symbolLabel")} value={token.symbol} mono />
-              <MetricCard label={t("operatorManage.xpnts.exchangeRate")} value={token.exchangeRate} unit={t("operatorManage.xpnts.exchangeRateUnit")} />
-              <MetricCard label={t("operatorManage.xpnts.community")} value={token.communityName} mono />
-              <MetricCard label={t("operatorManage.xpnts.yourBalance")} value={token.balance} unit={token.symbol} />
-              <MetricCard label={t("operatorManage.xpnts.owner")} value={shortAddr(token.communityOwner)} mono />
+              <MetricCard
+                label={t("operatorManage.xpnts.exchangeRate")}
+                value={token.exchangeRate}
+                unit={t("operatorManage.xpnts.exchangeRateUnit")}
+              />
+              <MetricCard
+                label={t("operatorManage.xpnts.community")}
+                value={token.communityName}
+                mono
+              />
+              <MetricCard
+                label={t("operatorManage.xpnts.yourBalance")}
+                value={token.balance}
+                unit={token.symbol}
+              />
+              <MetricCard
+                label={t("operatorManage.xpnts.owner")}
+                value={shortAddr(token.communityOwner)}
+                mono
+              />
             </div>
             <p className="mt-3 text-xs text-gray-400 font-mono break-all">
               {t("operatorManage.xpnts.tokenLabel")}{" "}
@@ -313,7 +344,13 @@ function XPNTsManager() {
               </div>
             )}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <Field label={t("operatorManage.xpnts.recipient")} value={mintTo} onChange={setMintTo} placeholder="0x…" mono />
+              <Field
+                label={t("operatorManage.xpnts.recipient")}
+                value={mintTo}
+                onChange={setMintTo}
+                placeholder="0x…"
+                mono
+              />
               <Field
                 label={t("operatorManage.xpnts.amountWithSymbol", { symbol: token.symbol })}
                 value={mintAmount}

--- a/aastar-frontend/lib/resources/resourceChecker.ts
+++ b/aastar-frontend/lib/resources/resourceChecker.ts
@@ -26,7 +26,7 @@ import {
   SUPER_PAYMASTER_ADDRESS,
   APNTS_ADDRESS,
   CHAIN_SEPOLIA,
-} from "@aastar/core";
+} from "@aastar/sdk/core";
 import type { Address } from "viem";
 import { ensureSdkConfig, getPublicClient } from "../sdk/client";
 import { clearCache, loadFromCache, saveToCache } from "./cache";
@@ -183,9 +183,21 @@ async function checkAOAResources(walletAddress: string): Promise<ResourceStatus>
   const addr = walletAddress.toLowerCase();
 
   const [registered, xpnts, paymaster, gToken, eth] = await Promise.all([
-    getCachedOrFetch(cacheKey("community", addr), () => isCommunityRegistered(address), r => r),
-    getCachedOrFetch(cacheKey("xpnts", addr), () => checkXPNTs(address), r => r.hasToken),
-    getCachedOrFetch(cacheKey("paymaster", addr), () => checkPaymaster(address), r => r.hasPaymaster),
+    getCachedOrFetch(
+      cacheKey("community", addr),
+      () => isCommunityRegistered(address),
+      r => r
+    ),
+    getCachedOrFetch(
+      cacheKey("xpnts", addr),
+      () => checkXPNTs(address),
+      r => r.hasToken
+    ),
+    getCachedOrFetch(
+      cacheKey("paymaster", addr),
+      () => checkPaymaster(address),
+      r => r.hasPaymaster
+    ),
     tokenBalance(GTOKEN_ADDRESS, address), // fresh, never cached
     ethBalance(address), // fresh, never cached
   ]);
@@ -224,11 +236,27 @@ async function checkAOAPlusResources(walletAddress: string): Promise<ResourceSta
   const addr = walletAddress.toLowerCase();
 
   const [registered, xpnts, aoaPaymaster, superRegistered, gToken, aPNTs, eth] = await Promise.all([
-    getCachedOrFetch(cacheKey("community", addr), () => isCommunityRegistered(address), r => r),
-    getCachedOrFetch(cacheKey("xpnts", addr), () => checkXPNTs(address), r => r.hasToken),
+    getCachedOrFetch(
+      cacheKey("community", addr),
+      () => isCommunityRegistered(address),
+      r => r
+    ),
+    getCachedOrFetch(
+      cacheKey("xpnts", addr),
+      () => checkXPNTs(address),
+      r => r.hasToken
+    ),
     // Only cache when there is NO conflict (no AOA paymaster / not yet registered).
-    getCachedOrFetch(cacheKey("aoa_paymaster", addr), () => checkPaymaster(address), r => !r.hasPaymaster),
-    getCachedOrFetch(cacheKey("superpaymaster", addr), () => isSuperPaymasterRegistered(address), r => !r),
+    getCachedOrFetch(
+      cacheKey("aoa_paymaster", addr),
+      () => checkPaymaster(address),
+      r => !r.hasPaymaster
+    ),
+    getCachedOrFetch(
+      cacheKey("superpaymaster", addr),
+      () => isSuperPaymasterRegistered(address),
+      r => !r
+    ),
     tokenBalance(GTOKEN_ADDRESS, address), // fresh, never cached
     tokenBalance(APNTS_ADDRESS, address), // fresh, never cached
     ethBalance(address), // fresh, never cached

--- a/aastar-frontend/lib/sdk/client.ts
+++ b/aastar-frontend/lib/sdk/client.ts
@@ -11,7 +11,7 @@
 import { createPublicClient, createWalletClient, custom, http } from "viem";
 import type { Address, Chain, PublicClient, WalletClient } from "viem";
 import { sepolia } from "viem/chains";
-import { applyConfig, CHAIN_SEPOLIA } from "@aastar/core";
+import { applyConfig, CHAIN_SEPOLIA } from "@aastar/sdk/core";
 
 let sdkConfigured = false;
 

--- a/aastar-frontend/lib/sdk/operator.ts
+++ b/aastar-frontend/lib/sdk/operator.ts
@@ -15,8 +15,8 @@
  * @module lib/sdk/operator
  */
 import type { WalletClient } from "viem";
-import { OperatorLifecycle, PaymasterOperatorClient } from "@aastar/operator";
-import { SUPER_PAYMASTER_ADDRESS, GTOKEN_ADDRESS } from "@aastar/core";
+import { OperatorLifecycle, PaymasterOperatorClient } from "@aastar/sdk/operator";
+import { SUPER_PAYMASTER_ADDRESS, GTOKEN_ADDRESS } from "@aastar/sdk/core";
 import { ensureSdkConfig, getPublicClient } from "./client";
 
 // @aastar/* bundles its own viem copy, so its WalletClient/PublicClient type

--- a/aastar-frontend/lib/yaaa.ts
+++ b/aastar-frontend/lib/yaaa.ts
@@ -1,5 +1,5 @@
-import { YAAAClient } from "@aastar/airaccount";
-import { KmsManager, LegacyPasskeyAssertion } from "@aastar/airaccount/server";
+import { YAAAClient } from "@aastar/sdk/kms";
+import { KmsManager, LegacyPasskeyAssertion } from "@aastar/sdk/kms";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api/v1";
 

--- a/aastar-frontend/next-env.d.ts
+++ b/aastar-frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -17,9 +17,7 @@
     "test:ci": "echo \"⚠️  No tests yet - skipping\""
   },
   "dependencies": {
-    "@aastar/airaccount": "^0.19.0",
-    "@aastar/core": "^0.18.0",
-    "@aastar/operator": "^0.18.0",
+    "@aastar/sdk": "^0.20.9",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,9 +81,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/airaccount": "^0.19.0",
-        "@aastar/core": "^0.18.0",
-        "@aastar/operator": "^0.18.0",
+        "@aastar/sdk": "^0.20.9",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -303,6 +301,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "aastar-frontend/node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmmirror.com/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "aastar-frontend/node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "aastar-frontend/node_modules/strip-ansi": {
@@ -1583,223 +1602,36 @@
         }
       }
     },
-    "node_modules/@a16z/helios": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmmirror.com/@a16z/helios/-/helios-0.11.1.tgz",
-      "integrity": "sha512-rd+RNnhKcDDRJsEOeHQ7I5FcSG2sZ1dKblCA7tI+tFdhQ5Fdox6ZwIQYdyn7s2YKVx+bnyrLociWxNvmAuaK/Q==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/@aastar/sdk": {
+      "version": "0.20.9",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.20.9.tgz",
+      "integrity": "sha512-/hIToT8IWzZjqSTDSOrVl1vnYJ9Rin/uyT61NWYTP/p6LPaN0WrLA5LZi0s2Afw93NDg9mLW9AYOdGSFDzwE6w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "uuid": "^11.0.5"
-      }
-    },
-    "node_modules/@a16z/helios/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/@aastar/airaccount": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@aastar/airaccount/-/airaccount-0.19.0.tgz",
-      "integrity": "sha512-5OoWnIrUiNxzIPO5vOkGfEKT3B0VQCoY4zqN2g7kLo6gEf5O3Mw5UXXhGc19xXWpjBmVH7JoqQg73PPbhbMJEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "^2.0.1",
         "@simplewebauthn/browser": "^13.2.2",
-        "axios": "^1.12.2"
-      },
-      "optionalDependencies": {
-        "@ledgerhq/hw-app-eth": "^7.6.0",
-        "@ledgerhq/hw-transport-webhid": "^6.33.0"
-      },
-      "peerDependencies": {
-        "ethers": "^6.0.0"
-      }
-    },
-    "node_modules/@aastar/core": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/core/-/core-0.18.0.tgz",
-      "integrity": "sha512-WFj8sH2DKp+ns30eiGrVqNqAhLXG+VU/fVWzDpjlYsxgLNRidTO0pmNQa7yBun8G5VSTeg7uTxFQTLmyv//qqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "^1.6.0",
+        "axios": "^1.12.2",
         "viem": "2.43.3"
       },
-      "optionalDependencies": {
-        "@a16z/helios": "^0.11.1"
-      }
-    },
-    "node_modules/@aastar/core/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmmirror.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
-      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT"
-    },
-    "node_modules/@aastar/core/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@aastar/core/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmmirror.com/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@aastar/core/node_modules/ox": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmmirror.com/ox/-/ox-0.11.1.tgz",
-      "integrity": "sha512-1l1gOLAqg0S0xiN1dH5nkPna8PucrZgrIJOfS49MLNiMevxu07Iz4ZjuJS9N+xifvT+PsZyIptS7WHM8nC+0+A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
       "peerDependencies": {
-        "typescript": ">=5.4.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       },
       "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aastar/core/node_modules/ox/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@aastar/core/node_modules/viem": {
-      "version": "2.43.3",
-      "resolved": "https://registry.npmmirror.com/viem/-/viem-2.43.3.tgz",
-      "integrity": "sha512-zM251fspfSjENCtfmT7cauuD+AA/YAlkFU7cksdEQJxj7wDuO0XFRWRH+RMvfmTFza88B9kug5cKU+Wk2nAjJg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "1.8.0",
-        "@scure/bip32": "1.7.0",
-        "@scure/bip39": "1.6.0",
-        "abitype": "1.2.3",
-        "isows": "1.0.7",
-        "ox": "0.11.1",
-        "ws": "8.18.3"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aastar/core/node_modules/viem/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@aastar/core/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
+        "react": {
           "optional": true
         },
-        "utf-8-validate": {
+        "react-dom": {
           "optional": true
         }
       }
     },
-    "node_modules/@aastar/operator": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/operator/-/operator-0.18.0.tgz",
-      "integrity": "sha512-7S7UBDVtTAhOBurCo2A4TGB8BE2kLxsNNhkRfwjFkRf5dJqpBZRXhSue6aPc/tZtYUjDQ+P2X8+4sCrEz28azA==",
-      "license": "MIT",
-      "dependencies": {
-        "@aastar/core": "0.18.0",
-        "viem": "2.43.3"
-      }
-    },
-    "node_modules/@aastar/operator/node_modules/@adraffy/ens-normalize": {
+    "node_modules/@aastar/sdk/node_modules/@adraffy/ens-normalize": {
       "version": "1.11.1",
       "resolved": "https://registry.npmmirror.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
-    "node_modules/@aastar/operator/node_modules/@noble/curves": {
+    "node_modules/@aastar/sdk/node_modules/@noble/curves": {
       "version": "1.9.1",
       "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
@@ -1814,7 +1646,7 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@aastar/operator/node_modules/@noble/hashes": {
+    "node_modules/@aastar/sdk/node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmmirror.com/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
@@ -1826,7 +1658,7 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@aastar/operator/node_modules/ox": {
+    "node_modules/@aastar/sdk/node_modules/ox": {
       "version": "0.11.1",
       "resolved": "https://registry.npmmirror.com/ox/-/ox-0.11.1.tgz",
       "integrity": "sha512-1l1gOLAqg0S0xiN1dH5nkPna8PucrZgrIJOfS49MLNiMevxu07Iz4ZjuJS9N+xifvT+PsZyIptS7WHM8nC+0+A==",
@@ -1856,7 +1688,7 @@
         }
       }
     },
-    "node_modules/@aastar/operator/node_modules/viem": {
+    "node_modules/@aastar/sdk/node_modules/viem": {
       "version": "2.43.3",
       "resolved": "https://registry.npmmirror.com/viem/-/viem-2.43.3.tgz",
       "integrity": "sha512-zM251fspfSjENCtfmT7cauuD+AA/YAlkFU7cksdEQJxj7wDuO0XFRWRH+RMvfmTFza88B9kug5cKU+Wk2nAjJg==",
@@ -1886,7 +1718,7 @@
         }
       }
     },
-    "node_modules/@aastar/operator/node_modules/ws": {
+    "node_modules/@aastar/sdk/node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmmirror.com/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
@@ -2071,13 +1903,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -2086,9 +1918,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2096,21 +1928,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.4",
-        "@babel/types": "^7.28.4",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -2137,14 +1969,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -2154,14 +1986,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -2181,9 +2013,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2191,29 +2023,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2223,9 +2055,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2233,9 +2065,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2243,9 +2075,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2253,9 +2085,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2263,27 +2095,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2348,13 +2180,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2390,13 +2222,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2516,13 +2348,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2541,33 +2373,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2575,14 +2407,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2811,438 +2643,28 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@ethersproject/abi": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
-      "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/hash": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
-      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/networks": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/transactions": "^5.8.0",
-        "@ethersproject/web": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
-      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/address": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
-      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/rlp": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/base64": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
-      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/bignumber": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
-      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "bn.js": "^5.2.1"
-      }
-    },
-    "node_modules/@ethersproject/bytes": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
-      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/constants": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
-      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/hash": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
-      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.8.0",
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/base64": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/keccak256": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
-      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "js-sha3": "0.8.0"
-      }
-    },
-    "node_modules/@ethersproject/logger": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
-      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@ethersproject/networks": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
-      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/properties": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
-      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/rlp": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
-      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/signing-key": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
-      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "6.6.1",
-        "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/@ethersproject/strings": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
-      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/transactions": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
-      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/address": "^5.8.0",
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/constants": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/rlp": "^5.8.0",
-        "@ethersproject/signing-key": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/web": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
-      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/base64": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "@ethersproject/strings": "^5.8.0"
-      }
-    },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react": {
       "version": "0.26.28",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/react/-/react-0.26.28.tgz",
       "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
       "license": "MIT",
       "dependencies": {
@@ -3256,12 +2678,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
+        "@floating-ui/dom": "^1.7.6"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -3269,9 +2691,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmmirror.com/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@headlessui/react": {
@@ -4195,6 +3617,33 @@
         }
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmmirror.com/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmmirror.com/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmmirror.com/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4837,238 +4286,6 @@
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@ledgerhq/client-ids": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/client-ids/-/client-ids-0.8.0.tgz",
-      "integrity": "sha512-COxmSvDAtyRlgitKcCfbq7+dqOnwzbyaasUgBj7AdVtswUwPOLLBbq1y/E/dg5TNjfXTV3zMCOu7WpNq0PdVTg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ledgerhq/live-env": "^2.30.0",
-        "@reduxjs/toolkit": "2.11.2",
-        "uuid": "^9.0.0"
-      }
-    },
-    "node_modules/@ledgerhq/client-ids/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@ledgerhq/devices": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.13.0.tgz",
-      "integrity": "sha512-hgGn1kpe/rT0EJ0Qs7rG+1TXA4g6HN2t3dB4DndRTqVqC9aSSbME+ajA0QWLZisxOD3zkwvO4Q0mJ2zARAKyag==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/logs": "^6.16.0",
-        "rxjs": "7.8.2",
-        "semver": "7.7.3"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/domain-service/-/domain-service-1.7.2.tgz",
-      "integrity": "sha512-u2BkKSQyDqw+txs97xa/t8zZmGb5XpsktPjaBNwJ8xxQkYGwi2Hz/IrveOgR/7lUTY0+iYmajuwJqVncH198KQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/logs": "^6.16.0",
-        "@ledgerhq/types-live": "^6.102.0",
-        "axios": "1.13.2",
-        "eip55": "^2.1.1",
-        "react": "19.0.0",
-        "react-dom": "19.0.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "scheduler": "^0.25.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0"
-      }
-    },
-    "node_modules/@ledgerhq/domain-service/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@ledgerhq/errors": {
-      "version": "6.32.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.32.0.tgz",
-      "integrity": "sha512-BjjvhLM6UXYUbhllqAduo9PSneLt9FXZ3TBEUFQ3MMSZOCHt0gAgDySLwul99R8fdYWkXBza4DYQjUNckpN2lg==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@ledgerhq/evm-tools": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/evm-tools/-/evm-tools-1.12.1.tgz",
-      "integrity": "sha512-TP6011l1qINtByuK930K4ETCSBwoTEwX+PSqFhaDelj2QSLmPllDj7uAL4LLAMyVCsKkfLK6SP+Qw2m9XVRnEA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ledgerhq/live-env": "^2.30.0",
-        "axios": "1.13.2",
-        "crypto-js": "4.2.0"
-      }
-    },
-    "node_modules/@ledgerhq/evm-tools/node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@ledgerhq/hw-app-eth": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-7.6.1.tgz",
-      "integrity": "sha512-rQPsjECXlRxQCmz43V7Xu53X/4+OFrWaLu4NWWB+JyWAl4vRbYkoR/4axlFM/wsDFmKGotFNce9QdqYx8GP56w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ledgerhq/domain-service": "^1.7.2",
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/evm-tools": "^1.12.1",
-        "@ledgerhq/hw-transport": "6.34.1",
-        "@ledgerhq/hw-transport-mocker": "^6.33.1",
-        "@ledgerhq/logs": "^6.16.0",
-        "@ledgerhq/types-live": "^6.102.0",
-        "axios": "1.13.2",
-        "bignumber.js": "^9.1.2",
-        "semver": "7.7.3"
-      }
-    },
-    "node_modules/@ledgerhq/hw-app-eth/node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport": {
-      "version": "6.34.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.34.1.tgz",
-      "integrity": "sha512-Bg9Qk2vtm0m0cZn9prZV2Hbvh3b42KBh4uomO00derh+eiwsdg5AXBBptAJiREkew1RVtETRdWxrKchUJfeWvA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ledgerhq/devices": "8.13.0",
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/logs": "^6.16.0",
-        "events": "^3.3.0"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-mocker": {
-      "version": "6.33.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-6.33.1.tgz",
-      "integrity": "sha512-lrz1JlOV+Q9QE228kUSiXeRc2TbpwDpY2kqPsDF+CuhlLxa+AqcK4O941cJJuFOuIx8hCEeZKiz1U2bcozKN7g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ledgerhq/hw-transport": "6.34.1",
-        "@ledgerhq/logs": "^6.16.0",
-        "rxjs": "7.8.2"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-webhid": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.34.0.tgz",
-      "integrity": "sha512-SG+UnZXyUzrJBSkZnRYGaaZV+C8yiu+pF69Mzw4AKOX6TG8RZ1tOvly8hhnRQ2/gXSiTgbc07N4T8ne2eFei3A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ledgerhq/devices": "8.13.0",
-        "@ledgerhq/errors": "^6.32.0",
-        "@ledgerhq/hw-transport": "6.34.1",
-        "@ledgerhq/logs": "^6.16.0"
-      }
-    },
-    "node_modules/@ledgerhq/live-env": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/live-env/-/live-env-2.30.0.tgz",
-      "integrity": "sha512-cs+MOC1oWv6b6Iuu0NiIjH78ecX4UAAFHgEHipdcojdsuOCRbPUxGmj/l3vpATkyEwTZEjIAVGFFtJ830KQDAw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "rxjs": "7.8.2",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@ledgerhq/logs": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.16.0.tgz",
-      "integrity": "sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
-    "node_modules/@ledgerhq/types-live": {
-      "version": "6.102.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/types-live/-/types-live-6.102.0.tgz",
-      "integrity": "sha512-/kAnEvW1g87BAtVJMXPQkZMNstjmYY+N620rOKvd+cbcZkVSa5N3MAjQHPdccLrJr/Xp5x+G21KDmp4u2j8Lfg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@ledgerhq/client-ids": "0.8.0",
-        "bignumber.js": "^9.1.2",
-        "rxjs": "7.8.2"
-      }
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -6194,16 +5411,13 @@
       }
     },
     "node_modules/@react-aria/focus": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.2.tgz",
-      "integrity": "sha512-JWaCR7wJVggj+ldmM/cb/DXFg47CXR55lznJhZBh4XVqJjMKwaOOqpT5vNN7kpC1wUpXicGNuDnJDN1S/+6dhQ==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmmirror.com/@react-aria/focus/-/focus-3.22.1.tgz",
+      "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.25.6",
-        "@react-aria/utils": "^3.31.0",
-        "@react-types/shared": "^3.32.1",
         "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -6211,110 +5425,27 @@
       }
     },
     "node_modules/@react-aria/interactions": {
-      "version": "3.25.6",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.6.tgz",
-      "integrity": "sha512-5UgwZmohpixwNMVkMvn9K1ceJe6TzlRlAfuYoQDUuOkk62/JVJNDLAPKIf5YMRc7d2B0rmfgaZLMtbREb0Zvkw==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmmirror.com/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-aria/utils": "^3.31.0",
-        "@react-stately/flags": "^3.1.2",
-        "@react-types/shared": "^3.32.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
-      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/utils": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.31.0.tgz",
-      "integrity": "sha512-ABOzCsZrWzf78ysswmguJbx3McQUja7yeGj6/vZo4JVsZNlxAN+E9rs381ExBRI0KzVo6iBTeX5De8eMZPJXig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.10",
-        "@react-stately/flags": "^3.1.2",
-        "@react-stately/utils": "^3.10.8",
-        "@react-types/shared": "^3.32.1",
+        "@react-types/shared": "^3.34.0",
         "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
+        "react-aria": "^3.48.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-stately/flags": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
-      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@react-stately/utils": {
-      "version": "3.10.8",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.8.tgz",
-      "integrity": "sha512-SN3/h7SzRsusVQjQ4v10LaVsDc81jyyR0DD5HnsQitm/I5WDpaSr2nRHtyloPFU48jlql1XX/S04T2DLQM7Y3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.1.tgz",
-      "integrity": "sha512-famxyD5emrGGpFuUlgOP6fVW2h/ZaF405G5KDi3zPHzyjAWys/8W6NAVJtNbkCkhedmvL0xOhvt8feGXyXaw5w==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmmirror.com/@react-types/shared/-/shared-3.35.0.tgz",
+      "integrity": "sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rtsao/scc": {
@@ -6485,20 +5616,6 @@
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
       "license": "MIT"
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@swc/core": {
       "version": "1.15.41",
@@ -7053,12 +6170,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
-      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "version": "3.14.3",
+      "resolved": "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.12"
+        "@tanstack/virtual-core": "3.17.1"
       },
       "funding": {
         "type": "github",
@@ -7070,9 +6187,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
-      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7240,9 +6357,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8981,6 +8098,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmmirror.com/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -9441,16 +8570,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -9642,13 +8761,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/bn.js": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
-      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/body-parser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
@@ -9696,13 +8808,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -10451,13 +9556,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -10778,45 +9876,12 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/eip55": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eip55/-/eip55-2.1.1.tgz",
-      "integrity": "sha512-WcagVAmNu2Ww2cDUfzuWVntYwFxbvZ5MvIyLZpMjTTkjD6sCvkGOiS86jTppzu9/gWsc8isLHAeMBWK02OnZmA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "keccak": "^3.0.3"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -11700,7 +10765,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -12802,17 +11867,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -12840,18 +11894,6 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/html-escaper": {
@@ -13018,17 +12060,6 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -14643,13 +13674,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14800,29 +13824,6 @@
         "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "node_modules/keccak": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
-      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/keccak/node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -15529,20 +14530,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -17010,13 +15997,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -17131,24 +16111,61 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
-      "license": "MIT",
+    "node_modules/react-aria": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmmirror.com/react-aria/-/react-aria-3.49.0.tgz",
+      "integrity": "sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.35.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.47.0",
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/react-hot-toast": {
@@ -17215,6 +16232,23 @@
         "react": "*"
       }
     },
+    "node_modules/react-stately": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmmirror.com/react-stately/-/react-stately-3.47.0.tgz",
+      "integrity": "sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.35.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -17241,23 +16275,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "optional": true,
-      "peerDependencies": {
-        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -17329,21 +16346,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmmirror.com/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -17626,7 +16637,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
@@ -18614,9 +17625,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmmirror.com/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
@@ -19782,16 +18793,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utility-types": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
-      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",


### PR DESCRIPTION
阶段一(P1-D)前端块。单包 `@aastar/sdk@0.20.9` 替代 `@aastar/airaccount`+`@aastar/core`+`@aastar/operator`。

## 改动
- **依赖+import**:三旧包 → `@aastar/sdk`;`airaccount`/`airaccount/server`→`/kms`、`core`→`/core`、`operator`→`/operator`。前端 tsconfig 是 `moduleResolution:bundler`,子路径 exports **原生解析,无需 paths shim**(与后端不同)。
- **configureOperator**:SDK 删了 exchangeRate 参数(改为运行时从 `xPNTsToken.exchangeRate()` 实时读)→ Step6 去掉第3参。
- **OperatorConfig**:删了 exchangeRate 字段 → superpaymaster 运营页改为 `xPNTsTokenActions(token).exchangeRate({token})` **实时读,保留汇率显示**。

## 验证(本地)
- `tsc --noEmit` ✅  `eslint --max-warnings 0` ✅  `next build`(全路由编译)✅  prettier(改动文件)✅

## 备注(P1 范围外,后续)
Step6 的汇率输入框对 configureOperator 已无效(汇率成为 token 级属性),UX 清理留作 follow-up。

配套:后端 #316、roadmap #315。