### PR TITLE
feat(frontend): 服务端 KMS 代理(api key 服务端注入,不进浏览器 bundle)

### DIFF
--- a/aastar-frontend/app/kms-api/[...path]/route.ts
+++ b/aastar-frontend/app/kms-api/[...path]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Server-side proxy for browser → KMS calls.
+//
+// Why a route handler instead of a next.config rewrite:
+//  - Injects the KMS api key from a SERVER env var (KMS_API_KEY) so the key
+//    never has to be shipped in the browser bundle (NEXT_PUBLIC_*). Falls back
+//    to forwarding the caller's x-api-key for local/dev where that's acceptable.
+//  - Forwards the browser Origin header — the KMS uses it to pick rp.id and to
+//    run its allowed-origin check, so it must reach the KMS unchanged.
+export const runtime = "nodejs";
+
+const KMS_BASE = process.env.KMS_PROXY_URL || "https://kms.aastar.io";
+
+async function proxy(req: NextRequest, pathParts: string[]) {
+  const targetPath = "/" + pathParts.join("/");
+  const url = KMS_BASE + targetPath + req.nextUrl.search;
+  const method = req.method;
+  const body = method === "GET" || method === "HEAD" ? undefined : await req.text();
+
+  const headers: Record<string, string> = {};
+  const ct = req.headers.get("content-type");
+  if (ct) headers["content-type"] = ct;
+  const origin = req.headers.get("origin");
+  if (origin) headers["origin"] = origin;
+  const apiKey = process.env.KMS_API_KEY || req.headers.get("x-api-key") || "";
+  if (apiKey) headers["x-api-key"] = apiKey;
+
+  const kmsRes = await fetch(url, { method, headers, body });
+  const text = await kmsRes.text();
+
+  // Status-only logging — never log the request body (it can carry WebAuthn
+  // credentials). On error, surface the KMS error message (no secrets in it).
+  if (kmsRes.status >= 400) {
+    console.warn(`[kms-proxy] ${method} ${targetPath} -> ${kmsRes.status}: ${text.slice(0, 500)}`);
+  }
+
+  return new NextResponse(text, {
+    status: kmsRes.status,
+    headers: { "content-type": kmsRes.headers.get("content-type") ?? "application/json" },
+  });
+}
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  const { path } = await ctx.params;
+  return proxy(req, path);
+}

--- a/aastar-frontend/app/kms-api/[...path]/route.ts
+++ b/aastar-frontend/app/kms-api/[...path]/route.ts
@@ -3,36 +3,77 @@ import { NextRequest, NextResponse } from "next/server";
 // Server-side proxy for browser → KMS calls.
 //
 // Why a route handler instead of a next.config rewrite:
-//  - Injects the KMS api key from a SERVER env var (KMS_API_KEY) so the key
-//    never has to be shipped in the browser bundle (NEXT_PUBLIC_*). Falls back
-//    to forwarding the caller's x-api-key for local/dev where that's acceptable.
-//  - Forwards the browser Origin header — the KMS uses it to pick rp.id and to
-//    run its allowed-origin check, so it must reach the KMS unchanged.
+//  - Injects the KMS api key from a SERVER env var (KMS_API_KEY) so the key never
+//    ships in the browser bundle (NEXT_PUBLIC_*).
+//  - Forwards the browser Origin header — the KMS uses it to pick rp.id and to run
+//    its allowed-origin check, so it must reach the KMS unchanged.
+//
+// Hardening (PR #322 review):
+//  #1 fail-closed: in production the server KMS_API_KEY is required; the
+//     client-supplied x-api-key fallback is only honored outside production (dev).
+//  #2 same-origin: reject cross-origin callers so the privileged server key can't
+//     be borrowed to hit arbitrary KMS endpoints with a forged Origin.
+//  #3 body cap: bound the request body size before reading it.
 export const runtime = "nodejs";
 
 const KMS_BASE = process.env.KMS_PROXY_URL || "https://kms.aastar.io";
+const MAX_BODY_BYTES = 64 * 1024; // KMS/WebAuthn payloads are small; 64KB is generous
+
+// Same-origin browser requests carry an Origin whose host matches the app host.
+// An absent Origin (e.g. a same-origin GET) is allowed; a mismatching one is not.
+function isSameOrigin(req: NextRequest): boolean {
+  const origin = req.headers.get("origin");
+  if (!origin) return true;
+  try {
+    return new URL(origin).host === req.headers.get("host");
+  } catch {
+    return false;
+  }
+}
 
 async function proxy(req: NextRequest, pathParts: string[]) {
-  const targetPath = "/" + pathParts.join("/");
-  const url = KMS_BASE + targetPath + req.nextUrl.search;
+  // #2 — block cross-origin callers
+  if (!isSameOrigin(req)) {
+    return NextResponse.json({ error: "Cross-origin requests are not allowed" }, { status: 403 });
+  }
+
+  // #3 — reject oversized bodies up front (content-length can be absent/spoofed;
+  // the post-read length check below is the authoritative one)
+  if (Number(req.headers.get("content-length") ?? 0) > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
+
+  // #1 — fail closed: prefer the server key; only fall back to the caller's
+  // x-api-key outside production. No key at all → refuse (never proxy unauthed).
+  const isProd = process.env.NODE_ENV === "production";
+  const apiKey = process.env.KMS_API_KEY || (!isProd ? req.headers.get("x-api-key") : null);
+  if (!apiKey) {
+    console.error("[kms-proxy] refusing request: KMS_API_KEY is not set (fail-closed)");
+    return NextResponse.json({ error: "KMS proxy is not configured" }, { status: 500 });
+  }
+
   const method = req.method;
   const body = method === "GET" || method === "HEAD" ? undefined : await req.text();
+  if (body && body.length > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "Payload too large" }, { status: 413 });
+  }
 
-  const headers: Record<string, string> = {};
+  const headers: Record<string, string> = { "x-api-key": apiKey };
   const ct = req.headers.get("content-type");
   if (ct) headers["content-type"] = ct;
   const origin = req.headers.get("origin");
   if (origin) headers["origin"] = origin;
-  const apiKey = process.env.KMS_API_KEY || req.headers.get("x-api-key") || "";
-  if (apiKey) headers["x-api-key"] = apiKey;
 
+  const url = KMS_BASE + "/" + pathParts.join("/") + req.nextUrl.search;
   const kmsRes = await fetch(url, { method, headers, body });
   const text = await kmsRes.text();
 
   // Status-only logging — never log the request body (it can carry WebAuthn
   // credentials). On error, surface the KMS error message (no secrets in it).
   if (kmsRes.status >= 400) {
-    console.warn(`[kms-proxy] ${method} ${targetPath} -> ${kmsRes.status}: ${text.slice(0, 500)}`);
+    console.warn(
+      `[kms-proxy] ${method} /${pathParts.join("/")} -> ${kmsRes.status}: ${text.slice(0, 500)}`
+    );
   }
 
   return new NextResponse(text, {

--- a/aastar-frontend/next.config.ts
+++ b/aastar-frontend/next.config.ts
@@ -15,15 +15,12 @@ const nextConfig: NextConfig = {
   }),
   async rewrites() {
     const backendUrl = process.env.BACKEND_API_URL || "http://127.0.0.1:3000";
-    const kmsUrl = process.env.KMS_PROXY_URL || "https://kms.aastar.io";
+    // /kms-api/* is handled by the server-side route handler at app/kms-api/[...path]
+    // (injects the KMS key server-side + diagnostics), not by a rewrite.
     return [
       {
         source: "/api/:path*",
         destination: `${backendUrl}/api/:path*`,
-      },
-      {
-        source: "/kms-api/:path*",
-        destination: `${kmsUrl}/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## 服务端 KMS 代理(把 api key 留在服务器,不进浏览器)

把 next.config 的 `/kms-api` rewrite 换成 Node route handler `app/kms-api/[...path]`:
- **服务端注入 KMS api key**:从服务器环境变量 `KMS_API_KEY` 注入,key 不再需要经 `NEXT_PUBLIC_KMS_API_KEY` 打进浏览器 bundle(之前讨论的生产正确做法)。dev 下若没配服务端 key,回退转发调用方的 `x-api-key`。
- **透传 Origin**:KMS 用它选 rp.id + 做 allowed-origin 校验,必须原样到 KMS。
- **日志安全**:只记状态;**绝不记请求体**(含 WebAuthn credential);4xx/5xx 时记 KMS 错误文本(无敏感信息)。

## 验证
经 Cloudflare 隧道公网域名(yaa.aastar.io)端到端验证:**passkey 注册 / KMS CreateKey 成功**(KMS_ORIGIN 加 `https://*.aastar.io` 后)。tsc / eslint / next build / prettier 全过。

## 背景
本轮联调把 YAA 经 Cloudflare Tunnel 暴露到 *.aastar.io(本地跑),打通注册全链路时定位到:KMS 的 origin 白名单(`KMS_ORIGIN`)需含部署子域 —— 已在 KMS 端补 `https://*.aastar.io`。

## Follow-up
从前端 env 去掉 `NEXT_PUBLIC_KMS_API_KEY`(handler 已优先用服务端 `KMS_API_KEY`),让 key 彻底只在服务端。
