### PR TITLE
feat(guardian): 账户创建对话框讲清 guardian 模型 + 3 个渠道

### DIFF
--- a/aastar-frontend/components/CreateAccountDialog.tsx
+++ b/aastar-frontend/components/CreateAccountDialog.tsx
@@ -165,11 +165,27 @@ export default function CreateAccountDialog({
       <div className="space-y-4">
         <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4">
           <p className="text-sm font-medium text-blue-800 dark:text-blue-300 mb-1">
-            Step {guardianNumber} of 2 — Guardian {guardianNumber} Scan
+            Step {guardianNumber} of 2 — Guardian {guardianNumber}
           </p>
           <p className="text-xs text-blue-700 dark:text-blue-400">
-            Have Guardian {guardianNumber} scan the QR code below with their phone, sign the
-            acceptance hash with their passkey, then paste the returned address and signature here.
+            Send this QR / link to whoever you want as Guardian {guardianNumber}. On the page they
+            can become a guardian in any of these ways — no app install needed:
+          </p>
+          <ul className="text-xs text-blue-700 dark:text-blue-400 list-disc pl-4 mt-1 space-y-0.5">
+            <li>
+              <span className="font-medium">Already have an AirAccount</span> — enter their address,
+              confirm with Face ID
+            </li>
+            <li>
+              <span className="font-medium">New guardian</span> — email + Face ID, creates a passkey
+              on the spot (no wallet needed)
+            </li>
+            <li>
+              <span className="font-medium">MetaMask</span> — sign with their own wallet
+            </li>
+          </ul>
+          <p className="text-xs text-blue-700 dark:text-blue-400 mt-1">
+            They&apos;ll get an address + signature to paste back below.
           </p>
         </div>
 
@@ -223,11 +239,25 @@ export default function CreateAccountDialog({
       case "config":
         return (
           <div className="space-y-4">
-            <div className="bg-amber-50 dark:bg-amber-900/20 rounded-lg p-4">
-              <p className="text-sm text-amber-800 dark:text-amber-300">
-                Creating an AirAccount requires 2 guardian devices. Each guardian scans a QR code
-                and signs with their passkey. The team Safe is added as the 3rd guardian
-                automatically.
+            <div className="bg-amber-50 dark:bg-amber-900/20 rounded-lg p-4 space-y-2 text-sm text-amber-800 dark:text-amber-300">
+              <p className="font-semibold">🛡️ Social recovery — no seed phrase</p>
+              <p>
+                Your account is protected by <span className="font-medium">3 guardians</span>; any{" "}
+                <span className="font-medium">2</span> can help you recover it to a new device. You
+                set <span className="font-medium">2 guardians</span> here; the{" "}
+                <span className="font-medium">community multisig</span> is added automatically as
+                the 3rd.
+              </p>
+              <p>
+                Because the community is only 1 of 3, it can never reach the 2 needed —{" "}
+                <span className="font-medium">
+                  even a rogue community can&apos;t move your funds
+                </span>
+                . Lose one of your two? You can still recover with the other + the community.
+              </p>
+              <p>
+                Each guardian just scans a QR on the next step — no app install needed. They can use
+                their existing AirAccount, MetaMask, or create a guardian on the spot.
               </p>
             </div>
 


### PR DESCRIPTION
## 在账户创建对话框里把 guardian 讲清楚 + 列出 3 个渠道

之前 guarded-account 对话框只有一句 "Creating an AirAccount requires 2 guardian devices",新用户**第一次注册时突然冒出 guardian、完全不知所云**。现在补上:

**config 步骤** — 用大白话讲社交恢复:
- 3 个 guardian、任意 2 个可恢复;
- **2 个你掌握 + 1 个社区**;
- 社区只占 3 中 1,够不到 2 → **即便作恶也偷不走你的钱**;
- 丢一个自己的,仍可用另一个 + 社区恢复。

**QR 步骤** — 列出 guardian 扫码后的 3 种方式(无需装 app):
- **已有 AirAccount** — 填地址,Face ID 确认
- **新建 guardian** — email + Face ID,当场建 passkey(无需钱包)
- **MetaMask** — 用自己的钱包签

## 关于第 4 个渠道(纯客户端 passkey,Google/iCloud,无 KMS)
**还没做** —— 它需要链上 P-256 guardian 验证(已提需求 airaccount-contract#119)。做完才能有"完全不依赖 KMS 的 passkey guardian"。

## 验证
tsc --noEmit / eslint / next build / prettier 全过。
