### PR TITLE
chore(deps): bump @aastar/sdk 0.20.9 → 0.21.1 (v0.20.0 infra sync)

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -17,7 +17,7 @@
     "test:ci": "echo \"⚠️  No tests yet - skipping\""
   },
   "dependencies": {
-    "@aastar/sdk": "^0.20.9",
+    "@aastar/sdk": "^0.21.1",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.20.9",
+    "@aastar/sdk": "^0.21.1",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.20.9",
+        "@aastar/sdk": "^0.21.1",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -81,7 +81,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.20.9",
+        "@aastar/sdk": "^0.21.1",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -351,9 +351,9 @@
       }
     },
     "aastar/node_modules/@aastar/sdk": {
-      "version": "0.20.9",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.20.9.tgz",
-      "integrity": "sha512-/hIToT8IWzZjqSTDSOrVl1vnYJ9Rin/uyT61NWYTP/p6LPaN0WrLA5LZi0s2Afw93NDg9mLW9AYOdGSFDzwE6w==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.21.1.tgz",
+      "integrity": "sha512-+3ncZKfq2aAC5BknRD1ebFKFkmW7FItxINGHm28VD7HSPk6eY7b+dkohXYAhnG21v0trKx+lgxXysOWFRYRb7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.20.9",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.20.9.tgz",
-      "integrity": "sha512-/hIToT8IWzZjqSTDSOrVl1vnYJ9Rin/uyT61NWYTP/p6LPaN0WrLA5LZi0s2Afw93NDg9mLW9AYOdGSFDzwE6w==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.21.1.tgz",
+      "integrity": "sha512-+3ncZKfq2aAC5BknRD1ebFKFkmW7FItxINGHm28VD7HSPk6eY7b+dkohXYAhnG21v0trKx+lgxXysOWFRYRb7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
## What

Bumps `@aastar/sdk` **0.20.9 → 0.21.1** to adopt the v0.20.0 **Batch 1** upstream sync. This is the SDK-side `airaccount-contract v0.20.0` foundation; **non-breaking for YAA** (verified below).

## Why it matters (independent of P-256)

1. **v0.20.0 addresses/ABIs** — 0.21.0 realigns all AirAccount Sepolia addresses to the **2026-06-20 v0.20.0 redeploy** (factory `0x99C9300d…`, impl `0xd51db7eB…`, extension `0x5529f508…`). YAA on 0.20.9 was still pointing at the **old `v0.19.0-beta.2`** deploy — so this is needed to transact against the current testnet contracts.
2. **#115 AA24 fix (0.21.1)** — v0.20.0 AirAccount `_validateSignature` routes on `signature[0]` as an algId prefix; a raw-65 sig whose first byte == `0x02` misroutes → **intermittent AA24**. 0.21.1 adds the opt-in `airAccountSig` option (66-byte `[0x02][r][s][v]`). Default unchanged; YAA's high-level `client.transfers.executeTransfer` path compiles unaffected. *(Open question for the SDK team: does `executeTransfer` auto-apply `airAccountSig` for v0.20.0 accounts, or does YAA need to opt in at the transfer layer? Tracked for runtime testnet verification.)*

## NOT in this PR (still gated)

The **P-256 / WebAuthn guardian USE** (`addP256Guardian`, `proposeRecoveryWithSig`, …) is **Batch 2** and ships as `NOT_IMPLEMENTED` stubs in 0.21.1 (per the SDK CHANGELOG). The high-level `createAccountWithGuardians` wrapper also still has **no P-256 param**. So the "switch guardians to passkey" work remains gated on Batch 2 — see aastar-sdk#110 / YAA#324. This PR is purely the Batch-1 infra bump.

## Verification

- `type-check` (aastar + aastar-frontend) ✅
- `build` (aastar + aastar-frontend) ✅
- backend tests **34/34** ✅
- `npm ci` clean (exit 0, no ERESOLVE) ✅

Lockfile generation needed `--legacy-peer-deps` because the SDK declares `peerOptional react@^18` while the frontend is **React 19** — but `npm ci` (lockfile-driven, what CI uses) resolves fine. The SDK should widen that peer to `^18 || ^19` (filed alongside aastar-sdk#110).

Refs: aastar-sdk CHANGELOG 0.21.0/0.21.1, aastar-sdk#110, YAA#324
