### PR TITLE
feat(guardian): wallet-free quick-register guardian + fix KMS default endpoint

### DIFF
--- a/aastar-frontend/app/guardian-sign/page.tsx
+++ b/aastar-frontend/app/guardian-sign/page.tsx
@@ -25,11 +25,15 @@
 
 import { Suspense, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { startAuthentication } from "@simplewebauthn/browser";
+import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
 import { kmsClient } from "@/lib/yaaa";
 import { ethers } from "ethers";
 
-type SignMethod = "passkey" | "metamask";
+// "passkey"   — guardian already has an AirAccount: enters their address, signs with their passkey.
+// "register"  — guardian has no account: creates a passkey (email + Face ID/fingerprint) on the fly,
+//               then signs. No wallet app needed.
+// "metamask"  — guardian signs with an injected EOA wallet.
+type SignMethod = "passkey" | "register" | "metamask";
 
 // ── Helper: apply EIP-191 prefix ──────────────────────────────────────────
 // Replicates: ethers.hashMessage(ethers.getBytes(hash))
@@ -60,6 +64,8 @@ function GuardianSignInner() {
 
   const [signMethod, setSignMethod] = useState<SignMethod>("passkey");
   const [guardianAddress, setGuardianAddress] = useState("");
+  const [guardianEmail, setGuardianEmail] = useState("");
+  const [registerStatus, setRegisterStatus] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [result, setResult] = useState<{ address: string; signature: string } | null>(null);
@@ -120,6 +126,83 @@ function GuardianSignInner() {
     }
   };
 
+  // Quick path for guardians WITHOUT an account: create a passkey + KMS key on the
+  // fly (email + biometric), wait for the derived EOA address, then sign the hash.
+  // Two biometric prompts: one to create the passkey, one to sign.
+  const handleRegisterAndSign = async () => {
+    setError("");
+    if (!acceptanceHash) {
+      setError("Missing acceptanceHash parameter. Please scan the QR code again.");
+      return;
+    }
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(guardianEmail)) {
+      setError("Please enter a valid email address.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const label = `guardian-${guardianEmail}`;
+
+      // 1. Create the passkey + KMS key (first biometric prompt)
+      setRegisterStatus("Creating your passkey…");
+      const beginResp = await kmsClient.beginRegistration({
+        Description: label,
+        UserName: guardianEmail,
+        UserDisplayName: guardianEmail.split("@")[0],
+      });
+      const regCredential = await startRegistration({ optionsJSON: beginResp.Options as any });
+      const completeResp = await kmsClient.completeRegistration({
+        ChallengeId: beginResp.ChallengeId,
+        Credential: regCredential,
+        Description: label,
+      });
+
+      // 2. Wait for KMS to derive the guardian's EOA address (can take up to ~2 min)
+      setRegisterStatus("Deriving your guardian address (up to 2 min)…");
+      const keyStatus = await kmsClient.pollUntilReady(completeResp.KeyId, 150_000, 3_000);
+      if (!keyStatus.Address) {
+        throw new Error("Key created but no address was derived. Please try again.");
+      }
+      const address = keyStatus.Address;
+
+      // 3. Sign the acceptance hash with the new passkey (second biometric prompt)
+      setRegisterStatus("Confirm signing with your passkey…");
+      const authResponse = await kmsClient.beginAuthentication({ Address: address });
+      const authCredential = await startAuthentication({
+        optionsJSON: authResponse.Options as any,
+      });
+      const signResponse = await kmsClient.signHashWithWebAuthn(
+        applyEip191(acceptanceHash),
+        authResponse.ChallengeId,
+        authCredential,
+        { Address: address }
+      );
+
+      setResult({
+        address,
+        signature: signResponse.Signature?.startsWith("0x")
+          ? signResponse.Signature
+          : "0x" + signResponse.Signature,
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        if (err.name === "NotAllowedError") {
+          setError("Passkey was cancelled or not allowed. Please try again.");
+        } else if (err.name === "NotSupportedError") {
+          setError("Passkeys are not supported on this device/browser.");
+        } else {
+          setError(err.message || "Registration/signing failed. Please try again.");
+        }
+      } else {
+        setError("Registration/signing failed. Please try again.");
+      }
+    } finally {
+      setLoading(false);
+      setRegisterStatus("");
+    }
+  };
+
   const handleSignWithMetaMask = async () => {
     setError("");
 
@@ -158,7 +241,12 @@ function GuardianSignInner() {
     }
   };
 
-  const handleSign = signMethod === "metamask" ? handleSignWithMetaMask : handleSignWithPasskey;
+  const handleSign =
+    signMethod === "metamask"
+      ? handleSignWithMetaMask
+      : signMethod === "register"
+        ? handleRegisterAndSign
+        : handleSignWithPasskey;
 
   const handleCopy = async (field: "address" | "sig" | "both") => {
     if (!result) return;
@@ -271,31 +359,48 @@ function GuardianSignInner() {
                 How would you like to sign?
               </label>
               <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                Choose either method — both guardians can use the same method or different ones.
+                Have an AirAccount? Use your passkey. New here? Create a guardian in one step — no
+                wallet app needed.
               </p>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-3 gap-2">
                 <button
                   type="button"
                   onClick={() => {
                     setSignMethod("passkey");
                     setError("");
                   }}
-                  className={`py-2.5 px-3 rounded-lg border text-sm font-medium transition-colors ${
+                  className={`py-2.5 px-2 rounded-lg border text-xs font-medium transition-colors ${
                     signMethod === "passkey"
                       ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400"
                       : "border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700"
                   }`}
                 >
-                  Passkey (KMS)
+                  I have a passkey
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSignMethod("register");
+                    setGuardianAddress("");
+                    setError("");
+                  }}
+                  className={`py-2.5 px-2 rounded-lg border text-xs font-medium transition-colors ${
+                    signMethod === "register"
+                      ? "border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400"
+                      : "border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700"
+                  }`}
+                >
+                  New guardian
                 </button>
                 <button
                   type="button"
                   onClick={() => {
                     setSignMethod("metamask");
                     setGuardianAddress("");
+                    setGuardianEmail("");
                     setError("");
                   }}
-                  className={`py-2.5 px-3 rounded-lg border text-sm font-medium transition-colors ${
+                  className={`py-2.5 px-2 rounded-lg border text-xs font-medium transition-colors ${
                     signMethod === "metamask"
                       ? "border-orange-500 bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-400"
                       : "border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700"
@@ -323,6 +428,33 @@ function GuardianSignInner() {
                 <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                   Enter the Ethereum address associated with your passkey on this device.
                 </p>
+              </div>
+            )}
+
+            {/* New guardian — email input */}
+            {signMethod === "register" && (
+              <div>
+                <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                  Your Email
+                </label>
+                <input
+                  type="email"
+                  value={guardianEmail}
+                  onChange={e => setGuardianEmail(e.target.value.trim())}
+                  placeholder="you@example.com"
+                  disabled={loading}
+                  className="block w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent disabled:opacity-50"
+                />
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  No wallet needed — we&apos;ll create a passkey on this device with Face ID /
+                  fingerprint. Sign in to iCloud (Apple) or Google (Android) first so the passkey
+                  syncs to your other devices and you don&apos;t lose guardian access.
+                </p>
+                {loading && registerStatus && (
+                  <p className="mt-2 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                    {registerStatus}
+                  </p>
+                )}
               </div>
             )}
 
@@ -356,7 +488,11 @@ function GuardianSignInner() {
               {loading ? (
                 <>
                   <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2" />
-                  {signMethod === "metamask" ? "Waiting for MetaMask..." : "Authenticating..."}
+                  {signMethod === "metamask"
+                    ? "Waiting for MetaMask..."
+                    : signMethod === "register"
+                      ? registerStatus || "Working…"
+                      : "Authenticating..."}
                 </>
               ) : signMethod === "metamask" ? (
                 <>
@@ -376,7 +512,7 @@ function GuardianSignInner() {
                       clipRule="evenodd"
                     />
                   </svg>
-                  Sign with Passkey
+                  {signMethod === "register" ? "Register & Sign" : "Sign with Passkey"}
                 </>
               )}
             </button>

--- a/aastar-frontend/app/page.tsx
+++ b/aastar-frontend/app/page.tsx
@@ -65,6 +65,15 @@ export default function HomePage() {
               </ul>
             </div>
           </div>
+
+          <div className="mt-6 rounded-lg bg-white/60 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-700 p-4 text-center">
+            <p className="text-xs text-gray-600 dark:text-gray-400">
+              🛡️ Asked to be someone&apos;s <span className="font-medium">guardian</span>? Just open
+              the link / QR code they send you — you can sign with Face ID / fingerprint, no wallet
+              and no install needed. Tip: sign in to iCloud (Apple) or Google (Android) so your
+              passkey syncs across your devices.
+            </p>
+          </div>
         </div>
       </div>
     </Layout>

--- a/aastar-frontend/app/recovery/page.tsx
+++ b/aastar-frontend/app/recovery/page.tsx
@@ -195,14 +195,42 @@ export default function RecoveryPage() {
               The guardians will each need to approve the recovery.
             </div>
 
-            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-sm text-red-800 dark:text-red-300">
-              <p className="font-semibold mb-1">⚠️ Choose diverse guardians</p>
-              <p>
-                Avoid making both guardians the same kind. A passkey/KMS guardian depends on the KMS
-                service — if it&apos;s unavailable, that guardian can&apos;t sign. For resilience,
-                use <span className="font-medium">different methods</span> (e.g. one passkey + one
-                self-custody MetaMask wallet, or two people on different devices), so no single
-                point of failure can block recovery.
+            <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 text-sm text-blue-800 dark:text-blue-300 space-y-2">
+              <p className="font-semibold">Choosing guardians: trust &amp; loss trade-offs</p>
+              <p className="text-blue-700 dark:text-blue-300/90">
+                A guardian is whoever can approve your recovery. Each kind shifts two things —{" "}
+                <span className="font-medium">who/what you trust</span> and{" "}
+                <span className="font-medium">how it can be lost</span>:
+              </p>
+              <ul className="space-y-1 text-xs text-blue-700 dark:text-blue-300/90 list-disc pl-4">
+                <li>
+                  <span className="font-medium">Passkey on Apple</span> — trust: your iCloud. Loss:
+                  low (syncs across your Apple devices).
+                </li>
+                <li>
+                  <span className="font-medium">Passkey on Google</span> — trust: your Google
+                  account. Loss: low (syncs across your Android devices).
+                </li>
+                <li>
+                  <span className="font-medium">MetaMask (self-custody)</span> — trust: only you.
+                  Loss: higher — lose the phone or seed phrase and it&apos;s gone.
+                </li>
+                <li>
+                  <span className="font-medium">A friend&apos;s AirAccount</span> — trust: that
+                  friend + their platform. Loss: low (they have their own backup).
+                </li>
+                <li>
+                  <span className="font-medium">Passkey via KMS (today)</span> — trust: the KMS
+                  service. Loss: medium (if KMS is down, that guardian can&apos;t sign).
+                </li>
+              </ul>
+              <p className="text-blue-700 dark:text-blue-300/90">
+                <span className="font-medium">Pick diverse guardians</span> — different methods,
+                people and platforms (e.g. one Apple passkey + one Google passkey + one
+                friend&apos;s wallet). Recovery only needs{" "}
+                <span className="font-medium">2 of 3</span>, so losing one guardian still lets you
+                recover — diversity makes sure no single failure (a lost phone, one platform, or the
+                KMS) can block them all at once.
               </p>
             </div>
 

--- a/aastar-frontend/app/recovery/page.tsx
+++ b/aastar-frontend/app/recovery/page.tsx
@@ -195,6 +195,17 @@ export default function RecoveryPage() {
               The guardians will each need to approve the recovery.
             </div>
 
+            <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-sm text-red-800 dark:text-red-300">
+              <p className="font-semibold mb-1">⚠️ Choose diverse guardians</p>
+              <p>
+                Avoid making both guardians the same kind. A passkey/KMS guardian depends on the KMS
+                service — if it&apos;s unavailable, that guardian can&apos;t sign. For resilience,
+                use <span className="font-medium">different methods</span> (e.g. one passkey + one
+                self-custody MetaMask wallet, or two people on different devices), so no single
+                point of failure can block recovery.
+              </p>
+            </div>
+
             {[
               {
                 label: "Account Address (to recover)",

--- a/aastar-frontend/lib/yaaa.ts
+++ b/aastar-frontend/lib/yaaa.ts
@@ -8,7 +8,7 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/a
 const KMS_ENDPOINT =
   typeof window !== "undefined"
     ? "/kms-api"
-    : process.env.NEXT_PUBLIC_KMS_URL || "https://kms1.aastar.io";
+    : process.env.NEXT_PUBLIC_KMS_URL || "https://kms.aastar.io";
 
 export const yaaa = new YAAAClient({
   apiURL: API_BASE_URL,

--- a/aastar-frontend/next.config.ts
+++ b/aastar-frontend/next.config.ts
@@ -15,7 +15,7 @@ const nextConfig: NextConfig = {
   }),
   async rewrites() {
     const backendUrl = process.env.BACKEND_API_URL || "http://127.0.0.1:3000";
-    const kmsUrl = process.env.KMS_PROXY_URL || "https://kms1.aastar.io";
+    const kmsUrl = process.env.KMS_PROXY_URL || "https://kms.aastar.io";
     return [
       {
         source: "/api/:path*",


### PR DESCRIPTION
## 1. guardian-sign 页新增第三种方式(原两种保留)
- **I have a passkey**(原):已有 AirAccount,填地址 + passkey 签 —— 不变
- **New guardian**(新增):无需钱包/无需预先有账户。填 email -> 当场建 passkey(Face ID/指纹)-> KMS 派生 EOA -> 签 acceptanceHash。两次生物识别(建+签)。提示登录 iCloud/Google 让 passkey 跨设备同步
- **MetaMask**(原)—— 不变

普通人在手机浏览器零安装即可当 guardian。

## 2. 修复 KMS 默认端点 kms1 -> kms.aastar.io
next.config 代理 + yaaa 客户端 fallback 从旧实例 kms1.aastar.io(v0.16.8,无 localhost-RP)改为 kms.aastar.io(v0.23.1)。

## 验证
tsc --noEmit / eslint --max-warnings 0 / next build(/guardian-sign 编译)/ prettier 全过。guardian passkey 签名仍走 SDK kmsClient,无新增直连 KMS。实链待 Face ID。