### PR TITLE
fix(transfer): 用 SDK canonical 地址替代硬编码 PMv4/aPNTs (P1-E)

### DIFF
--- a/aastar/src/transfer/transfer.service.ts
+++ b/aastar/src/transfer/transfer.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, Inject, BadRequestException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
+import { getCanonicalAddresses } from "@aastar/sdk/core";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 import { AddressBookService } from "./address-book.service";
 import { ExecuteTransferDto } from "./dto/execute-transfer.dto";
@@ -9,7 +11,8 @@ import { EstimateGasDto } from "./dto/estimate-gas.dto";
 export class TransferService {
   constructor(
     @Inject(YAAA_SERVER_CLIENT) private client: YAAAServerClient,
-    private addressBookService: AddressBookService
+    private addressBookService: AddressBookService,
+    private configService: ConfigService
   ) {}
 
   async executeTransfer(userId: string, transferDto: ExecuteTransferDto) {
@@ -18,11 +21,14 @@ export class TransferService {
     }
 
     // PMv4 requires the ERC-20 gas token address appended to paymasterData.
-    // Its contract has no token() getter so we supply it explicitly.
-    const PMV4_ADDRESS = "0xd0c82dc12b7d65b03df7972f67d13f1d33469a98";
-    const APNTS_TOKEN = "0xDf669834F04988BcEE0E3B6013B6b867Bd38778d";
+    // Its contract has no token() getter so we supply it explicitly. Addresses
+    // come from the SDK's canonical set for the configured chain (the same source
+    // the paymaster list is built from) — never hardcoded.
+    const canonical = getCanonicalAddresses(this.configService.get<number>("chainId") ?? 11155111);
     const paymasterTokenAddress =
-      transferDto.paymasterAddress?.toLowerCase() === PMV4_ADDRESS ? APNTS_TOKEN : undefined;
+      transferDto.paymasterAddress?.toLowerCase() === canonical.paymasterV4?.toLowerCase()
+        ? canonical.aPNTs
+        : undefined;
 
     // Pass the Legacy assertion through to the SDK, which forwards it
     // to BLSSignatureService → ISignerAdapter → KmsSigner → KMS SignHash.

--- a/aastar/src/transfer/transfer.service.ts
+++ b/aastar/src/transfer/transfer.service.ts
@@ -24,8 +24,12 @@ export class TransferService {
     // Its contract has no token() getter so we supply it explicitly. Addresses
     // come from the SDK's canonical set for the configured chain (the same source
     // the paymaster list is built from) — never hardcoded.
+    // `canonical` is undefined for an unsupported CHAIN_ID; guard so a misconfig
+    // surfaces as "no paymaster token" rather than a TypeError that crashes every
+    // transfer (strictNullChecks is off, so tsc won't catch this).
     const canonical = getCanonicalAddresses(this.configService.get<number>("chainId") ?? 11155111);
     const paymasterTokenAddress =
+      canonical &&
       transferDto.paymasterAddress?.toLowerCase() === canonical.paymasterV4?.toLowerCase()
         ? canonical.aPNTs
         : undefined;


### PR DESCRIPTION
阶段一 P1-E:清理 `transfer.service.ts` 的硬编码地址,改用 SDK 提供的 canonical 地址。

## 问题(不只是清理,是修正确性)
`transfer.service` 硬编码:
```
PMV4_ADDRESS = 0xd0c82dc12b7d65b03df7972f67d13f1d33469a98  (v4 时代,已过期)
APNTS_TOKEN  = 0xDf669834F04988BcEE0E3B6013B6b867Bd38778d  (已过期)
```
而**前端选的 paymaster 地址来自 SDK 的 paymaster 列表**(`client.paymaster`),即 SDK canonical `paymasterV4 = 0x1f0D4e…`。两者不匹配 → `transferDto.paymasterAddress === PMV4_ADDRESS` 恒为 false → **PMv4 的 aPNTs gas token 实际从未被附加**(静默的支付路径 bug)。

## 修复
改用 `getCanonicalAddresses(chainId).{paymasterV4, aPNTs}` —— 与 paymaster 列表同源,匹配成立且自动跟随 redeploy。chainId 取自 config(默认 Sepolia 11155111)。transfer 路径**零硬编码地址**。

## 验证
- `tsc -p build` ✅ · `tsc --noEmit` ✅ · **34/34 单测** ✅ · lint(仅既有无关 warning)✅ · prettier ✅
- 对照确认:`getCanonicalAddresses(11155111).paymasterV4 = 0x1f0D4e…`、`.aPNTs = 0x9e66B4…`

## 备注
- `scripts/update-superpaymaster-price.js`(记忆提及)实际不存在,transfer.service 是唯一硬编码点。
- ⚠️ 支付敏感:合并后建议测试网验一笔 PMv4 gasless 转账。
- 基于已合并的 #316/#317(SDK 0.20.x 同步)。