### PR TITLE
chore: 修复仓库既有 prettier 格式漂移(让 Code Quality / CI Success 回绿)

### DIFF
--- a/aastar-frontend/app/admin/page.tsx
+++ b/aastar-frontend/app/admin/page.tsx
@@ -112,160 +112,163 @@ export default function AdminPage() {
 
   return (
     <Layout requireAuth>
-    <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-          <ShieldCheckIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
-          {t("adminPage.title")}
-        </h1>
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-400">
-            {t("adminPage.chain", { chainId: dashboard.chainId })}
-          </span>
-          {dashboard.isAdmin ? (
-            <span className="px-2 py-1 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 rounded-full text-xs font-semibold">
-              {t("adminPage.protocolAdminBadge")}
+      <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <ShieldCheckIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+            {t("adminPage.title")}
+          </h1>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-400">
+              {t("adminPage.chain", { chainId: dashboard.chainId })}
             </span>
-          ) : (
-            <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded-full text-xs">
-              {t("adminPage.readOnlyBadge")}
-            </span>
-          )}
-        </div>
-      </div>
-
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
-          {error}
-        </div>
-      )}
-
-      {/* Registry Overview */}
-      <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1 flex items-center gap-2">
-          <CircleStackIcon className="h-5 w-5 text-gray-400" />
-          {t("adminPage.registryOverview")}
-        </h2>
-        <p className="text-xs text-gray-400 font-mono mb-4">{registryStats.registryAddress}</p>
-
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <StatCard
-            label={t("adminPage.communityAdmins")}
-            value={registryStats.roleCounts.communityAdmin}
-          />
-          <StatCard label={t("adminPage.spoOperators")} value={registryStats.roleCounts.spo} />
-          <StatCard label={t("adminPage.v4Operators")} value={registryStats.roleCounts.v4Operator} />
-          <StatCard label={t("adminPage.endUsers")} value={registryStats.roleCounts.endUser} />
-        </div>
-
-        <div className="mt-4 flex items-center gap-4 text-xs text-gray-500">
-          <span className="font-mono">
-            {t("adminPage.owner", { address: `${registryStats.owner?.slice(0, 10)}…` })}
-          </span>
-          <span>{t("adminPage.version", { version: registryStats.version })}</span>
-        </div>
-      </section>
-
-      {/* Role Configurations */}
-      <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          {t("adminPage.roleConfigsTitle")}
-        </h2>
-        <div className="space-y-4">
-          {roleConfigs.map(role => (
-            <div
-              key={role.roleId}
-              className="rounded-xl border border-gray-100 dark:border-gray-700 p-4"
-            >
-              <div className="flex items-center justify-between mb-2">
-                <p className="font-medium text-gray-900 dark:text-white text-sm">
-                  {t(`roleNames.${role.name}`, { defaultValue: role.name })}
-                </p>
-                <div className="flex items-center gap-2">
-                  <span
-                    className={`px-2 py-0.5 rounded text-xs ${
-                      role.config.isActive
-                        ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
-                        : "bg-gray-100 dark:bg-gray-700 text-gray-500"
-                    }`}
-                  >
-                    {role.config.isActive ? t("adminPage.active") : t("adminPage.inactive")}
-                  </span>
-                  <span className="text-xs text-gray-400">
-                    {t("adminPage.members", { count: role.memberCount })}
-                  </span>
-                </div>
-              </div>
-              <div className="grid grid-cols-3 gap-3 text-xs">
-                <div>
-                  <p className="text-gray-400">{t("adminPage.minStake")}</p>
-                  <p className="font-semibold text-gray-700 dark:text-gray-300">
-                    {parseFloat(role.config.minStake).toFixed(0)} GTOKEN
-                  </p>
-                </div>
-                <div>
-                  <p className="text-gray-400">{t("adminPage.entryBurn")}</p>
-                  <p className="font-semibold text-gray-700 dark:text-gray-300">
-                    {parseFloat(role.config.entryBurn).toFixed(0)} GTOKEN
-                  </p>
-                </div>
-                <div>
-                  <p className="text-gray-400">{t("adminPage.exitFee")}</p>
-                  <p className="font-semibold text-gray-700 dark:text-gray-300">
-                    {role.config.exitFeePercent}%
-                  </p>
-                </div>
-              </div>
-              <p className="text-xs font-mono text-gray-400 mt-2 truncate">
-                {t("adminPage.roleIdLabel", { roleId: role.roleId })}
-              </p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* GToken Stats */}
-      <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-          <CurrencyDollarIcon className="h-5 w-5 text-gray-400" />
-          {t("adminPage.gtokenTitle", { symbol: gtokenStats.symbol })}
-        </h2>
-        <div className="grid grid-cols-2 gap-4">
-          <StatCard
-            label={t("adminPage.totalSupply")}
-            value={parseFloat(gtokenStats.totalSupply).toLocaleString(undefined, {
-              maximumFractionDigits: 0,
-            })}
-            sub={gtokenStats.symbol}
-          />
-          <StatCard
-            label={t("adminPage.stakingContractBalance")}
-            value={parseFloat(gtokenStats.stakingContractBalance).toLocaleString(undefined, {
-              maximumFractionDigits: 0,
-            })}
-            sub={t("adminPage.lockedInStaking")}
-          />
-        </div>
-        <p className="text-xs font-mono text-gray-400 mt-3">{gtokenStats.address}</p>
-      </section>
-
-      {/* System Contract Addresses */}
-      <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          {t("adminPage.systemAddressesTitle")}
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {Object.entries(systemAddresses).map(([key, addr]) => (
-            <div key={key} className="flex gap-2 text-xs">
-              <span className="text-gray-400 w-32 shrink-0 capitalize">
-                {key.replace(/([A-Z])/g, " $1").trim()}:
+            {dashboard.isAdmin ? (
+              <span className="px-2 py-1 bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 rounded-full text-xs font-semibold">
+                {t("adminPage.protocolAdminBadge")}
               </span>
-              <span className="font-mono text-gray-600 dark:text-gray-300 break-all">{addr}</span>
-            </div>
-          ))}
+            ) : (
+              <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded-full text-xs">
+                {t("adminPage.readOnlyBadge")}
+              </span>
+            )}
+          </div>
         </div>
-      </section>
-    </div>
+
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        {/* Registry Overview */}
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1 flex items-center gap-2">
+            <CircleStackIcon className="h-5 w-5 text-gray-400" />
+            {t("adminPage.registryOverview")}
+          </h2>
+          <p className="text-xs text-gray-400 font-mono mb-4">{registryStats.registryAddress}</p>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard
+              label={t("adminPage.communityAdmins")}
+              value={registryStats.roleCounts.communityAdmin}
+            />
+            <StatCard label={t("adminPage.spoOperators")} value={registryStats.roleCounts.spo} />
+            <StatCard
+              label={t("adminPage.v4Operators")}
+              value={registryStats.roleCounts.v4Operator}
+            />
+            <StatCard label={t("adminPage.endUsers")} value={registryStats.roleCounts.endUser} />
+          </div>
+
+          <div className="mt-4 flex items-center gap-4 text-xs text-gray-500">
+            <span className="font-mono">
+              {t("adminPage.owner", { address: `${registryStats.owner?.slice(0, 10)}…` })}
+            </span>
+            <span>{t("adminPage.version", { version: registryStats.version })}</span>
+          </div>
+        </section>
+
+        {/* Role Configurations */}
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            {t("adminPage.roleConfigsTitle")}
+          </h2>
+          <div className="space-y-4">
+            {roleConfigs.map(role => (
+              <div
+                key={role.roleId}
+                className="rounded-xl border border-gray-100 dark:border-gray-700 p-4"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <p className="font-medium text-gray-900 dark:text-white text-sm">
+                    {t(`roleNames.${role.name}`, { defaultValue: role.name })}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`px-2 py-0.5 rounded text-xs ${
+                        role.config.isActive
+                          ? "bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300"
+                          : "bg-gray-100 dark:bg-gray-700 text-gray-500"
+                      }`}
+                    >
+                      {role.config.isActive ? t("adminPage.active") : t("adminPage.inactive")}
+                    </span>
+                    <span className="text-xs text-gray-400">
+                      {t("adminPage.members", { count: role.memberCount })}
+                    </span>
+                  </div>
+                </div>
+                <div className="grid grid-cols-3 gap-3 text-xs">
+                  <div>
+                    <p className="text-gray-400">{t("adminPage.minStake")}</p>
+                    <p className="font-semibold text-gray-700 dark:text-gray-300">
+                      {parseFloat(role.config.minStake).toFixed(0)} GTOKEN
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-gray-400">{t("adminPage.entryBurn")}</p>
+                    <p className="font-semibold text-gray-700 dark:text-gray-300">
+                      {parseFloat(role.config.entryBurn).toFixed(0)} GTOKEN
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-gray-400">{t("adminPage.exitFee")}</p>
+                    <p className="font-semibold text-gray-700 dark:text-gray-300">
+                      {role.config.exitFeePercent}%
+                    </p>
+                  </div>
+                </div>
+                <p className="text-xs font-mono text-gray-400 mt-2 truncate">
+                  {t("adminPage.roleIdLabel", { roleId: role.roleId })}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* GToken Stats */}
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+            <CurrencyDollarIcon className="h-5 w-5 text-gray-400" />
+            {t("adminPage.gtokenTitle", { symbol: gtokenStats.symbol })}
+          </h2>
+          <div className="grid grid-cols-2 gap-4">
+            <StatCard
+              label={t("adminPage.totalSupply")}
+              value={parseFloat(gtokenStats.totalSupply).toLocaleString(undefined, {
+                maximumFractionDigits: 0,
+              })}
+              sub={gtokenStats.symbol}
+            />
+            <StatCard
+              label={t("adminPage.stakingContractBalance")}
+              value={parseFloat(gtokenStats.stakingContractBalance).toLocaleString(undefined, {
+                maximumFractionDigits: 0,
+              })}
+              sub={t("adminPage.lockedInStaking")}
+            />
+          </div>
+          <p className="text-xs font-mono text-gray-400 mt-3">{gtokenStats.address}</p>
+        </section>
+
+        {/* System Contract Addresses */}
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            {t("adminPage.systemAddressesTitle")}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {Object.entries(systemAddresses).map(([key, addr]) => (
+              <div key={key} className="flex gap-2 text-xs">
+                <span className="text-gray-400 w-32 shrink-0 capitalize">
+                  {key.replace(/([A-Z])/g, " $1").trim()}:
+                </span>
+                <span className="font-mono text-gray-600 dark:text-gray-300 break-all">{addr}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
     </Layout>
   );
 }

--- a/aastar-frontend/app/community/page.tsx
+++ b/aastar-frontend/app/community/page.tsx
@@ -65,7 +65,11 @@ function CommunityCard({ entry }: { entry: CommunityEntry }) {
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
       <div className="flex items-start gap-3">
         {entry.metadata?.logoURI ? (
-          <img src={resolveImageUrl(entry.metadata.logoURI)} alt={name} className="w-10 h-10 rounded-full" />
+          <img
+            src={resolveImageUrl(entry.metadata.logoURI)}
+            alt={name}
+            className="w-10 h-10 rounded-full"
+          />
         ) : (
           <div className="w-10 h-10 rounded-full bg-indigo-100 dark:bg-indigo-900 flex items-center justify-center">
             <span className="text-indigo-600 dark:text-indigo-300 font-bold text-sm">
@@ -77,9 +81,7 @@ function CommunityCard({ entry }: { entry: CommunityEntry }) {
           <p className="font-semibold text-gray-900 dark:text-white truncate">{name}</p>
           <p className="text-xs text-gray-500 font-mono">{shortenAddr(entry.address)}</p>
           {entry.metadata?.description && (
-            <p className="text-xs text-gray-500 mt-1 line-clamp-2">
-              {entry.metadata.description}
-            </p>
+            <p className="text-xs text-gray-500 mt-1 line-clamp-2">{entry.metadata.description}</p>
           )}
         </div>
       </div>
@@ -163,183 +165,182 @@ export default function CommunityPage() {
     );
   }
 
-  const myName = dashboard?.metadata?.name || (dashboard?.address ? shortenAddr(dashboard.address) : "—");
+  const myName =
+    dashboard?.metadata?.name || (dashboard?.address ? shortenAddr(dashboard.address) : "—");
 
   return (
     <Layout requireAuth>
-    <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
-      <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-        <UserGroupIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
-        {t("communityPage.title")}
-      </h1>
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+          <UserGroupIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+          {t("communityPage.title")}
+        </h1>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
-          {error}
-        </div>
-      )}
-
-      {/* My Community Dashboard */}
-      {dashboard && (
-        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-              {t("communityPage.myStatusTitle")}
-            </h2>
-            {dashboard.isAdmin ? (
-              <span className="px-2 py-1 bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 rounded-full text-xs font-semibold">
-                {t("communityPage.communityAdminBadge")}
-              </span>
-            ) : (
-              <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded-full text-xs">
-                {t("communityPage.notCommunityAdminBadge")}
-              </span>
-            )}
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
+            {error}
           </div>
+        )}
 
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-            <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-              <p className="text-xs text-gray-500 mb-1">{t("communityPage.gtokenBalance")}</p>
-              <p className="text-xl font-bold text-gray-900 dark:text-white">
-                {parseFloat(dashboard.gtokenBalance || "0").toFixed(2)}
-              </p>
-              <p className="text-xs text-gray-400">GTOKEN</p>
-            </div>
-
-            {dashboard.isAdmin && dashboard.metadata && (
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-500 mb-1">{t("communityPage.communityName")}</p>
-                <p className="text-lg font-bold text-gray-900 dark:text-white truncate">
-                  {myName}
-                </p>
-                <p className="text-xs text-gray-400">
-                  {t("communityPage.staked", {
-                    amount: parseFloat(dashboard.metadata.stakeAmount).toFixed(0),
-                  })}
-                </p>
-              </div>
-            )}
-
-            {dashboard.isAdmin && dashboard.tokenAddress && dashboard.tokenInfo && (
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-500 mb-1">{t("communityPage.xpntsToken")}</p>
-                <p className="text-lg font-bold text-gray-900 dark:text-white">
-                  {dashboard.tokenInfo.symbol}
-                </p>
-                <p className="text-xs text-gray-400">
-                  {t("communityPage.supply", {
-                    amount: parseFloat(dashboard.tokenInfo.totalSupply).toLocaleString(),
-                  })}
-                </p>
-              </div>
-            )}
-          </div>
-
-          {dashboard.isAdmin && !dashboard.tokenAddress && (
-            <div className="mt-4 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-4">
-              <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
-                {t("communityPage.noTokenTitle")}
-              </p>
-              <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                {t("communityPage.noTokenDesc")}
-              </p>
-            </div>
-          )}
-
-          {!dashboard.isAdmin && (
-            <div className="mt-4 rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-4">
-              <p className="text-sm font-medium text-blue-800 dark:text-blue-300">
-                {t("communityPage.registerTitle")}
-              </p>
-              <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
-                {t("communityPage.registerDescPrefix")}{" "}
-                <code className="bg-blue-100 dark:bg-blue-800 px-1 rounded">ROLE_COMMUNITY</code>{" "}
-                {t("communityPage.registerDescSuffix")}
-              </p>
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* Address Lookup */}
-      <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-          <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
-          {t("communityPage.lookupTitle")}
-        </h2>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            onKeyDown={e => e.key === "Enter" && handleSearch()}
-            placeholder="0x..."
-            className="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-emerald-500"
-          />
-          <button
-            onClick={handleSearch}
-            disabled={searching}
-            className="px-4 py-2 bg-slate-900 hover:bg-slate-800 dark:bg-emerald-600 dark:hover:bg-emerald-500 text-white text-sm rounded-lg disabled:opacity-50"
-          >
-            {searching ? t("communityPage.searching") : t("communityPage.search")}
-          </button>
-        </div>
-
-        {searchResult && (
-          <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-xl">
-            <div className="flex items-center gap-2 mb-2">
-              <p className="font-semibold text-gray-900 dark:text-white text-sm">
-                {searchResult.metadata?.name || shortenAddr(searchResult.address)}
-              </p>
-              {searchResult.metadata ? (
-                <span className="px-2 py-0.5 bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded text-xs">
+        {/* My Community Dashboard */}
+        {dashboard && (
+          <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                {t("communityPage.myStatusTitle")}
+              </h2>
+              {dashboard.isAdmin ? (
+                <span className="px-2 py-1 bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300 rounded-full text-xs font-semibold">
                   {t("communityPage.communityAdminBadge")}
                 </span>
               ) : (
-                <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded text-xs">
-                  {t("communityPage.notRegistered")}
+                <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded-full text-xs">
+                  {t("communityPage.notCommunityAdminBadge")}
                 </span>
               )}
             </div>
-            <p className="text-xs font-mono text-gray-500">{searchResult.address}</p>
-            {searchResult.metadata?.description && (
-              <p className="text-xs text-gray-500 mt-1">{searchResult.metadata.description}</p>
-            )}
-            {searchResult.tokenAddress && searchResult.tokenInfo && (
-              <div className="mt-2 flex items-center gap-2">
-                <CurrencyDollarIcon className="h-4 w-4 text-green-500" />
-                <span className="text-xs text-gray-600 dark:text-gray-300">
-                  {t("communityPage.supplyInline", {
-                    symbol: searchResult.tokenInfo.symbol,
-                    amount: parseFloat(searchResult.tokenInfo.totalSupply).toLocaleString(),
-                  })}
-                </span>
+
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                <p className="text-xs text-gray-500 mb-1">{t("communityPage.gtokenBalance")}</p>
+                <p className="text-xl font-bold text-gray-900 dark:text-white">
+                  {parseFloat(dashboard.gtokenBalance || "0").toFixed(2)}
+                </p>
+                <p className="text-xs text-gray-400">GTOKEN</p>
+              </div>
+
+              {dashboard.isAdmin && dashboard.metadata && (
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-500 mb-1">{t("communityPage.communityName")}</p>
+                  <p className="text-lg font-bold text-gray-900 dark:text-white truncate">
+                    {myName}
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    {t("communityPage.staked", {
+                      amount: parseFloat(dashboard.metadata.stakeAmount).toFixed(0),
+                    })}
+                  </p>
+                </div>
+              )}
+
+              {dashboard.isAdmin && dashboard.tokenAddress && dashboard.tokenInfo && (
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-500 mb-1">{t("communityPage.xpntsToken")}</p>
+                  <p className="text-lg font-bold text-gray-900 dark:text-white">
+                    {dashboard.tokenInfo.symbol}
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    {t("communityPage.supply", {
+                      amount: parseFloat(dashboard.tokenInfo.totalSupply).toLocaleString(),
+                    })}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            {dashboard.isAdmin && !dashboard.tokenAddress && (
+              <div className="mt-4 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-4">
+                <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                  {t("communityPage.noTokenTitle")}
+                </p>
+                <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                  {t("communityPage.noTokenDesc")}
+                </p>
               </div>
             )}
-          </div>
-        )}
-      </section>
 
-      {/* Community List */}
-      <section>
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-          <BuildingOfficeIcon className="h-5 w-5 text-gray-400" />
-          {t("communityPage.allAdminsTitle")}
-          <span className="ml-1 text-sm text-gray-400 font-normal">
-            ({communities.length})
-          </span>
-        </h2>
-        {communities.length === 0 ? (
-          <p className="text-sm text-gray-500">{t("communityPage.noCommunities")}</p>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {communities.map(c => (
-              <CommunityCard key={c.address} entry={c} />
-            ))}
-          </div>
+            {!dashboard.isAdmin && (
+              <div className="mt-4 rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-4">
+                <p className="text-sm font-medium text-blue-800 dark:text-blue-300">
+                  {t("communityPage.registerTitle")}
+                </p>
+                <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+                  {t("communityPage.registerDescPrefix")}{" "}
+                  <code className="bg-blue-100 dark:bg-blue-800 px-1 rounded">ROLE_COMMUNITY</code>{" "}
+                  {t("communityPage.registerDescSuffix")}
+                </p>
+              </div>
+            )}
+          </section>
         )}
-      </section>
-    </div>
+
+        {/* Address Lookup */}
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+            <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+            {t("communityPage.lookupTitle")}
+          </h2>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              onKeyDown={e => e.key === "Enter" && handleSearch()}
+              placeholder="0x..."
+              className="flex-1 px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-slate-900 dark:focus:ring-emerald-500"
+            />
+            <button
+              onClick={handleSearch}
+              disabled={searching}
+              className="px-4 py-2 bg-slate-900 hover:bg-slate-800 dark:bg-emerald-600 dark:hover:bg-emerald-500 text-white text-sm rounded-lg disabled:opacity-50"
+            >
+              {searching ? t("communityPage.searching") : t("communityPage.search")}
+            </button>
+          </div>
+
+          {searchResult && (
+            <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-xl">
+              <div className="flex items-center gap-2 mb-2">
+                <p className="font-semibold text-gray-900 dark:text-white text-sm">
+                  {searchResult.metadata?.name || shortenAddr(searchResult.address)}
+                </p>
+                {searchResult.metadata ? (
+                  <span className="px-2 py-0.5 bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded text-xs">
+                    {t("communityPage.communityAdminBadge")}
+                  </span>
+                ) : (
+                  <span className="px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded text-xs">
+                    {t("communityPage.notRegistered")}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs font-mono text-gray-500">{searchResult.address}</p>
+              {searchResult.metadata?.description && (
+                <p className="text-xs text-gray-500 mt-1">{searchResult.metadata.description}</p>
+              )}
+              {searchResult.tokenAddress && searchResult.tokenInfo && (
+                <div className="mt-2 flex items-center gap-2">
+                  <CurrencyDollarIcon className="h-4 w-4 text-green-500" />
+                  <span className="text-xs text-gray-600 dark:text-gray-300">
+                    {t("communityPage.supplyInline", {
+                      symbol: searchResult.tokenInfo.symbol,
+                      amount: parseFloat(searchResult.tokenInfo.totalSupply).toLocaleString(),
+                    })}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* Community List */}
+        <section>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
+            <BuildingOfficeIcon className="h-5 w-5 text-gray-400" />
+            {t("communityPage.allAdminsTitle")}
+            <span className="ml-1 text-sm text-gray-400 font-normal">({communities.length})</span>
+          </h2>
+          {communities.length === 0 ? (
+            <p className="text-sm text-gray-500">{t("communityPage.noCommunities")}</p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {communities.map(c => (
+                <CommunityCard key={c.address} entry={c} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
     </Layout>
   );
 }

--- a/aastar-frontend/app/dashboard/page.tsx
+++ b/aastar-frontend/app/dashboard/page.tsx
@@ -601,7 +601,11 @@ function DashboardContent() {
               <div className="p-6">
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-lg font-medium text-gray-900 dark:text-white flex items-center gap-2">
-                    <svg className="w-5 h-5 text-slate-600 dark:text-emerald-400" viewBox="0 0 24 24" fill="currentColor">
+                    <svg
+                      className="w-5 h-5 text-slate-600 dark:text-emerald-400"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                    >
                       <path d="M19.77 7.23l.01-.01-3.72-3.72L15 4.56l2.11 2.11c-.94.36-1.61 1.26-1.61 2.33a2.5 2.5 0 002.5 2.5c.36 0 .69-.08 1-.21V19c0 .55-.45 1-1 1s-1-.45-1-1v-3c0-1.1-.9-2-2-2h-1V5c0-1.1-.9-2-2-2H6C4.9 3 4 3.9 4 5v16h10v-7.5h1.5v5a2.5 2.5 0 005 0V9c0-.69-.28-1.32-.73-1.77zM12 10H6V5h6v5zm6 0a1 1 0 110-2 1 1 0 010 2z" />
                     </svg>
                     Paymaster Status

--- a/aastar-frontend/app/layout.tsx
+++ b/aastar-frontend/app/layout.tsx
@@ -31,10 +31,7 @@ export const metadata: Metadata = {
     title: "AAStar",
   },
   icons: {
-    icon: [
-      { url: "/favicon.ico" },
-      { url: "/icon-512.png", sizes: "512x512", type: "image/png" },
-    ],
+    icon: [{ url: "/favicon.ico" }, { url: "/icon-512.png", sizes: "512x512", type: "image/png" }],
     apple: [{ url: "/apple-icon.png", sizes: "180x180", type: "image/png" }],
   },
 };

--- a/aastar-frontend/app/operator/deploy/components/FormField.tsx
+++ b/aastar-frontend/app/operator/deploy/components/FormField.tsx
@@ -28,7 +28,9 @@ export default function FormField({
 }: FormFieldProps) {
   return (
     <label className="block">
-      <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{label}</span>
+      <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        {label}
+      </span>
       <input
         type={type}
         value={value}

--- a/aastar-frontend/app/operator/deploy/components/StepCard.tsx
+++ b/aastar-frontend/app/operator/deploy/components/StepCard.tsx
@@ -55,7 +55,9 @@ export default function StepCard({
         {icon && <div className="text-slate-700 dark:text-emerald-400 shrink-0 mt-0.5">{icon}</div>}
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h2>
-          {description && <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{description}</p>}
+          {description && (
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{description}</p>
+          )}
         </div>
       </div>
 
@@ -69,7 +71,9 @@ export default function StepCard({
             <CheckCircleIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
           )}
           <span className="text-emerald-700 dark:text-emerald-300">
-            {status === "pending" ? t("operatorDeploy.tx.pending") : t("operatorDeploy.tx.confirmedLabel")}
+            {status === "pending"
+              ? t("operatorDeploy.tx.pending")
+              : t("operatorDeploy.tx.confirmedLabel")}
           </span>
           <a
             href={explorerTx(txHash)}

--- a/aastar-frontend/app/operator/deploy/components/WizardProgress.tsx
+++ b/aastar-frontend/app/operator/deploy/components/WizardProgress.tsx
@@ -34,9 +34,7 @@ export default function WizardProgress({ labels, current }: WizardProgressProps)
               </span>
               <span
                 className={`text-xs font-medium whitespace-nowrap ${
-                  active
-                    ? "text-gray-900 dark:text-white"
-                    : "text-gray-400 dark:text-gray-500"
+                  active ? "text-gray-900 dark:text-white" : "text-gray-400 dark:text-gray-500"
                 }`}
               >
                 {label}

--- a/aastar-frontend/app/operator/deploy/components/useTxStep.ts
+++ b/aastar-frontend/app/operator/deploy/components/useTxStep.ts
@@ -40,7 +40,8 @@ type Translate = (key: string) => string;
 
 function humanizeError(err: unknown, t: Translate): string {
   const raw = err instanceof Error ? err.message : String(err);
-  if (/user rejected|denied|rejected the request/i.test(raw)) return t("operatorDeploy.tx.rejected");
+  if (/user rejected|denied|rejected the request/i.test(raw))
+    return t("operatorDeploy.tx.rejected");
   if (/insufficient funds/i.test(raw)) return t("operatorDeploy.tx.insufficientFunds");
   // viem stuffs the useful bit in the first line; keep it short for the UI.
   return raw.split("\n")[0].slice(0, 200);

--- a/aastar-frontend/app/operator/deploy/page.tsx
+++ b/aastar-frontend/app/operator/deploy/page.tsx
@@ -69,7 +69,10 @@ export default function OperatorDeployPage() {
       : [...head, "paymaster", "entrypoint", "done"];
   }, [data.mode]);
 
-  const onNext = useCallback(() => setStep(s => Math.min(s + 1, stepKeys.length - 1)), [stepKeys.length]);
+  const onNext = useCallback(
+    () => setStep(s => Math.min(s + 1, stepKeys.length - 1)),
+    [stepKeys.length]
+  );
   const onBack = useCallback(() => setStep(s => Math.max(s - 1, 0)), []);
 
   const refreshResources = useCallback(async () => {
@@ -135,7 +138,9 @@ export default function OperatorDeployPage() {
       case "deposit-apnts":
         return <Step7DepositAPNTs {...stepProps} />;
       case "done":
-        return <StepComplete data={data} onDone={() => router.push("/operator")} onRestart={restart} />;
+        return (
+          <StepComplete data={data} onDone={() => router.push("/operator")} onRestart={restart} />
+        );
       default:
         return null;
     }

--- a/aastar-frontend/app/operator/deploy/steps/Step1ConnectSelect.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step1ConnectSelect.tsx
@@ -94,9 +94,13 @@ export default function Step1ConnectSelect({ data, update, onNext }: Step1Props)
             >
               <div className="flex items-center gap-2 mb-2">
                 <Icon className="h-5 w-5 text-slate-700 dark:text-emerald-400" />
-                <span className="font-semibold text-gray-900 dark:text-white">{t(`${m.ns}.title`)}</span>
+                <span className="font-semibold text-gray-900 dark:text-white">
+                  {t(`${m.ns}.title`)}
+                </span>
               </div>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">{t(`${m.ns}.subtitle`)}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                {t(`${m.ns}.subtitle`)}
+              </p>
               <ul className="space-y-1">
                 {[1, 2, 3, 4].map(n => (
                   <li key={n} className="text-xs text-gray-600 dark:text-gray-300 flex gap-1.5">

--- a/aastar-frontend/app/operator/deploy/steps/Step2ResourceCheck.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step2ResourceCheck.tsx
@@ -69,7 +69,8 @@ export default function Step2ResourceCheck({ address, data, update, onNext, onBa
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const balancesOk = !!res && res.hasEnoughGToken && res.hasEnoughETH && (mode === "aoa" || res.hasEnoughAPNTs);
+  const balancesOk =
+    !!res && res.hasEnoughGToken && res.hasEnoughETH && (mode === "aoa" || res.hasEnoughAPNTs);
 
   return (
     <StepCard
@@ -128,12 +129,21 @@ export default function Step2ResourceCheck({ address, data, update, onNext, onBa
             <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">
               {t("operatorDeploy.step2.onChainState")}
             </p>
-            <Row label={t("operatorDeploy.step2.communityRegistered")} ok={res.isCommunityRegistered} />
+            <Row
+              label={t("operatorDeploy.step2.communityRegistered")}
+              ok={res.isCommunityRegistered}
+            />
             <Row label={t("operatorDeploy.step2.xpntsDeployed")} ok={res.hasXPNTs} />
             {mode === "aoa" ? (
-              <Row label={t("operatorDeploy.step2.aoaPaymasterDeployed")} ok={res.hasAOAPaymaster} />
+              <Row
+                label={t("operatorDeploy.step2.aoaPaymasterDeployed")}
+                ok={res.hasAOAPaymaster}
+              />
             ) : (
-              <Row label={t("operatorDeploy.step2.registeredOnSuper")} ok={res.hasSuperPaymasterRegistered} />
+              <Row
+                label={t("operatorDeploy.step2.registeredOnSuper")}
+                ok={res.hasSuperPaymasterRegistered}
+              />
             )}
           </div>
 

--- a/aastar-frontend/app/operator/deploy/steps/Step5DeployPaymasterV4.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step5DeployPaymasterV4.tsx
@@ -81,7 +81,12 @@ export default function Step5DeployPaymasterV4({
             {t("operatorDeploy.step5Paymaster.alreadyDeployed")}
           </div>
           {paymaster && (
-            <a href={explorerAddr(paymaster)} target="_blank" rel="noopener noreferrer" className="font-mono text-xs hover:underline break-all">
+            <a
+              href={explorerAddr(paymaster)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-xs hover:underline break-all"
+            >
               {paymaster}
             </a>
           )}

--- a/aastar-frontend/app/operator/deploy/steps/Step5RegisterSuper.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step5RegisterSuper.tsx
@@ -21,7 +21,13 @@ import { useTxStep } from "../components/useTxStep";
 import StepCard from "../components/StepCard";
 import WizardButton from "../components/WizardButton";
 
-export default function Step5RegisterSuper({ walletClient, data, onNext, onBack, refreshResources }: StepProps) {
+export default function Step5RegisterSuper({
+  walletClient,
+  data,
+  onNext,
+  onBack,
+  refreshResources,
+}: StepProps) {
   const { t } = useTranslation();
   const already = !!data.resources?.hasSuperPaymasterRegistered;
   const tx = useTxStep();

--- a/aastar-frontend/app/operator/deploy/steps/Step7DepositAPNTs.tsx
+++ b/aastar-frontend/app/operator/deploy/steps/Step7DepositAPNTs.tsx
@@ -18,7 +18,14 @@ import StepCard from "../components/StepCard";
 import WizardButton from "../components/WizardButton";
 import FormField from "../components/FormField";
 
-export default function Step7DepositAPNTs({ walletClient, data, update, onNext, onBack, refreshResources }: StepProps) {
+export default function Step7DepositAPNTs({
+  walletClient,
+  data,
+  update,
+  onNext,
+  onBack,
+  refreshResources,
+}: StepProps) {
   const { t } = useTranslation();
   const tx = useTxStep();
   const [amount, setAmount] = useState(data.aPNTsDeposit);
@@ -64,7 +71,13 @@ export default function Step7DepositAPNTs({ walletClient, data, update, onNext, 
         </>
       }
     >
-      <FormField label={t("operatorDeploy.step7Apnts.depositAmount")} type="number" value={amount} onChange={setAmount} hint={t("operatorDeploy.step7Apnts.depositHint")} />
+      <FormField
+        label={t("operatorDeploy.step7Apnts.depositAmount")}
+        type="number"
+        value={amount}
+        onChange={setAmount}
+        hint={t("operatorDeploy.step7Apnts.depositHint")}
+      />
     </StepCard>
   );
 }

--- a/aastar-frontend/app/operator/manage/_components/shared.tsx
+++ b/aastar-frontend/app/operator/manage/_components/shared.tsx
@@ -17,7 +17,12 @@
  */
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowPathIcon, CheckBadgeIcon, XCircleIcon, WalletIcon } from "@heroicons/react/24/outline";
+import {
+  ArrowPathIcon,
+  CheckBadgeIcon,
+  XCircleIcon,
+  WalletIcon,
+} from "@heroicons/react/24/outline";
 import { useWallet } from "@/contexts/WalletContext";
 import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
 
@@ -108,7 +113,11 @@ export function StatusBadge({ active, label }: StatusBadgeProps) {
           : "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400"
       }`}
     >
-      {active ? <CheckBadgeIcon className="h-3.5 w-3.5" /> : <XCircleIcon className="h-3.5 w-3.5" />}
+      {active ? (
+        <CheckBadgeIcon className="h-3.5 w-3.5" />
+      ) : (
+        <XCircleIcon className="h-3.5 w-3.5" />
+      )}
       {label}
     </span>
   );
@@ -180,7 +189,9 @@ export function ConnectGate({ children }: { children: ReactNode }) {
           ) : (
             <WalletIcon className="h-4 w-4" />
           )}
-          {isConnecting ? t("operatorManage.shared.connecting") : t("operatorManage.shared.connectWallet")}
+          {isConnecting
+            ? t("operatorManage.shared.connecting")
+            : t("operatorManage.shared.connectWallet")}
         </button>
       ) : (
         <p className="text-xs text-amber-600 dark:text-amber-400">

--- a/aastar-frontend/app/operator/page.tsx
+++ b/aastar-frontend/app/operator/page.tsx
@@ -122,218 +122,218 @@ export default function OperatorPage() {
 
   return (
     <Layout requireAuth>
-    <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
-      <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-        <ServerStackIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
-        {t("operatorDashboard.title")}
-      </h1>
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+          <ServerStackIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+          {t("operatorDashboard.title")}
+        </h1>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
-          {error}
-        </div>
-      )}
-
-      {/* Quick Actions — entry points to the operator write flows */}
-      <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <button
-          type="button"
-          onClick={() => router.push("/operator/deploy")}
-          className="text-left bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 hover:border-emerald-400 dark:hover:border-emerald-500 transition-colors"
-        >
-          <div className="flex items-center gap-2 mb-1">
-            <RocketLaunchIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-            <span className="font-semibold text-gray-900 dark:text-white">
-              {t("operatorHub.onboard.title")}
-            </span>
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
+            {error}
           </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            {t("operatorHub.onboard.desc")}
-          </p>
-        </button>
-        <button
-          type="button"
-          onClick={() => router.push("/operator/manage")}
-          className="text-left bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 hover:border-emerald-400 dark:hover:border-emerald-500 transition-colors"
-        >
-          <div className="flex items-center gap-2 mb-1">
-            <WrenchScrewdriverIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-            <span className="font-semibold text-gray-900 dark:text-white">
-              {t("operatorHub.manage.title")}
-            </span>
-          </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            {t("operatorHub.manage.desc")}
-          </p>
-        </button>
-      </section>
+        )}
 
-      {/* My Operator Status */}
-      {dashboard && (
-        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-              {t("operatorDashboard.myStatusTitle")}
-            </h2>
-            <div className="flex gap-2">
-              <StatusBadge active={dashboard.isSPO} label={t("operatorDashboard.spoBadge")} />
-              <StatusBadge
-                active={dashboard.isV4Operator}
-                label={t("operatorDashboard.v4OperatorBadge")}
-              />
+        {/* Quick Actions — entry points to the operator write flows */}
+        <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <button
+            type="button"
+            onClick={() => router.push("/operator/deploy")}
+            className="text-left bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 hover:border-emerald-400 dark:hover:border-emerald-500 transition-colors"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <RocketLaunchIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {t("operatorHub.onboard.title")}
+              </span>
             </div>
-          </div>
-
-          {/* GToken Balance */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-            <MetricCard
-              label={t("operatorDashboard.gtokenBalance")}
-              value={dashboard.gtokenBalance}
-              unit="GTOKEN"
-            />
-
-            {dashboard.isSPO && dashboard.spoStatus && (
-              <>
-                <MetricCard
-                  label={t("operatorDashboard.spoStake")}
-                  value={dashboard.spoStatus.stakeAmount}
-                  unit="GTOKEN"
-                />
-                <MetricCard
-                  label={t("operatorDashboard.spBalance")}
-                  value={dashboard.spoStatus.balance}
-                  unit="aPNTs"
-                  sub={
-                    dashboard.spoStatus.isConfigured
-                      ? t("operatorDashboard.configured")
-                      : t("operatorDashboard.notConfigured")
-                  }
-                />
-                <MetricCard
-                  label={t("operatorDashboard.exchangeRate")}
-                  value={dashboard.spoStatus.exchangeRate}
-                  unit="aPNTs/GWEI"
-                />
-              </>
-            )}
-
-            {dashboard.v4Status.paymasterAddress && (
-              <MetricCard
-                label={t("operatorDashboard.v4PaymasterEth")}
-                value={dashboard.v4Status.balance}
-                unit="ETH"
-                sub={shortenAddr(dashboard.v4Status.paymasterAddress)}
-              />
-            )}
-          </div>
-
-          {/* SPO Registration Guide */}
-          {!dashboard.isSPO && (
-            <div className="rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-4">
-              <p className="text-sm font-medium text-blue-800 dark:text-blue-300 mb-1">
-                {t("operatorDashboard.registerSpoTitle")}
-              </p>
-              <ol className="text-xs text-blue-600 dark:text-blue-400 space-y-1 list-decimal list-inside">
-                <li>{t("operatorDashboard.registerSpoStep1")}</li>
-                <li>
-                  {t("operatorDashboard.registerSpoStep2Prefix")}{" "}
-                  <code className="bg-blue-100 dark:bg-blue-800 px-1 rounded">
-                    registerRoleSelf
-                  </code>{" "}
-                  {t("operatorDashboard.registerSpoStep2Suffix")}
-                </li>
-                <li>{t("operatorDashboard.registerSpoStep3")}</li>
-                <li>{t("operatorDashboard.registerSpoStep4")}</li>
-              </ol>
-            </div>
-          )}
-
-          {/* SPO configured but not V4 */}
-          {!dashboard.v4Status.paymasterAddress && (
-            <div className="mt-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-4">
-              <p className="text-sm font-medium text-amber-800 dark:text-amber-300 mb-1">
-                {t("operatorDashboard.deployV4Title")}
-              </p>
-              <ol className="text-xs text-amber-600 dark:text-amber-400 space-y-1 list-decimal list-inside">
-                <li>
-                  {t("operatorDashboard.deployV4Step1Prefix")}{" "}
-                  <code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">
-                    deployPaymaster
-                  </code>{" "}
-                  {t("operatorDashboard.deployV4Step1Suffix")}
-                </li>
-                <li>
-                  {t("operatorDashboard.deployV4Step2Prefix")}{" "}
-                  <code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">
-                    ROLE_PAYMASTER_SUPER
-                  </code>{" "}
-                  {t("operatorDashboard.deployV4Step2Suffix")}
-                </li>
-              </ol>
-            </div>
-          )}
-
-          {/* Contract Addresses */}
-          <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700">
-            <p className="text-xs text-gray-500 mb-2">
-              {t("operatorDashboard.contractAddresses")}
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t("operatorHub.onboard.desc")}
             </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs font-mono">
-              {[
-                ["Registry", dashboard.registryAddress],
-                ["SuperPaymaster", dashboard.superPaymasterAddress],
-                ["PaymasterFactory", dashboard.paymasterFactoryAddress],
-                ["GTokenStaking", dashboard.stakingAddress],
-              ].map(([label, addr]) => (
-                <div key={label} className="flex gap-2 text-gray-600 dark:text-gray-400">
-                  <span className="text-gray-400 w-32 shrink-0">{label}:</span>
-                  <span className="truncate">{addr}</span>
-                </div>
-              ))}
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push("/operator/manage")}
+            className="text-left bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 hover:border-emerald-400 dark:hover:border-emerald-500 transition-colors"
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <WrenchScrewdriverIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {t("operatorHub.manage.title")}
+              </span>
             </div>
-          </div>
-        </section>
-      )}
-
-      {/* Operator Lists */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
-            {t("operatorDashboard.spoOperatorsTitle")}
-            <span className="ml-2 text-sm font-normal text-gray-400">({spoList.length})</span>
-          </h2>
-          {spoList.length === 0 ? (
-            <p className="text-sm text-gray-400">{t("operatorDashboard.noneRegistered")}</p>
-          ) : (
-            <ul className="space-y-1">
-              {spoList.map(addr => (
-                <li key={addr} className="text-xs font-mono text-gray-600 dark:text-gray-300">
-                  {addr}
-                </li>
-              ))}
-            </ul>
-          )}
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t("operatorHub.manage.desc")}
+            </p>
+          </button>
         </section>
 
-        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-          <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
-            {t("operatorDashboard.v4OperatorsTitle")}
-            <span className="ml-2 text-sm font-normal text-gray-400">({v4List.length})</span>
-          </h2>
-          {v4List.length === 0 ? (
-            <p className="text-sm text-gray-400">{t("operatorDashboard.noneRegistered")}</p>
-          ) : (
-            <ul className="space-y-1">
-              {v4List.map(addr => (
-                <li key={addr} className="text-xs font-mono text-gray-600 dark:text-gray-300">
-                  {addr}
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
+        {/* My Operator Status */}
+        {dashboard && (
+          <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                {t("operatorDashboard.myStatusTitle")}
+              </h2>
+              <div className="flex gap-2">
+                <StatusBadge active={dashboard.isSPO} label={t("operatorDashboard.spoBadge")} />
+                <StatusBadge
+                  active={dashboard.isV4Operator}
+                  label={t("operatorDashboard.v4OperatorBadge")}
+                />
+              </div>
+            </div>
+
+            {/* GToken Balance */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
+              <MetricCard
+                label={t("operatorDashboard.gtokenBalance")}
+                value={dashboard.gtokenBalance}
+                unit="GTOKEN"
+              />
+
+              {dashboard.isSPO && dashboard.spoStatus && (
+                <>
+                  <MetricCard
+                    label={t("operatorDashboard.spoStake")}
+                    value={dashboard.spoStatus.stakeAmount}
+                    unit="GTOKEN"
+                  />
+                  <MetricCard
+                    label={t("operatorDashboard.spBalance")}
+                    value={dashboard.spoStatus.balance}
+                    unit="aPNTs"
+                    sub={
+                      dashboard.spoStatus.isConfigured
+                        ? t("operatorDashboard.configured")
+                        : t("operatorDashboard.notConfigured")
+                    }
+                  />
+                  <MetricCard
+                    label={t("operatorDashboard.exchangeRate")}
+                    value={dashboard.spoStatus.exchangeRate}
+                    unit="aPNTs/GWEI"
+                  />
+                </>
+              )}
+
+              {dashboard.v4Status.paymasterAddress && (
+                <MetricCard
+                  label={t("operatorDashboard.v4PaymasterEth")}
+                  value={dashboard.v4Status.balance}
+                  unit="ETH"
+                  sub={shortenAddr(dashboard.v4Status.paymasterAddress)}
+                />
+              )}
+            </div>
+
+            {/* SPO Registration Guide */}
+            {!dashboard.isSPO && (
+              <div className="rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-4">
+                <p className="text-sm font-medium text-blue-800 dark:text-blue-300 mb-1">
+                  {t("operatorDashboard.registerSpoTitle")}
+                </p>
+                <ol className="text-xs text-blue-600 dark:text-blue-400 space-y-1 list-decimal list-inside">
+                  <li>{t("operatorDashboard.registerSpoStep1")}</li>
+                  <li>
+                    {t("operatorDashboard.registerSpoStep2Prefix")}{" "}
+                    <code className="bg-blue-100 dark:bg-blue-800 px-1 rounded">
+                      registerRoleSelf
+                    </code>{" "}
+                    {t("operatorDashboard.registerSpoStep2Suffix")}
+                  </li>
+                  <li>{t("operatorDashboard.registerSpoStep3")}</li>
+                  <li>{t("operatorDashboard.registerSpoStep4")}</li>
+                </ol>
+              </div>
+            )}
+
+            {/* SPO configured but not V4 */}
+            {!dashboard.v4Status.paymasterAddress && (
+              <div className="mt-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-4">
+                <p className="text-sm font-medium text-amber-800 dark:text-amber-300 mb-1">
+                  {t("operatorDashboard.deployV4Title")}
+                </p>
+                <ol className="text-xs text-amber-600 dark:text-amber-400 space-y-1 list-decimal list-inside">
+                  <li>
+                    {t("operatorDashboard.deployV4Step1Prefix")}{" "}
+                    <code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">
+                      deployPaymaster
+                    </code>{" "}
+                    {t("operatorDashboard.deployV4Step1Suffix")}
+                  </li>
+                  <li>
+                    {t("operatorDashboard.deployV4Step2Prefix")}{" "}
+                    <code className="bg-amber-100 dark:bg-amber-800 px-1 rounded">
+                      ROLE_PAYMASTER_SUPER
+                    </code>{" "}
+                    {t("operatorDashboard.deployV4Step2Suffix")}
+                  </li>
+                </ol>
+              </div>
+            )}
+
+            {/* Contract Addresses */}
+            <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-700">
+              <p className="text-xs text-gray-500 mb-2">
+                {t("operatorDashboard.contractAddresses")}
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs font-mono">
+                {[
+                  ["Registry", dashboard.registryAddress],
+                  ["SuperPaymaster", dashboard.superPaymasterAddress],
+                  ["PaymasterFactory", dashboard.paymasterFactoryAddress],
+                  ["GTokenStaking", dashboard.stakingAddress],
+                ].map(([label, addr]) => (
+                  <div key={label} className="flex gap-2 text-gray-600 dark:text-gray-400">
+                    <span className="text-gray-400 w-32 shrink-0">{label}:</span>
+                    <span className="truncate">{addr}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* Operator Lists */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
+              {t("operatorDashboard.spoOperatorsTitle")}
+              <span className="ml-2 text-sm font-normal text-gray-400">({spoList.length})</span>
+            </h2>
+            {spoList.length === 0 ? (
+              <p className="text-sm text-gray-400">{t("operatorDashboard.noneRegistered")}</p>
+            ) : (
+              <ul className="space-y-1">
+                {spoList.map(addr => (
+                  <li key={addr} className="text-xs font-mono text-gray-600 dark:text-gray-300">
+                    {addr}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
+              {t("operatorDashboard.v4OperatorsTitle")}
+              <span className="ml-2 text-sm font-normal text-gray-400">({v4List.length})</span>
+            </h2>
+            {v4List.length === 0 ? (
+              <p className="text-sm text-gray-400">{t("operatorDashboard.noneRegistered")}</p>
+            ) : (
+              <ul className="space-y-1">
+                {v4List.map(addr => (
+                  <li key={addr} className="text-xs font-mono text-gray-600 dark:text-gray-300">
+                    {addr}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
       </div>
-    </div>
     </Layout>
   );
 }

--- a/aastar-frontend/app/role/page.tsx
+++ b/aastar-frontend/app/role/page.tsx
@@ -125,9 +125,7 @@ export default function RolePage() {
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             {t("rolePage.title")}
           </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            {t("rolePage.subtitle")}
-          </p>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{t("rolePage.subtitle")}</p>
         </div>
 
         {/* Registry Info */}
@@ -141,7 +139,10 @@ export default function RolePage() {
             </div>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {[
-                { label: t("rolePage.communityAdmins"), value: registryInfo.roleCounts.communityAdmin },
+                {
+                  label: t("rolePage.communityAdmins"),
+                  value: registryInfo.roleCounts.communityAdmin,
+                },
                 { label: t("rolePage.spoOperators"), value: registryInfo.roleCounts.spo },
                 { label: t("rolePage.v4Operators"), value: registryInfo.roleCounts.v4Operator },
                 { label: t("rolePage.endUsers"), value: registryInfo.roleCounts.endUser },
@@ -198,11 +199,31 @@ export default function RolePage() {
             </div>
 
             <div className="flex flex-wrap gap-2 mb-5">
-              <RoleBadge label={t("rolePage.badge.protocolAdmin")} active={roleInfo.isAdmin} color="purple" />
-              <RoleBadge label={t("rolePage.badge.communityAdmin")} active={roleInfo.isCommunityAdmin} color="green" />
-              <RoleBadge label={t("rolePage.badge.spoOperator")} active={roleInfo.isSPO} color="orange" />
-              <RoleBadge label={t("rolePage.badge.v4Operator")} active={roleInfo.isV4Operator} color="blue" />
-              <RoleBadge label={t("rolePage.badge.endUser")} active={roleInfo.isEndUser} color="gray" />
+              <RoleBadge
+                label={t("rolePage.badge.protocolAdmin")}
+                active={roleInfo.isAdmin}
+                color="purple"
+              />
+              <RoleBadge
+                label={t("rolePage.badge.communityAdmin")}
+                active={roleInfo.isCommunityAdmin}
+                color="green"
+              />
+              <RoleBadge
+                label={t("rolePage.badge.spoOperator")}
+                active={roleInfo.isSPO}
+                color="orange"
+              />
+              <RoleBadge
+                label={t("rolePage.badge.v4Operator")}
+                active={roleInfo.isV4Operator}
+                color="blue"
+              />
+              <RoleBadge
+                label={t("rolePage.badge.endUser")}
+                active={roleInfo.isEndUser}
+                color="gray"
+              />
             </div>
 
             {/* Navigation Cards */}
@@ -275,13 +296,17 @@ export default function RolePage() {
                 </button>
               )}
 
-              {!roleInfo.isAdmin && !roleInfo.isCommunityAdmin && !roleInfo.isSPO && !roleInfo.isV4Operator && !roleInfo.isEndUser && (
-                <div className="col-span-full text-center py-6 text-gray-500 dark:text-gray-400">
-                  <ShieldCheckIcon className="h-10 w-10 mx-auto mb-2 opacity-40" />
-                  <p className="text-sm">{t("rolePage.noRolesTitle")}</p>
-                  <p className="text-xs mt-1">{t("rolePage.noRolesHint")}</p>
-                </div>
-              )}
+              {!roleInfo.isAdmin &&
+                !roleInfo.isCommunityAdmin &&
+                !roleInfo.isSPO &&
+                !roleInfo.isV4Operator &&
+                !roleInfo.isEndUser && (
+                  <div className="col-span-full text-center py-6 text-gray-500 dark:text-gray-400">
+                    <ShieldCheckIcon className="h-10 w-10 mx-auto mb-2 opacity-40" />
+                    <p className="text-sm">{t("rolePage.noRolesTitle")}</p>
+                    <p className="text-xs mt-1">{t("rolePage.noRolesHint")}</p>
+                  </div>
+                )}
             </div>
           </div>
         ) : null}

--- a/aastar-frontend/app/sale/page.tsx
+++ b/aastar-frontend/app/sale/page.tsx
@@ -84,7 +84,10 @@ export default function SalePage() {
     Promise.all([
       saleAPI.getGTokenStatus().then(r => setGTokenStatus(r.data)),
       saleAPI.getAPNTsStatus().then(r => setAPNTsStatus(r.data)),
-      saleAPI.getGTokenEligibility().then(r => setEligibility(r.data)).catch(() => null),
+      saleAPI
+        .getGTokenEligibility()
+        .then(r => setEligibility(r.data))
+        .catch(() => null),
     ])
       .catch(err => {
         if (err.response?.status === 401) router.push("/auth/login");
@@ -118,242 +121,242 @@ export default function SalePage() {
 
   return (
     <Layout requireAuth>
-    <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
-      <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
-        <CurrencyDollarIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
-        {t("salePage.title")}
-      </h1>
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+          <CurrencyDollarIcon className="h-7 w-7 text-slate-700 dark:text-emerald-400" />
+          {t("salePage.title")}
+        </h1>
 
-      {error && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
-          {error}
-        </div>
-      )}
-
-      {/* GToken Sale */}
-      <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-            <ArrowTrendingUpIcon className="h-5 w-5 text-indigo-400" />
-            {t("salePage.gtokenSaleTitle")}
-          </h2>
-          {gTokenStatus?.configured ? (
-            gTokenStatus.saleEnded ? (
-              <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded-full text-xs">
-                {t("salePage.saleEnded")}
-              </span>
-            ) : (
-              <span className="px-2 py-1 bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded-full text-xs font-medium">
-                {t("salePage.stageActive", { stage: gTokenStatus.currentStage })}
-              </span>
-            )
-          ) : (
-            <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-400 rounded-full text-xs">
-              {t("salePage.notConfigured")}
-            </span>
-          )}
-        </div>
-
-        {gTokenStatus?.configured ? (
-          <>
-            {/* Price Info */}
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-400 mb-1">{t("salePage.currentPrice")}</p>
-                <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  ${parseFloat(gTokenStatus.currentPriceUSD).toFixed(4)}
-                </p>
-                <p className="text-xs text-gray-400">{t("salePage.perGToken")}</p>
-              </div>
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-400 mb-1">{t("salePage.tokensSold")}</p>
-                <p className="text-xl font-bold text-gray-900 dark:text-white">
-                  {parseFloat(gTokenStatus.tokensSold).toLocaleString(undefined, {
-                    maximumFractionDigits: 0,
-                  })}
-                </p>
-                <p className="text-xs text-gray-400">
-                  {t("salePage.ofTotal", {
-                    total: parseFloat(gTokenStatus.totalForSale).toLocaleString(undefined, {
-                      maximumFractionDigits: 0,
-                    }),
-                  })}
-                </p>
-              </div>
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-400 mb-1">{t("salePage.ceilingPrice")}</p>
-                <p className="text-xl font-bold text-gray-900 dark:text-white">
-                  ${parseFloat(gTokenStatus.ceilingPriceUSD).toFixed(4)}
-                </p>
-                <p className="text-xs text-gray-400">{t("salePage.maxPrice")}</p>
-              </div>
-            </div>
-
-            {/* Progress */}
-            <div className="mb-4">
-              <div className="flex justify-between text-xs text-gray-500 mb-2">
-                <span>{t("salePage.stage1")}</span>
-                <span>{t("salePage.stage2")}</span>
-                <span>{t("salePage.stage3")}</span>
-              </div>
-              <ProgressBar percent={gTokenStatus.soldPercent} />
-              <p className="text-right text-xs text-gray-400 mt-1">
-                {t("salePage.percentSold", { percent: gTokenStatus.soldPercent.toFixed(1) })}
-              </p>
-            </div>
-
-            {/* Eligibility */}
-            {eligibility && (
-              <div
-                className={`rounded-xl p-4 border ${
-                  eligibility.eligible
-                    ? "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800"
-                    : "bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700"
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  {eligibility.eligible ? (
-                    <CheckBadgeIcon className="h-5 w-5 text-green-600" />
-                  ) : (
-                    <XCircleIcon className="h-5 w-5 text-gray-400" />
-                  )}
-                  <p
-                    className={`text-sm font-medium ${
-                      eligibility.eligible
-                        ? "text-green-800 dark:text-green-300"
-                        : "text-gray-600 dark:text-gray-300"
-                    }`}
-                  >
-                    {eligibility.eligible ? t("salePage.eligibleMsg") : eligibility.reason}
-                  </p>
-                </div>
-                {eligibility.eligible && (
-                  <p className="text-xs text-green-600 dark:text-green-400 mt-1">
-                    {t("salePage.eligibleHintPrefix")}{" "}
-                    <code className="bg-green-100 dark:bg-green-800 px-1 rounded">
-                      buyTokens(usdAmount, paymentToken, signature)
-                    </code>{" "}
-                    {t("salePage.eligibleHintSuffix")}
-                  </p>
-                )}
-              </div>
-            )}
-
-            <p className="mt-2 text-xs font-mono text-gray-400">
-              {t("salePage.contract", { address: gTokenStatus.address })}
-            </p>
-          </>
-        ) : (
-          <p className="text-sm text-gray-500">
-            {t("salePage.gtokenNotConfigured", { env: "GTOKEN_SALE_ADDRESS" })}
-          </p>
+        {error && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
+            {error}
+          </div>
         )}
-      </section>
 
-      {/* aPNTs Sale */}
-      <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
-            <CurrencyDollarIcon className="h-5 w-5 text-purple-400" />
-            {t("salePage.apntsSaleTitle")}
-          </h2>
-          {aPNTsStatus?.configured ? (
-            aPNTsStatus.saleActive ? (
-              <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 rounded-full text-xs font-medium">
-                {t("salePage.active")}
-              </span>
+        {/* GToken Sale */}
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+              <ArrowTrendingUpIcon className="h-5 w-5 text-indigo-400" />
+              {t("salePage.gtokenSaleTitle")}
+            </h2>
+            {gTokenStatus?.configured ? (
+              gTokenStatus.saleEnded ? (
+                <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded-full text-xs">
+                  {t("salePage.saleEnded")}
+                </span>
+              ) : (
+                <span className="px-2 py-1 bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300 rounded-full text-xs font-medium">
+                  {t("salePage.stageActive", { stage: gTokenStatus.currentStage })}
+                </span>
+              )
             ) : (
-              <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded-full text-xs">
-                {t("salePage.noInventory")}
+              <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-400 rounded-full text-xs">
+                {t("salePage.notConfigured")}
               </span>
-            )
-          ) : (
-            <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-400 rounded-full text-xs">
-              {t("salePage.notConfigured")}
-            </span>
-          )}
-        </div>
+            )}
+          </div>
 
-        {aPNTsStatus?.configured ? (
-          <>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-400 mb-1">{t("salePage.price")}</p>
-                <p className="text-2xl font-bold text-gray-900 dark:text-white">
-                  ${parseFloat(aPNTsStatus.priceUSD).toFixed(4)}
-                </p>
-                <p className="text-xs text-gray-400">{t("salePage.perApnts")}</p>
-              </div>
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-400 mb-1">{t("salePage.available")}</p>
-                <p className="text-xl font-bold text-gray-900 dark:text-white">
-                  {parseFloat(aPNTsStatus.availableInventory).toLocaleString(undefined, {
-                    maximumFractionDigits: 0,
-                  })}
-                </p>
-                <p className="text-xs text-gray-400">{t("salePage.apnts")}</p>
-              </div>
-              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-                <p className="text-xs text-gray-400 mb-1">{t("salePage.limits")}</p>
-                <p className="text-sm font-semibold text-gray-900 dark:text-white">
-                  {parseFloat(aPNTsStatus.minPurchaseAmount).toFixed(0)} –{" "}
-                  {parseFloat(aPNTsStatus.maxPurchaseAmount).toLocaleString(undefined, {
-                    maximumFractionDigits: 0,
-                  })}
-                </p>
-                <p className="text-xs text-gray-400">{t("salePage.apntsPerPurchase")}</p>
-              </div>
-            </div>
-
-            {/* Quote calculator */}
-            <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
-              <p className="text-sm font-medium text-gray-900 dark:text-white mb-3">
-                {t("salePage.priceCalculator")}
-              </p>
-              <div className="flex gap-2">
-                <div className="flex-1 relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">
-                    $
-                  </span>
-                  <input
-                    type="number"
-                    value={quoteUSD}
-                    onChange={e => setQuoteUSD(e.target.value)}
-                    onKeyDown={e => e.key === "Enter" && fetchQuote()}
-                    placeholder="100"
-                    className="w-full pl-7 pr-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                  />
+          {gTokenStatus?.configured ? (
+            <>
+              {/* Price Info */}
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-400 mb-1">{t("salePage.currentPrice")}</p>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                    ${parseFloat(gTokenStatus.currentPriceUSD).toFixed(4)}
+                  </p>
+                  <p className="text-xs text-gray-400">{t("salePage.perGToken")}</p>
                 </div>
-                <button
-                  onClick={fetchQuote}
-                  disabled={quoteLoading}
-                  className="px-4 py-2 bg-slate-900 hover:bg-slate-800 dark:bg-emerald-600 dark:hover:bg-emerald-500 text-white text-sm rounded-lg disabled:opacity-50"
-                >
-                  {quoteLoading ? t("salePage.quoting") : t("salePage.quote")}
-                </button>
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-400 mb-1">{t("salePage.tokensSold")}</p>
+                  <p className="text-xl font-bold text-gray-900 dark:text-white">
+                    {parseFloat(gTokenStatus.tokensSold).toLocaleString(undefined, {
+                      maximumFractionDigits: 0,
+                    })}
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    {t("salePage.ofTotal", {
+                      total: parseFloat(gTokenStatus.totalForSale).toLocaleString(undefined, {
+                        maximumFractionDigits: 0,
+                      }),
+                    })}
+                  </p>
+                </div>
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-400 mb-1">{t("salePage.ceilingPrice")}</p>
+                  <p className="text-xl font-bold text-gray-900 dark:text-white">
+                    ${parseFloat(gTokenStatus.ceilingPriceUSD).toFixed(4)}
+                  </p>
+                  <p className="text-xs text-gray-400">{t("salePage.maxPrice")}</p>
+                </div>
               </div>
-              {apntsQuote && (
-                <div className="mt-3 flex items-center gap-2 text-sm">
-                  <span className="text-gray-500">${apntsQuote.usdIn} USDC</span>
-                  <span className="text-gray-400">→</span>
-                  <span className="font-bold text-purple-700 dark:text-purple-300">
-                    {parseFloat(apntsQuote.aPNTsOut).toLocaleString()} aPNTs
-                  </span>
+
+              {/* Progress */}
+              <div className="mb-4">
+                <div className="flex justify-between text-xs text-gray-500 mb-2">
+                  <span>{t("salePage.stage1")}</span>
+                  <span>{t("salePage.stage2")}</span>
+                  <span>{t("salePage.stage3")}</span>
+                </div>
+                <ProgressBar percent={gTokenStatus.soldPercent} />
+                <p className="text-right text-xs text-gray-400 mt-1">
+                  {t("salePage.percentSold", { percent: gTokenStatus.soldPercent.toFixed(1) })}
+                </p>
+              </div>
+
+              {/* Eligibility */}
+              {eligibility && (
+                <div
+                  className={`rounded-xl p-4 border ${
+                    eligibility.eligible
+                      ? "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800"
+                      : "bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700"
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    {eligibility.eligible ? (
+                      <CheckBadgeIcon className="h-5 w-5 text-green-600" />
+                    ) : (
+                      <XCircleIcon className="h-5 w-5 text-gray-400" />
+                    )}
+                    <p
+                      className={`text-sm font-medium ${
+                        eligibility.eligible
+                          ? "text-green-800 dark:text-green-300"
+                          : "text-gray-600 dark:text-gray-300"
+                      }`}
+                    >
+                      {eligibility.eligible ? t("salePage.eligibleMsg") : eligibility.reason}
+                    </p>
+                  </div>
+                  {eligibility.eligible && (
+                    <p className="text-xs text-green-600 dark:text-green-400 mt-1">
+                      {t("salePage.eligibleHintPrefix")}{" "}
+                      <code className="bg-green-100 dark:bg-green-800 px-1 rounded">
+                        buyTokens(usdAmount, paymentToken, signature)
+                      </code>{" "}
+                      {t("salePage.eligibleHintSuffix")}
+                    </p>
+                  )}
                 </div>
               )}
-            </div>
 
-            <p className="mt-3 text-xs font-mono text-gray-400">
-              {t("salePage.contract", { address: aPNTsStatus.address })}
+              <p className="mt-2 text-xs font-mono text-gray-400">
+                {t("salePage.contract", { address: gTokenStatus.address })}
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-gray-500">
+              {t("salePage.gtokenNotConfigured", { env: "GTOKEN_SALE_ADDRESS" })}
             </p>
-          </>
-        ) : (
-          <p className="text-sm text-gray-500">
-            {t("salePage.apntsNotConfigured", { env: "APNTS_SALE_ADDRESS" })}
-          </p>
-        )}
-      </section>
-    </div>
+          )}
+        </section>
+
+        {/* aPNTs Sale */}
+        <section className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+              <CurrencyDollarIcon className="h-5 w-5 text-purple-400" />
+              {t("salePage.apntsSaleTitle")}
+            </h2>
+            {aPNTsStatus?.configured ? (
+              aPNTsStatus.saleActive ? (
+                <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-300 rounded-full text-xs font-medium">
+                  {t("salePage.active")}
+                </span>
+              ) : (
+                <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-500 rounded-full text-xs">
+                  {t("salePage.noInventory")}
+                </span>
+              )
+            ) : (
+              <span className="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-400 rounded-full text-xs">
+                {t("salePage.notConfigured")}
+              </span>
+            )}
+          </div>
+
+          {aPNTsStatus?.configured ? (
+            <>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-400 mb-1">{t("salePage.price")}</p>
+                  <p className="text-2xl font-bold text-gray-900 dark:text-white">
+                    ${parseFloat(aPNTsStatus.priceUSD).toFixed(4)}
+                  </p>
+                  <p className="text-xs text-gray-400">{t("salePage.perApnts")}</p>
+                </div>
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-400 mb-1">{t("salePage.available")}</p>
+                  <p className="text-xl font-bold text-gray-900 dark:text-white">
+                    {parseFloat(aPNTsStatus.availableInventory).toLocaleString(undefined, {
+                      maximumFractionDigits: 0,
+                    })}
+                  </p>
+                  <p className="text-xs text-gray-400">{t("salePage.apnts")}</p>
+                </div>
+                <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                  <p className="text-xs text-gray-400 mb-1">{t("salePage.limits")}</p>
+                  <p className="text-sm font-semibold text-gray-900 dark:text-white">
+                    {parseFloat(aPNTsStatus.minPurchaseAmount).toFixed(0)} –{" "}
+                    {parseFloat(aPNTsStatus.maxPurchaseAmount).toLocaleString(undefined, {
+                      maximumFractionDigits: 0,
+                    })}
+                  </p>
+                  <p className="text-xs text-gray-400">{t("salePage.apntsPerPurchase")}</p>
+                </div>
+              </div>
+
+              {/* Quote calculator */}
+              <div className="bg-gray-50 dark:bg-gray-900 rounded-xl p-4">
+                <p className="text-sm font-medium text-gray-900 dark:text-white mb-3">
+                  {t("salePage.priceCalculator")}
+                </p>
+                <div className="flex gap-2">
+                  <div className="flex-1 relative">
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">
+                      $
+                    </span>
+                    <input
+                      type="number"
+                      value={quoteUSD}
+                      onChange={e => setQuoteUSD(e.target.value)}
+                      onKeyDown={e => e.key === "Enter" && fetchQuote()}
+                      placeholder="100"
+                      className="w-full pl-7 pr-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    />
+                  </div>
+                  <button
+                    onClick={fetchQuote}
+                    disabled={quoteLoading}
+                    className="px-4 py-2 bg-slate-900 hover:bg-slate-800 dark:bg-emerald-600 dark:hover:bg-emerald-500 text-white text-sm rounded-lg disabled:opacity-50"
+                  >
+                    {quoteLoading ? t("salePage.quoting") : t("salePage.quote")}
+                  </button>
+                </div>
+                {apntsQuote && (
+                  <div className="mt-3 flex items-center gap-2 text-sm">
+                    <span className="text-gray-500">${apntsQuote.usdIn} USDC</span>
+                    <span className="text-gray-400">→</span>
+                    <span className="font-bold text-purple-700 dark:text-purple-300">
+                      {parseFloat(apntsQuote.aPNTsOut).toLocaleString()} aPNTs
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              <p className="mt-3 text-xs font-mono text-gray-400">
+                {t("salePage.contract", { address: aPNTsStatus.address })}
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-gray-500">
+              {t("salePage.apntsNotConfigured", { env: "APNTS_SALE_ADDRESS" })}
+            </p>
+          )}
+        </section>
+      </div>
     </Layout>
   );
 }

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -753,7 +753,8 @@ export default function TransferPage() {
                           Gas used: {parseInt(transferStatus.actualGasUsed, 16).toLocaleString()}
                           {transferStatus.actualGasCost && (
                             <span className="ml-2">
-                              Cost: {(parseInt(transferStatus.actualGasCost, 16) / 1e18).toFixed(8)} ETH
+                              Cost: {(parseInt(transferStatus.actualGasCost, 16) / 1e18).toFixed(8)}{" "}
+                              ETH
                             </span>
                           )}
                           {transferStatus.retryCount > 0 && (

--- a/aastar-frontend/components/Layout.tsx
+++ b/aastar-frontend/components/Layout.tsx
@@ -94,8 +94,7 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
         <nav className="hidden md:block sticky top-0 z-50 bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 backdrop-blur-lg bg-opacity-90 dark:bg-opacity-90">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="flex justify-between h-16">
-              <div className="flex items-center">
-              </div>
+              <div className="flex items-center"></div>
 
               {/* Desktop Navigation */}
               <div className="flex items-center space-x-2">

--- a/aastar-frontend/contexts/WalletContext.tsx
+++ b/aastar-frontend/contexts/WalletContext.tsx
@@ -74,7 +74,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   // Reflect account switches from the injected wallet.
   useEffect(() => {
     const provider = getInjectedProvider() as
-      | { on?: (e: string, cb: (a: string[]) => void) => void; removeListener?: (e: string, cb: (a: string[]) => void) => void }
+      | {
+          on?: (e: string, cb: (a: string[]) => void) => void;
+          removeListener?: (e: string, cb: (a: string[]) => void) => void;
+        }
       | undefined;
     if (!provider?.on) return;
     const onAccountsChanged = (accounts: string[]) => {

--- a/aastar-frontend/lib/api.ts
+++ b/aastar-frontend/lib/api.ts
@@ -295,8 +295,7 @@ export const saleAPI = {
   getOverview: () => api.get("/sale/overview"),
   getGTokenStatus: () => api.get("/sale/gtoken/status"),
   getAPNTsStatus: () => api.get("/sale/apnts/status"),
-  getAPNTsQuote: (usdAmount: string) =>
-    api.get("/sale/apnts/quote", { params: { usdAmount } }),
+  getAPNTsQuote: (usdAmount: string) => api.get("/sale/apnts/quote", { params: { usdAmount } }),
   getGTokenEvents: () => api.get("/sale/gtoken/events"),
   getGTokenEligibility: (address?: string) =>
     api.get("/sale/gtoken/eligibility", { params: address ? { address } : undefined }),

--- a/aastar-frontend/lib/i18n/LanguageSwitcher.tsx
+++ b/aastar-frontend/lib/i18n/LanguageSwitcher.tsx
@@ -42,7 +42,7 @@ export default function LanguageSwitcher({ className = "" }: { className?: strin
       aria-label="Language"
       className={`inline-flex items-center gap-0.5 rounded-lg border border-gray-200 bg-white p-0.5 text-sm font-medium dark:border-gray-700 dark:bg-gray-800 ${className}`}
     >
-      {LANGUAGES.map((lang) => {
+      {LANGUAGES.map(lang => {
         const isActive = mounted && active === lang.code;
         return (
           <button

--- a/aastar/src/community/community.controller.ts
+++ b/aastar/src/community/community.controller.ts
@@ -44,9 +44,7 @@ export class CommunityController {
   @ApiOperation({ summary: "Get xPNTs token info for an address" })
   @ApiQuery({ name: "address", required: true })
   async getTokenInfo(@Query("address") address: string) {
-    const tokenAddress = await this.communityService.getDeployedTokenAddress(
-      address as Address
-    );
+    const tokenAddress = await this.communityService.getDeployedTokenAddress(address as Address);
     if (!tokenAddress) {
       return { address, tokenAddress: null, tokenInfo: null };
     }

--- a/aastar/src/sale/sale.controller.ts
+++ b/aastar/src/sale/sale.controller.ts
@@ -56,7 +56,13 @@ export class SaleController {
   @ApiOperation({ summary: "Check if authenticated user is eligible to buy GToken" })
   async checkGTokenEligibility(@Request() req: any, @Query("address") address?: string) {
     const target = (address || req.user?.walletAddress) as Address | undefined;
-    if (!target) return { address: null, eligible: false, hasBought: false, reason: "No wallet address linked" };
+    if (!target)
+      return {
+        address: null,
+        eligible: false,
+        hasBought: false,
+        reason: "No wallet address linked",
+      };
     const hasBought = await this.saleService.checkGTokenHasBought(target);
     return {
       address: target,

--- a/aastar/src/sale/sale.service.spec.ts
+++ b/aastar/src/sale/sale.service.spec.ts
@@ -11,9 +11,7 @@ jest.mock("viem", () => ({
     getLogs: mockGetLogs,
   })),
   http: jest.fn(),
-  formatUnits: jest.fn((val: bigint, dec: number) =>
-    (Number(val) / Math.pow(10, dec)).toFixed(6)
-  ),
+  formatUnits: jest.fn((val: bigint, dec: number) => (Number(val) / Math.pow(10, dec)).toFixed(6)),
   parseAbi: jest.fn(() => []),
 }));
 
@@ -100,10 +98,7 @@ describe("SaleService", () => {
       });
 
       const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          SaleService,
-          { provide: ConfigService, useValue: { get: mockConfigGet } },
-        ],
+        providers: [SaleService, { provide: ConfigService, useValue: { get: mockConfigGet } }],
       }).compile();
 
       service = module.get<SaleService>(SaleService);
@@ -118,12 +113,12 @@ describe("SaleService", () => {
 
     it("getGTokenSaleStatus calls readContract for each field", async () => {
       mockReadContract
-        .mockResolvedValueOnce(BigInt("1000000"))    // getCurrentPriceUSD
+        .mockResolvedValueOnce(BigInt("1000000")) // getCurrentPriceUSD
         .mockResolvedValueOnce(BigInt("100000000000000000000000")) // tokensSold
         .mockResolvedValueOnce(BigInt("1050000000000000000000000")) // totalTokensForSale
-        .mockResolvedValueOnce(BigInt("210000000000000000000000"))  // STAGE1_TOKEN_LIMIT
-        .mockResolvedValueOnce(BigInt("630000000000000000000000"))  // STAGE2_TOKEN_LIMIT
-        .mockResolvedValueOnce(BigInt("4885000"));   // CEILING_PRICE_USD
+        .mockResolvedValueOnce(BigInt("210000000000000000000000")) // STAGE1_TOKEN_LIMIT
+        .mockResolvedValueOnce(BigInt("630000000000000000000000")) // STAGE2_TOKEN_LIMIT
+        .mockResolvedValueOnce(BigInt("4885000")); // CEILING_PRICE_USD
 
       const status = await service.getGTokenSaleStatus();
       expect(status.configured).toBe(true);

--- a/aastar/src/token/token.controller.ts
+++ b/aastar/src/token/token.controller.ts
@@ -25,7 +25,7 @@ export class TokenController {
     name: "category",
     required: false,
     enum: Object.values(TokenCategory),
-    type: 'string',
+    type: "string",
     description: "Filter by category",
   })
   @ApiResponse({
@@ -228,7 +228,7 @@ export class TokenController {
     name: "category",
     required: false,
     enum: Object.values(TokenCategory),
-    type: 'string',
+    type: "string",
     description: "Filter by category",
   })
   @ApiQuery({


### PR DESCRIPTION
## 背景
master 长期存在 prettier 格式漂移:`prettier --check` 在 ~27 个文件上失败,导致 CI 的 `Code Quality (aastar)` / `Code Quality (aastar-frontend)` / `CI Success` 一直红(这几个是**非 required** check,所以此前 PR 仍能合,但信号一直是红的)。

## 改动
跑两个 workspace 自己的 format 脚本:
- `npm run format -w aastar`(`prettier --write "src/**/*.ts"`)
- `npm run format -w aastar-frontend`(`prettier --write "**/*.{js,jsx,ts,tsx,json,css,md}"`)

**纯空白格式化,零逻辑改动**,27 文件。

## 验证
- `format:check` 两 workspace 均通过 ✅
- sanity:后端 `build` ✅、前端 `type-check` ✅
- 未跑 root `prettier --write .`(避免动 7702/lib 等无关目录);CI Code Quality 检的就是这两个 workspace。

合并后 `Code Quality` / `CI Success` 应回绿。