### PR TITLE
chore(account): mark P-256 guardian integration seam (comment only)

### DIFF
--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -161,6 +161,15 @@ export class AccountService {
 
     const dailyLimitWei = this.parseDailyLimitToWei(dto.dailyLimit) ?? 0n;
 
+    // ── SEAM: P-256 (WebAuthn) passkey guardian — see YAA#324 / aastar-sdk#110 ──
+    // A passkey guardian is a secp256r1 pubkey (x, y), NOT an address, and needs
+    // NO acceptance signature at creation (unlike ECDSA guardians above). The
+    // v0.20.0 contract factory InitConfig carries it via `guardianP256X/Y bytes32[3]`.
+    // The published @aastar/sdk@0.20.9 does NOT yet expose this on
+    // createAccountWithGuardians (batch1 added it post-v0.20.9, unpublished).
+    // When the SDK publishes the P-256 InitConfig wrapper, plug it in here, e.g.:
+    //   p256Guardians: dto.guardianP256 ? [{ x: dto.guardianP256.x, y: dto.guardianP256.y }] : undefined,
+    // No speculative wiring now — see the "flip on publish" checklist in YAA#324.
     return this.client.accounts.createAccountWithGuardians(userId, {
       guardian1: dto.guardian1,
       guardian1Sig: dto.guardian1Sig,


### PR DESCRIPTION
## What

Adds a single **anchor comment** at the `createAccountWithGuardians` call in `account.service.ts`, marking exactly where the P-256 (WebAuthn) passkey guardian plugs in once the SDK exposes it. **No behavior change** — comment only.

This is the "留缝, 不写集成" step: the seam is documented in code so the post-publish wiring is a small, mechanical diff, but no speculative integration is written against the unpublished SDK shape.

## Why now / why not more

- Published `@aastar/sdk@0.20.9` does **not** carry the `guardianP256X/Y` InitConfig — verified (`guardianP256X` is 0-hit in its dist).
- The SDK's batch1 (InitConfig + `getGuardianP256Key`) is merged on the SDK mainline but **post-`v0.20.9`**, i.e. unpublished. Batch2 (`addP256Guardian` / `proposeRecoveryWithSig`) is still `NOT_IMPLEMENTED` stubs.
- So integration is intentionally deferred. The **"flip on publish" checklist** lives in YAA#324; the **SDK asks** (expose P-256 on `createAccountWithGuardians`, `@aastar/sdk` re-export, batch2 timeline, P-256-needs-no-acceptance-sig) are in aastar-sdk#110.

## Note captured in the comment

A P-256 guardian is a `(x, y)` pubkey, not an address, and needs **no acceptance signature at creation** (unlike the ECDSA guardians) — the proof comes at recovery time via `proposeRecoveryWithSig`. That simplifies the eventual passkey-guardian creation flow (no QR→sign roundtrip).

Refs: YAA#324, aastar-sdk#110
