### PR TITLE
chore(deps): bump @aastar/sdk 0.21.1 → 0.22.0 (Batch 2 P-256 guardian)

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -17,7 +17,7 @@
     "test:ci": "echo \"⚠️  No tests yet - skipping\""
   },
   "dependencies": {
-    "@aastar/sdk": "^0.21.1",
+    "@aastar/sdk": "^0.22.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.21.1",
+    "@aastar/sdk": "^0.22.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.21.1",
+        "@aastar/sdk": "^0.22.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -81,7 +81,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.21.1",
+        "@aastar/sdk": "^0.22.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -351,9 +351,9 @@
       }
     },
     "aastar/node_modules/@aastar/sdk": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.21.1.tgz",
-      "integrity": "sha512-+3ncZKfq2aAC5BknRD1ebFKFkmW7FItxINGHm28VD7HSPk6eY7b+dkohXYAhnG21v0trKx+lgxXysOWFRYRb7Q==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-qdBYc7wCAkhFVygkDcD9uf1V9I/ZiLPMyR++BggcXgj6bRwvehUETRcQ/ZZvtbahSsylxS/8wPGhQEJ0Nu3UjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.21.1.tgz",
-      "integrity": "sha512-+3ncZKfq2aAC5BknRD1ebFKFkmW7FItxINGHm28VD7HSPk6eY7b+dkohXYAhnG21v0trKx+lgxXysOWFRYRb7Q==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-qdBYc7wCAkhFVygkDcD9uf1V9I/ZiLPMyR++BggcXgj6bRwvehUETRcQ/ZZvtbahSsylxS/8wPGhQEJ0Nu3UjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
## What

Bumps `@aastar/sdk` **0.21.1 → 0.22.0** — the **Batch 2** release that ships the real client-side P-256 (WebAuthn passkey) guardian implementations (airaccount-contract v0.20.0), replacing the former `NOT_IMPLEMENTED` stubs.

0.22.0 exposes directly from `@aastar/sdk` (no separate `@aastar/core` dep): `buildP256GuardianChallenge`, `encodeWebAuthnAssertion`, `coseToP256XY`, `signP256GuardianAssertion`, `buildInitConfig`, and `airAccountExtensionActions` (`addP256Guardian` / `proposeRecoveryWithSig` / mixed-sig). On-chain proven on Sepolia (`proposeRecoveryWithSig` status 0x1).

## Scope — dependency bump only

The actual YAA wiring lands in follow-up PRs per YAA#324:
- passkey-guardian creation (owner-only, guardian-sig-free, via `buildInitConfig`)
- passkey-signed recovery (`proposeRecoveryWithSig`)
- removing the two KMS-backed guardian methods + CreateAccountDialog rewording

These are a viem-action integration path (the P-256 surface is viem-based) distinct from YAA's KMS server-client `createAccountWithGuardians`, so they're being planned + done incrementally rather than crammed into the bump.

## Lockfile

Deps unchanged vs 0.21.1 (viem/axios/@simplewebauthn), so this is a **surgical** patch: only the two `@aastar/sdk` lockfile entries (version/resolved/integrity, replaced as a bound block to avoid touching `@eslint/config-array@0.21.1`) + the two workspace range refs. (Regenerating the whole lockfile with local npm prunes it and breaks `next` under `npm ci` — see prior #328.)

## Verification

- `npm ci` clean ✅
- type-check (aastar + aastar-frontend) ✅
- build (aastar + aastar-frontend, incl. next build) ✅
- backend tests 34/34 ✅

Refs: aastar-sdk v0.22.0, aastar-sdk#110 (closed), YAA#324
