### PR TITLE
feat(recovery): passkey-guardian recovery UI (WebAuthn ceremony → relayed)

### DIFF
--- a/aastar-frontend/app/recovery/page.tsx
+++ b/aastar-frontend/app/recovery/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Layout from "@/components/Layout";
+import PasskeyRecoveryCard from "@/components/PasskeyRecoveryCard";
 import { guardianAPI } from "@/lib/api";
 import toast from "react-hot-toast";
 
@@ -155,8 +156,25 @@ export default function RecoveryPage() {
       <div className="max-w-lg mx-auto px-4 py-8">
         <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">Social Recovery</h1>
         <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
-          Recover an AirAccount by collecting 2-of-3 guardian approvals.
+          Recover an AirAccount with your passkey guardian, or by collecting 2-of-3 guardian
+          approvals.
         </p>
+
+        {/* Passkey recovery — one-step, backend-relayed (no gas, no second device) */}
+        <div className="mb-8">
+          <PasskeyRecoveryCard />
+        </div>
+
+        <div className="relative mb-8">
+          <div className="absolute inset-0 flex items-center" aria-hidden="true">
+            <div className="w-full border-t border-gray-200 dark:border-gray-700" />
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-white dark:bg-gray-900 px-3 text-xs uppercase tracking-wide text-gray-400">
+              or ECDSA guardians (2-of-3)
+            </span>
+          </div>
+        </div>
 
         {/* Step progress */}
         {step !== "done" && (

--- a/aastar-frontend/components/PasskeyRecoveryCard.tsx
+++ b/aastar-frontend/components/PasskeyRecoveryCard.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { guardianAPI } from "@/lib/api";
+import { signGuardianRecovery } from "@/lib/p256-guardian";
+import toast from "react-hot-toast";
+
+function isAddress(v: string) {
+  return /^0x[0-9a-fA-F]{40}$/.test(v);
+}
+
+/**
+ * Passkey (P-256) social recovery — one-step propose.
+ *
+ * The guardian's passkey (Face ID / fingerprint, synced via iCloud/Google) signs
+ * the recovery challenge; the backend relays proposeRecoveryWithSig on-chain and
+ * pays gas (the passkey signature is the authorization, so any relayer may submit).
+ * No second device, no KMS, no gas for the guardian.
+ */
+export default function PasskeyRecoveryCard() {
+  const [accountAddress, setAccountAddress] = useState("");
+  const [newOwner, setNewOwner] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  const handlePropose = async () => {
+    if (!isAddress(accountAddress)) return toast.error("Invalid account address");
+    if (!isAddress(newOwner)) return toast.error("Invalid new owner address");
+
+    setLoading(true);
+    try {
+      // 1. Backend builds the challenge (reads on-chain nonce + P-256 guardian slot).
+      const prep = await guardianAPI.prepareP256Recovery({ accountAddress, newOwner });
+
+      // 2. The passkey signs the challenge (WebAuthn assertion ceremony).
+      const assertion = await signGuardianRecovery({ challenge: prep.data.challenge });
+
+      // 3. Backend encodes the assertion + relays proposeRecoveryWithSig.
+      const res = await guardianAPI.submitP256Recovery({
+        accountAddress,
+        newOwner,
+        ...assertion,
+      });
+
+      setTxHash(res.data.transactionHash);
+      toast.success("Recovery proposed on-chain with your passkey!");
+    } catch (error: any) {
+      if (error?.name === "NotAllowedError") {
+        toast.error("Passkey authentication was cancelled.");
+      } else {
+        const message =
+          error.response?.data?.message || error.message || "Failed to propose recovery";
+        toast.error(message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-900/20 p-5 space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-indigo-900 dark:text-indigo-200">
+          Recover with passkey
+        </h2>
+        <p className="mt-1 text-sm text-indigo-700 dark:text-indigo-300">
+          Sign with the passkey guardian you set up (Face ID / fingerprint). The backend submits the
+          recovery on-chain and pays the gas — no second device, no KMS.
+        </p>
+      </div>
+
+      {txHash ? (
+        <div className="rounded-lg bg-green-100 dark:bg-green-900/30 p-3 text-sm text-green-800 dark:text-green-300">
+          <p className="font-medium">Recovery proposed. ✅</p>
+          <p className="mt-1 break-all font-mono text-xs">tx: {txHash}</p>
+          <p className="mt-2">
+            After the on-chain time lock, anyone can call <span className="font-mono">execute</span>{" "}
+            to finalize the new owner.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Account address
+            </label>
+            <input
+              type="text"
+              value={accountAddress}
+              onChange={e => setAccountAddress(e.target.value.trim())}
+              placeholder="0x… (the AirAccount to recover)"
+              disabled={loading}
+              className="block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              New owner address
+            </label>
+            <input
+              type="text"
+              value={newOwner}
+              onChange={e => setNewOwner(e.target.value.trim())}
+              placeholder="0x… (the new signer to take control)"
+              disabled={loading}
+              className="block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm px-3 py-2"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handlePropose}
+            disabled={loading}
+            className="inline-flex w-full justify-center items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? (
+              <>
+                <div className="w-4 h-4 mr-2 border-b-2 border-white rounded-full animate-spin" />
+                Signing…
+              </>
+            ) : (
+              "Propose recovery with passkey"
+            )}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/aastar-frontend/lib/api.ts
+++ b/aastar-frontend/lib/api.ts
@@ -231,6 +231,18 @@ export const guardianAPI = {
   cancelRecovery: (data: { accountAddress: string }) => api.post("/guardian/recovery/cancel", data),
 
   getPendingRecovery: (accountAddress: string) => api.get(`/guardian/recovery/${accountAddress}`),
+
+  prepareP256Recovery: (data: { accountAddress: string; newOwner: string }) =>
+    api.post("/guardian/recovery/p256/prepare", data),
+
+  submitP256Recovery: (data: {
+    accountAddress: string;
+    newOwner: string;
+    authenticatorData: string;
+    clientDataJSON: string;
+    r: string;
+    s: string;
+  }) => api.post("/guardian/recovery/p256/submit", data),
 };
 
 export const addressBookAPI = {

--- a/aastar-frontend/lib/p256-guardian.ts
+++ b/aastar-frontend/lib/p256-guardian.ts
@@ -11,7 +11,7 @@
 // signing (WebAuthn assertion → calldata, EIP-7212 verified) are wrapped by the SDK
 // (aastar-sdk#110) and are NOT done here.
 
-import { startRegistration } from "@simplewebauthn/browser";
+import { startRegistration, startAuthentication } from "@simplewebauthn/browser";
 
 export interface GuardianPasskey {
   /** 0x-prefixed 32-byte secp256r1 X coordinate. */
@@ -91,4 +91,71 @@ export async function createGuardianPasskey(opts: {
   }
   const { x, y } = xyFromSpki(b64urlToBytes(spkiB64));
   return { x, y, credentialId: credential.id };
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (h.length % 2 !== 0) throw new Error("Invalid hex length");
+  const out = new Uint8Array(h.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+// Parse a DER-encoded ECDSA signature (WebAuthn ES256) into 32-byte r and s.
+// DER: 0x30 len 0x02 rLen r… 0x02 sLen s… — each integer may carry a leading 0x00
+// sign byte or be shorter than 32 bytes, so normalise to fixed 32-byte big-endian.
+function derToRS(der: Uint8Array): { r: string; s: string } {
+  if (der[0] !== 0x30) throw new Error("Bad DER: not a sequence");
+  let off = 2; // skip 0x30, total-length
+  const readInt = (): Uint8Array => {
+    if (der[off] !== 0x02) throw new Error("Bad DER: expected integer");
+    const len = der[off + 1];
+    let val = der.slice(off + 2, off + 2 + len);
+    off += 2 + len;
+    while (val.length > 32 && val[0] === 0x00) val = val.slice(1); // drop sign byte
+    if (val.length > 32) throw new Error("Bad DER: scalar too long");
+    const padded = new Uint8Array(32);
+    padded.set(val, 32 - val.length); // left-pad to 32 bytes
+    return padded;
+  };
+  const r = readInt();
+  const s = readInt();
+  return { r: bytesToHex(r), s: bytesToHex(s) };
+}
+
+export interface GuardianRecoveryAssertion {
+  authenticatorData: string;
+  clientDataJSON: string;
+  r: string;
+  s: string;
+}
+
+/**
+ * Have the guardian's passkey sign a recovery challenge (the 32-byte digest from the
+ * backend's buildProposeRecoveryChallenge). Runs the WebAuthn assertion ceremony and
+ * returns the parts the contract verifies (authenticatorData, clientDataJSON, r, s).
+ * The (low-S normalisation + ABI encoding into the on-chain sig blob is done server-side
+ * by the SDK's encodeWebAuthnAssertion.)
+ */
+export async function signGuardianRecovery(opts: {
+  challenge: string;
+}): Promise<GuardianRecoveryAssertion> {
+  if (typeof window === "undefined") throw new Error("signGuardianRecovery is browser-only");
+
+  const challengeBytes = hexToBytes(opts.challenge);
+  const assertion = await startAuthentication({
+    optionsJSON: {
+      challenge: b64urlEncode(challengeBytes),
+      rpId: window.location.hostname,
+      userVerification: "required",
+      timeout: 120000,
+    },
+  });
+
+  const r = assertion.response;
+  return {
+    authenticatorData: bytesToHex(b64urlToBytes(r.authenticatorData)),
+    clientDataJSON: bytesToHex(b64urlToBytes(r.clientDataJSON)),
+    ...derToRS(b64urlToBytes(r.signature)),
+  };
 }


### PR DESCRIPTION
## What

Frontend half of **passkey (P-256) social recovery** — pairs with the backend `guardian/recovery/p256/{prepare,submit}` endpoints (#333).

One-step **"propose recovery with passkey"**: enter the account + new owner → the passkey (Face ID / fingerprint) signs the backend's challenge → the backend relays `proposeRecoveryWithSig` on-chain and pays gas. No second device, no KMS, no gas for the guardian.

## Changes
- `lib/p256-guardian.ts` — `signGuardianRecovery()`: runs the WebAuthn assertion ceremony over the backend challenge, returns `authenticatorData` / `clientDataJSON` / `r` / `s` (DER → fixed 32-byte parse). Low-S normalisation + ABI encoding stay server-side (SDK `encodeWebAuthnAssertion`).
- `lib/api.ts` — `guardianAPI.prepareP256Recovery` / `submitP256Recovery`.
- `components/PasskeyRecoveryCard.tsx` — self-contained propose-recovery card.
- `app/recovery/page.tsx` — renders the card above the legacy ECDSA 2-of-3 flow.

## Verification
- type-check ✅ · lint ✅ · next build ✅ (`/recovery` compiles)

> Runtime depends on the backend P-256 recovery endpoints (#333).

Refs: YAA#324
