### PR TITLE
feat(account): backend P-256 passkey guardian creation endpoint

### DIFF
--- a/aastar/src/account/account.controller.ts
+++ b/aastar/src/account/account.controller.ts
@@ -3,7 +3,11 @@ import { ApiTags, ApiOperation, ApiBearerAuth, ApiResponse } from "@nestjs/swagg
 import { AccountService } from "./account.service";
 import { CreateAccountDto } from "./dto/create-account.dto";
 import { RotateSignerDto } from "./dto/rotate-signer.dto";
-import { GuardianSetupPrepareDto, CreateWithGuardiansDto } from "./dto/guardian-setup.dto";
+import {
+  GuardianSetupPrepareDto,
+  CreateWithGuardiansDto,
+  CreateWithP256GuardiansDto,
+} from "./dto/guardian-setup.dto";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 
 @ApiTags("account")
@@ -78,6 +82,19 @@ export class AccountController {
   })
   async createWithGuardians(@Request() req, @Body() dto: CreateWithGuardiansDto) {
     return this.accountService.createWithGuardians(req.user.sub, dto);
+  }
+
+  @Post("create-with-p256-guardians")
+  @ApiOperation({
+    summary: "Create account with P-256 (WebAuthn passkey) guardians — no KMS, no QR scan",
+    description:
+      "Creates an AirAccount whose guardians are secp256r1 passkey public keys (x, y) — " +
+      "synced via iCloud Keychain / Google Password Manager, outside any KMS. P-256 guardians " +
+      "are an owner-bootstrap: registered at deploy time with NO acceptance signature, so unlike " +
+      "create-with-guardians there is no prepare/QR step. dailyLimit MUST be > 0. Requires SDK >= 0.23.0.",
+  })
+  async createWithP256Guardians(@Request() req, @Body() dto: CreateWithP256GuardiansDto) {
+    return this.accountService.createWithP256Guardians(req.user.sub, dto);
   }
 
   @Post("rotate-signer")

--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -2,7 +2,11 @@ import { Injectable, Inject, NotFoundException, BadRequestException } from "@nes
 import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 import { CreateAccountDto, EntryPointVersionDto } from "./dto/create-account.dto";
-import { GuardianSetupPrepareDto, CreateWithGuardiansDto } from "./dto/guardian-setup.dto";
+import {
+  GuardianSetupPrepareDto,
+  CreateWithGuardiansDto,
+  CreateWithP256GuardiansDto,
+} from "./dto/guardian-setup.dto";
 import { DatabaseService } from "../database/database.service";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
@@ -161,20 +165,57 @@ export class AccountService {
 
     const dailyLimitWei = this.parseDailyLimitToWei(dto.dailyLimit) ?? 0n;
 
-    // ── SEAM: P-256 (WebAuthn) passkey guardian — see YAA#324 / aastar-sdk#110 ──
-    // A passkey guardian is a secp256r1 pubkey (x, y), NOT an address, and needs
-    // NO acceptance signature at creation (unlike ECDSA guardians above). The
-    // v0.20.0 contract factory InitConfig carries it via `guardianP256X/Y bytes32[3]`.
-    // The published @aastar/sdk@0.20.9 does NOT yet expose this on
-    // createAccountWithGuardians (batch1 added it post-v0.20.9, unpublished).
-    // When the SDK publishes the P-256 InitConfig wrapper, plug it in here, e.g.:
-    //   p256Guardians: dto.guardianP256 ? [{ x: dto.guardianP256.x, y: dto.guardianP256.y }] : undefined,
-    // No speculative wiring now — see the "flip on publish" checklist in YAA#324.
     return this.client.accounts.createAccountWithGuardians(userId, {
       guardian1: dto.guardian1,
       guardian1Sig: dto.guardian1Sig,
       guardian2: dto.guardian2,
       guardian2Sig: dto.guardian2Sig,
+      dailyLimit: dailyLimitWei,
+      salt: dto.salt,
+      entryPointVersion: version,
+    });
+  }
+
+  /**
+   * Create an account with P-256 (WebAuthn passkey) guardian(s) — @aastar/sdk >= 0.23.0.
+   *
+   * A passkey guardian is a secp256r1 pubkey (x, y), NOT an address, and is an
+   * owner-bootstrap: registered at deploy time with NO acceptance signature (unlike
+   * the ECDSA path's QR-scan flow). The SDK's createAccountWithP256Guardians uses the
+   * factory's full-config `createAccount(owner, salt, config)` path — the only
+   * entrypoint that accepts the 8-field InitConfig (guardianP256X/Y). dailyLimit MUST
+   * be > 0: a guardian set enables the on-chain guard.
+   */
+  async createWithP256Guardians(userId: string, dto: CreateWithP256GuardiansDto) {
+    const dailyLimitWei = this.parseDailyLimitToWei(dto.dailyLimit);
+    if (dailyLimitWei === undefined || dailyLimitWei <= 0n) {
+      throw new BadRequestException(
+        "dailyLimit must be > 0 for a P-256 guardian account (a guardian set enables the on-chain guard)."
+      );
+    }
+
+    const seen = new Set<string>();
+    for (const g of dto.p256Guardians) {
+      const key = `${g.x.toLowerCase()}:${g.y.toLowerCase()}`;
+      if (seen.has(key)) {
+        throw new BadRequestException("Duplicate P-256 guardian public key");
+      }
+      seen.add(key);
+    }
+
+    const versionDto = dto.entryPointVersion || EntryPointVersionDto.V0_7;
+    const versionMap: Record<string, "0.6" | "0.7" | "0.8"> = {
+      "0.6": "0.6",
+      "0.7": "0.7",
+      "0.8": "0.8",
+    };
+    const version = versionMap[versionDto] as any;
+
+    return this.client.accounts.createAccountWithP256Guardians(userId, {
+      p256Guardians: dto.p256Guardians.map(g => ({
+        x: g.x as `0x${string}`,
+        y: g.y as `0x${string}`,
+      })),
       dailyLimit: dailyLimitWei,
       salt: dto.salt,
       entryPointVersion: version,

--- a/aastar/src/account/dto/guardian-setup.dto.ts
+++ b/aastar/src/account/dto/guardian-setup.dto.ts
@@ -1,6 +1,20 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsOptional, IsNumber, IsString, IsEnum, IsEthereumAddress } from "class-validator";
+import {
+  IsOptional,
+  IsNumber,
+  IsString,
+  IsEnum,
+  IsEthereumAddress,
+  IsArray,
+  ArrayMinSize,
+  ArrayMaxSize,
+  ValidateNested,
+  Matches,
+} from "class-validator";
+import { Type } from "class-transformer";
 import { EntryPointVersionDto } from "./create-account.dto";
+
+const HEX32 = /^0x[0-9a-fA-F]{64}$/;
 
 export class GuardianSetupPrepareDto {
   @ApiProperty({
@@ -53,6 +67,65 @@ export class CreateWithGuardiansDto {
   dailyLimit: string;
 
   @ApiProperty({ description: "Salt used during prepare step", required: false })
+  @IsOptional()
+  @IsNumber()
+  salt?: number;
+
+  @ApiProperty({
+    description: "EntryPoint version to use",
+    enum: EntryPointVersionDto,
+    default: EntryPointVersionDto.V0_7,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(EntryPointVersionDto)
+  entryPointVersion?: EntryPointVersionDto;
+}
+
+/**
+ * A P-256 (WebAuthn passkey) guardian, identified by its secp256r1 public key.
+ * Not an address — the contract stores the sentinel P256_GUARDIAN_SENTINEL in the
+ * guardian-address slot and the (x, y) pair in parallel storage.
+ */
+export class P256GuardianKeyDto {
+  @ApiProperty({ description: "secp256r1 public key X coordinate (0x-prefixed 32-byte hex)" })
+  @Matches(HEX32, { message: "x must be a 0x-prefixed 32-byte hex string" })
+  x: string;
+
+  @ApiProperty({ description: "secp256r1 public key Y coordinate (0x-prefixed 32-byte hex)" })
+  @Matches(HEX32, { message: "y must be a 0x-prefixed 32-byte hex string" })
+  y: string;
+}
+
+/**
+ * Create an account with P-256 passkey guardian(s). Unlike CreateWithGuardiansDto
+ * (ECDSA guardians that scan a QR and sign an acceptance hash), P-256 guardians are
+ * an owner-bootstrap: the owner registers the pubkeys at deploy time with NO guardian
+ * signature, so there is no prepare/QR step. The contract's config-hash-in-salt binding
+ * stands in for acceptance sigs. Requires @aastar/sdk >= 0.23.0.
+ */
+export class CreateWithP256GuardiansDto {
+  @ApiProperty({
+    description:
+      "P-256 passkey guardian public keys installed at deploy time (1–3). Owner-bootstrap — no acceptance signatures.",
+    type: [P256GuardianKeyDto],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(3)
+  @ValidateNested({ each: true })
+  @Type(() => P256GuardianKeyDto)
+  p256Guardians: P256GuardianKeyDto[];
+
+  @ApiProperty({
+    description:
+      "Daily transfer limit in ETH. MUST be > 0 — a guardian set enables the on-chain guard.",
+    example: "1.0",
+  })
+  @IsString()
+  dailyLimit: string;
+
+  @ApiProperty({ description: "Salt for deterministic address generation", required: false })
   @IsOptional()
   @IsNumber()
   salt?: number;


### PR DESCRIPTION
## What

Wires `@aastar/sdk@0.23.0`'s `createAccountWithP256Guardians` into YAA's backend — the **creation half** of YAA#324 (passkey-guardian, no KMS).

A P-256 guardian is a secp256r1 pubkey `(x, y)`, not an address (synced via iCloud Keychain / Google Password Manager, outside any KMS). It's an **owner-bootstrap**: registered at deploy time with **NO acceptance signature**, so unlike the ECDSA `create-with-guardians` path there's **no prepare/QR step**.

## Changes

- **dto** — `P256GuardianKeyDto` (x/y, 0x 32-byte hex) + `CreateWithP256GuardiansDto` (1–3 `p256Guardians`, `dailyLimit`, `salt?`, `entryPointVersion?`).
- **service** — `createWithP256Guardians`: validates `dailyLimit > 0` (a guardian set enables the on-chain guard), rejects duplicate keys, delegates to the SDK.
- **controller** — `POST account/create-with-p256-guardians`.
- Drops the now-obsolete P-256 **SEAM** comment in `createWithGuardians` (#327) — the real wiring landed here.

## Scope

Backend creation only (independent PR). Follow-ups: frontend creation UX, passkey-signed recovery, removing the two KMS guardian methods.

## Verification
- type-check ✅ · build ✅ · backend tests 34/34 ✅ · lint clean (my files)

Refs: YAA#324, aastar-sdk#118 (closed), aastar-sdk v0.23.0
