### PR TITLE
feat(guardian): backend passkey-guardian recovery (proposeRecoveryWithSig, relayed)

### DIFF
--- a/aastar/src/guardian/dto/guardian.dto.ts
+++ b/aastar/src/guardian/dto/guardian.dto.ts
@@ -1,5 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEthereumAddress, IsNotEmpty } from "class-validator";
+import { IsEthereumAddress, IsNotEmpty, Matches } from "class-validator";
+
+const HEX = /^0x[0-9a-fA-F]+$/;
+const HEX32 = /^0x[0-9a-fA-F]{64}$/;
 
 export class AddGuardianDto {
   @ApiProperty({ description: "Ethereum address of the guardian to add" })
@@ -46,4 +49,55 @@ export class CancelRecoveryDto {
   @IsEthereumAddress()
   @IsNotEmpty()
   accountAddress: string;
+}
+
+/**
+ * Step 1 of passkey-guardian recovery: ask the backend for the 32-byte challenge
+ * the guardian's passkey must sign (navigator.credentials.get). The backend reads
+ * the on-chain recovery nonce and builds buildProposeRecoveryChallenge.
+ */
+export class PrepareP256RecoveryDto {
+  @ApiProperty({ description: "Account (AirAccount) address to recover" })
+  @IsEthereumAddress()
+  @IsNotEmpty()
+  accountAddress: string;
+
+  @ApiProperty({ description: "New owner/signer address to transfer control to" })
+  @IsEthereumAddress()
+  @IsNotEmpty()
+  newOwner: string;
+}
+
+/**
+ * Step 2 of passkey-guardian recovery: submit the WebAuthn assertion produced by
+ * the guardian's passkey over the challenge from step 1. The backend encodes it
+ * (encodeWebAuthnAssertion) and relays proposeRecoveryWithSig on-chain (the contract
+ * accepts ANY relayer — the passkey signature is the proof), paying gas itself.
+ */
+export class SubmitP256RecoveryDto {
+  @ApiProperty({ description: "Account (AirAccount) address to recover" })
+  @IsEthereumAddress()
+  @IsNotEmpty()
+  accountAddress: string;
+
+  @ApiProperty({ description: "New owner/signer address (must match the prepare step)" })
+  @IsEthereumAddress()
+  @IsNotEmpty()
+  newOwner: string;
+
+  @ApiProperty({ description: "WebAuthn authenticatorData (0x hex)" })
+  @Matches(HEX, { message: "authenticatorData must be 0x-prefixed hex" })
+  authenticatorData: string;
+
+  @ApiProperty({ description: "Full WebAuthn clientDataJSON the authenticator signed (0x hex)" })
+  @Matches(HEX, { message: "clientDataJSON must be 0x-prefixed hex" })
+  clientDataJSON: string;
+
+  @ApiProperty({ description: "ES256 signature r (0x 32-byte hex)" })
+  @Matches(HEX32, { message: "r must be a 0x-prefixed 32-byte hex string" })
+  r: string;
+
+  @ApiProperty({ description: "ES256 signature s (0x 32-byte hex)" })
+  @Matches(HEX32, { message: "s must be a 0x-prefixed 32-byte hex string" })
+  s: string;
 }

--- a/aastar/src/guardian/guardian.controller.ts
+++ b/aastar/src/guardian/guardian.controller.ts
@@ -20,6 +20,8 @@ import {
   SupportRecoveryDto,
   ExecuteRecoveryDto,
   CancelRecoveryDto,
+  PrepareP256RecoveryDto,
+  SubmitP256RecoveryDto,
 } from "./dto/guardian.dto";
 
 @ApiTags("guardian")
@@ -103,5 +105,27 @@ export class GuardianController {
   @ApiParam({ name: "accountAddress", description: "Smart account address" })
   async getPendingRecovery(@Param("accountAddress") accountAddress: string) {
     return this.guardianService.getPendingRecovery(accountAddress);
+  }
+
+  @Post("recovery/p256/prepare")
+  @ApiOperation({
+    summary: "Build the challenge a passkey guardian must sign to propose recovery",
+    description:
+      "Reads the on-chain recovery nonce + P-256 guardian slot and returns the 32-byte challenge " +
+      "to pass to navigator.credentials.get(). Step 1 of passkey-guardian recovery.",
+  })
+  async prepareP256Recovery(@Body() dto: PrepareP256RecoveryDto) {
+    return this.guardianService.prepareP256Recovery(dto);
+  }
+
+  @Post("recovery/p256/submit")
+  @ApiOperation({
+    summary: "Relay proposeRecoveryWithSig with a passkey guardian's WebAuthn assertion",
+    description:
+      "Encodes the WebAuthn assertion and relays proposeRecoveryWithSig on-chain (backend pays gas; " +
+      "the passkey signature is the authorization, so any relayer may submit). Step 2 of recovery.",
+  })
+  async submitP256Recovery(@Body() dto: SubmitP256RecoveryDto) {
+    return this.guardianService.submitP256Recovery(dto);
   }
 }

--- a/aastar/src/guardian/guardian.service.ts
+++ b/aastar/src/guardian/guardian.service.ts
@@ -15,7 +15,10 @@ import {
   RemoveGuardianDto,
   InitiateRecoveryDto,
   SupportRecoveryDto,
+  PrepareP256RecoveryDto,
+  SubmitP256RecoveryDto,
 } from "./dto/guardian.dto";
+import { buildProposeRecoveryChallenge, encodeWebAuthnAssertion } from "@aastar/sdk";
 
 // Time lock before recovery can be executed (48 hours in ms)
 const RECOVERY_DELAY_MS = 48 * 60 * 60 * 1000;
@@ -38,6 +41,22 @@ const AIRACCOUNT_RECOVERY_ABI = [
   // read the active recovery proposal stored on-chain
   "function activeRecovery() external view returns (address newOwner, uint256 proposedAt, uint256 approvalBitmap, uint256 cancellationBitmap)",
 ];
+
+// AirAccount v0.20.0 P-256 (WebAuthn passkey) guardian recovery — AirAccountExtension,
+// reached via the account `fallback`→`delegatecall` (so calls target the account address).
+// Source: airaccount-contract docs/p256-guardian-spec.md §5.2 + getGuardianP256Key / getRecoveryNonce.
+const AIRACCOUNT_P256_RECOVERY_ABI = [
+  // monotonic nonce domain-separating P-256 recovery payloads
+  "function getRecoveryNonce() external view returns (uint256)",
+  // (x, y) secp256r1 pubkey of guardian slot `index` (zero pair => not a P-256 guardian)
+  "function getGuardianP256Key(uint256 index) external view returns (bytes32 x, bytes32 y)",
+  // passkey guardian proposes recovery — ANY relayer may submit (sig is the proof)
+  "function proposeRecoveryWithSig(address newOwner, uint8 gIdx, bytes sig) external",
+];
+
+// Max guardian slots on-chain (InitConfig guardians/guardianP256X/Y are bytes32[3]/address[3]).
+const MAX_GUARDIAN_SLOTS = 3;
+const ZERO32 = "0x" + "00".repeat(32);
 
 @Injectable()
 export class GuardianService {
@@ -454,5 +473,118 @@ export class GuardianService {
           }
         : { active: false },
     };
+  }
+
+  // ─── P-256 (passkey) guardian recovery ───────────────────────────────────
+
+  /**
+   * Resolve which on-chain guardian slot holds a P-256 (passkey) key.
+   * Returns the single non-zero slot's index + (x, y). Errors if there are zero or
+   * more than one (the latter needs the guardian's pubkey to disambiguate — not yet
+   * supported; our creation flow installs a single passkey guardian).
+   */
+  private async resolveP256GuardianSlot(
+    accountAddress: string
+  ): Promise<{ gIdx: number; x: string; y: string }> {
+    const provider = this.getProvider();
+    const ext = new ethers.Contract(accountAddress, AIRACCOUNT_P256_RECOVERY_ABI, provider);
+    const slots: { gIdx: number; x: string; y: string }[] = [];
+    for (let i = 0; i < MAX_GUARDIAN_SLOTS; i++) {
+      const [x, y] = await ext.getGuardianP256Key(i);
+      if (x !== ZERO32 || y !== ZERO32) {
+        slots.push({ gIdx: i, x, y });
+      }
+    }
+    if (slots.length === 0) {
+      throw new BadRequestException("This account has no P-256 (passkey) guardian.");
+    }
+    if (slots.length > 1) {
+      throw new BadRequestException(
+        "Account has multiple passkey guardians; disambiguating by credential is not yet supported."
+      );
+    }
+    return slots[0];
+  }
+
+  /**
+   * Step 1 — build the 32-byte challenge the guardian's passkey must sign to propose
+   * recovery. Reads the on-chain recovery nonce + the P-256 guardian slot.
+   */
+  async prepareP256Recovery(dto: PrepareP256RecoveryDto): Promise<{
+    challenge: string;
+    accountAddress: string;
+    newOwner: string;
+    gIdx: number;
+    nonce: string;
+    chainId: number;
+  }> {
+    const provider = this.getProvider();
+    const ext = new ethers.Contract(dto.accountAddress, AIRACCOUNT_P256_RECOVERY_ABI, provider);
+    const { gIdx } = await this.resolveP256GuardianSlot(dto.accountAddress);
+    const nonce: bigint = await ext.getRecoveryNonce();
+    const chainId = this.configService.get<number>("chainId") || 11155111;
+
+    const challenge = buildProposeRecoveryChallenge({
+      chainId,
+      account: dto.accountAddress as `0x${string}`,
+      nonce,
+      newOwner: dto.newOwner as `0x${string}`,
+    });
+
+    return {
+      challenge,
+      accountAddress: dto.accountAddress,
+      newOwner: dto.newOwner,
+      gIdx,
+      nonce: nonce.toString(),
+      chainId,
+    };
+  }
+
+  /**
+   * Step 2 — encode the guardian's WebAuthn assertion and RELAY proposeRecoveryWithSig
+   * on-chain (the contract accepts any relayer; the backend pays gas). Unlike the ECDSA
+   * proposeRecovery() path, the passkey signature — not msg.sender — is the authorization,
+   * so the backend relayer CAN submit this.
+   */
+  async submitP256Recovery(dto: SubmitP256RecoveryDto): Promise<{
+    success: boolean;
+    transactionHash: string;
+    gIdx: number;
+    newOwner: string;
+  }> {
+    const { gIdx } = await this.resolveP256GuardianSlot(dto.accountAddress);
+
+    // Encode + validate the assertion (low-S, webauthn.get prefix, challenge slot) —
+    // a bad blob fails here with a clear message rather than as an opaque on-chain revert.
+    const sig = encodeWebAuthnAssertion({
+      authenticatorData: dto.authenticatorData as `0x${string}`,
+      clientDataJSON: dto.clientDataJSON as `0x${string}`,
+      r: dto.r as `0x${string}`,
+      s: dto.s as `0x${string}`,
+    });
+
+    const signer = this.getRelaySigner();
+    const ext = new ethers.Contract(dto.accountAddress, AIRACCOUNT_P256_RECOVERY_ABI, signer);
+
+    try {
+      const tx: ethers.TransactionResponse = await ext.proposeRecoveryWithSig(
+        dto.newOwner,
+        gIdx,
+        sig
+      );
+      const receipt = await tx.wait();
+      if (!receipt || receipt.status !== 1) {
+        throw new InternalServerErrorException("proposeRecoveryWithSig transaction reverted");
+      }
+      this.logger.log(
+        `P-256 recovery proposed for ${dto.accountAddress} -> ${dto.newOwner} (gIdx ${gIdx}, tx ${tx.hash})`
+      );
+      return { success: true, transactionHash: tx.hash, gIdx, newOwner: dto.newOwner };
+    } catch (err) {
+      const message = (err as Error).message || "Failed to submit passkey recovery";
+      this.logger.error(`submitP256Recovery failed for ${dto.accountAddress}: ${message}`);
+      throw new InternalServerErrorException(message);
+    }
   }
 }


### PR DESCRIPTION
## What

Adds **P-256 (WebAuthn passkey) social recovery** to the backend, **relayed** by the existing `ETH_PRIVATE_KEY` relayer (backend pays gas).

The key unlock: unlike the ECDSA `proposeRecovery()` path — which requires `msg.sender == guardian`, so the backend relayer **cannot** call it (the existing code says exactly this) — v0.20.0's **`proposeRecoveryWithSig` accepts ANY relayer**. The passkey signature is the authorization, so the backend submits it and pays gas.

> Per the design call: **backend-relay for test convenience**. The normal-user **gasless-via-Paymaster** path (user pays with aPNTs/xPNTs) is the follow-up.

## Flow

1. `POST guardian/recovery/p256/prepare { accountAddress, newOwner }` → reads `getRecoveryNonce()` + the P-256 guardian slot, returns the 32-byte `buildProposeRecoveryChallenge` (what the passkey signs via `navigator.credentials.get`) + `gIdx`.
2. `POST guardian/recovery/p256/submit { accountAddress, newOwner, authenticatorData, clientDataJSON, r, s }` → `encodeWebAuthnAssertion` (validates low-S / `webauthn.get` prefix / challenge slot) → relays `proposeRecoveryWithSig(newOwner, gIdx, sig)`.

## Changes
- `dto/guardian.dto.ts` — `PrepareP256RecoveryDto`, `SubmitP256RecoveryDto` (hex-validated assertion fields)
- `guardian.service.ts` — `resolveP256GuardianSlot` (matches the on-chain passkey slot → `gIdx`), `prepareP256Recovery`, `submitP256Recovery` (relayed); P-256 extension ABI fragments
- `guardian.controller.ts` — the two endpoints

Uses `@aastar/sdk@0.23.0`'s `buildProposeRecoveryChallenge` + `encodeWebAuthnAssertion`. On-chain authorization is the passkey signature, not endpoint auth.

## Scope

Backend only (independent PR). Follow-ups: the guardian-side WebAuthn ceremony UI (recovery page) that calls these, then removing the two KMS guardian methods.

## Verification
- type-check ✅ · build ✅ · backend tests 34/34 ✅

Refs: YAA#324, airaccount-contract v0.20.0 p256-guardian-spec §5.2
