### PR TITLE
chore(kms): 把 api key 彻底移出浏览器 bundle(#322 follow-up)

### DIFF
--- a/aastar-frontend/lib/yaaa.ts
+++ b/aastar-frontend/lib/yaaa.ts
@@ -3,8 +3,9 @@ import { KmsManager, LegacyPasskeyAssertion } from "@aastar/sdk/kms";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3000/api/v1";
 
-// In the browser, KMS calls are proxied through Next.js to avoid CORS issues.
-// The proxy is configured in next.config.ts: /kms-api/* → KMS_PROXY_URL/*
+// In the browser, KMS calls go through the server-side proxy at
+// app/kms-api/[...path], which injects the KMS api key from a SERVER env var —
+// so the key is never shipped in the browser bundle.
 const KMS_ENDPOINT =
   typeof window !== "undefined"
     ? "/kms-api"
@@ -26,7 +27,9 @@ export const yaaa = new YAAAClient({
 export const kmsClient = new KmsManager({
   kmsEndpoint: KMS_ENDPOINT,
   kmsEnabled: true,
-  kmsApiKey: process.env.NEXT_PUBLIC_KMS_API_KEY,
+  // No api key in the browser — the /kms-api proxy injects it server-side, so the
+  // key stays out of the client bundle. (NEXT_PUBLIC_KMS_API_KEY is intentionally
+  // not read here.)
 });
 
 // ── extractLegacyAssertion ────────────────────────────────────────


### PR DESCRIPTION
## 把 KMS api key 彻底移出浏览器 bundle(#322 的 follow-up)

`kmsClient`(`lib/yaaa.ts`)不再传 `kmsApiKey` —— 浏览器不再发 `x-api-key`。所有浏览器 KMS 调用走 `/kms-api` route handler(PR #322),由服务端 `KMS_API_KEY` 注入 key。**结果:KMS api key 不再烤进客户端 bundle。**

## 验证
- clean production build(`rm -rf .next` + build):**整个 `.next`(client static + server)都搜不到 key** ✓
- 经公网隧道注册仍正常:`BeginRegistration → 200`、rp.id=aastar.io(服务端注入 key)✓
- tsc / eslint / build / prettier 全过

## 部署说明
前端环境:设服务端 `KMS_API_KEY`,**去掉 `NEXT_PUBLIC_KMS_API_KEY`**。proxy 在生产 fail-closed(无 server key 即拒),所以 KMS_API_KEY 必须配。
