### PR TITLE
chore(deps): bump @aastar/sdk 0.22.0 → 0.23.0 (server-client P-256 creation)

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -17,7 +17,7 @@
     "test:ci": "echo \"⚠️  No tests yet - skipping\""
   },
   "dependencies": {
-    "@aastar/sdk": "^0.22.0",
+    "@aastar/sdk": "^0.23.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.22.0",
+    "@aastar/sdk": "^0.23.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.22.0",
+        "@aastar/sdk": "^0.23.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -81,7 +81,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.22.0",
+        "@aastar/sdk": "^0.23.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -351,9 +351,9 @@
       }
     },
     "aastar/node_modules/@aastar/sdk": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.22.0.tgz",
-      "integrity": "sha512-qdBYc7wCAkhFVygkDcD9uf1V9I/ZiLPMyR++BggcXgj6bRwvehUETRcQ/ZZvtbahSsylxS/8wPGhQEJ0Nu3UjA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.23.0.tgz",
+      "integrity": "sha512-zVbXTgOQXrCywNRkfOXVF7fVXs+BtTPTsJKq9uAMynyScTSSrZ3tD0mV5F7HSbNjymJR92DV9cJnHewVtsH7wA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.22.0.tgz",
-      "integrity": "sha512-qdBYc7wCAkhFVygkDcD9uf1V9I/ZiLPMyR++BggcXgj6bRwvehUETRcQ/ZZvtbahSsylxS/8wPGhQEJ0Nu3UjA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.23.0.tgz",
+      "integrity": "sha512-zVbXTgOQXrCywNRkfOXVF7fVXs+BtTPTsJKq9uAMynyScTSSrZ3tD0mV5F7HSbNjymJR92DV9cJnHewVtsH7wA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
## What

Bumps `@aastar/sdk` **0.22.0 → 0.23.0**, which resolves **aastar-sdk#118**: the KMS server client now exposes **P-256 main-account creation** — the entrypoint YAA needs.

(0.22.0 shipped the P-256 surface viem-only; YAA's KMS-orchestrated server client builds the ERC-4337 initCode internally + signs the deploy via the KMS owner key, so it couldn't inject `guardianP256X/Y` through the viem `buildInitConfig` path. #118 asked for a server-client entrypoint; 0.23.0 delivers it.)

New server-client API:
- `createAccountWithP256Guardians(userId, { p256Guardians: [{x,y}], dailyLimit (>0), ecdsaGuardians?, salt?, entryPointVersion? })` — full 8-field InitConfig path; **P-256 guardians are owner-bootstrap (NO acceptance sig)**.
- `createAccount(userId, { p256Guardians?, dailyLimit>0, ... })` — same via the convenience method.

## Scope — dependency bump only

The YAA wiring lands in follow-ups per YAA#324:
- passkey-guardian creation (`createAccountWithP256Guardians`)
- passkey-signed recovery (`proposeRecoveryWithSig` path)
- remove the two KMS-backed guardian methods + CreateAccountDialog rewording

## Lockfile

Deps unchanged vs 0.22.0 — surgical block-bound patch of the two `@aastar/sdk` entries + two workspace range refs (regenerating prunes the lockfile + breaks `next` under `npm ci`; see #328).

## Verification
- `npm ci` clean ✅ · type-check both ✅ · build both (incl. next) ✅ · backend tests 34/34 ✅

Refs: aastar-sdk v0.23.0, aastar-sdk#118 (closed), YAA#324
