### PR TITLE
feat(nav): GitHub-style account avatar dropdown (Profile / Organizations / Settings)

### DIFF
--- a/aastar-frontend/components/Layout.tsx
+++ b/aastar-frontend/components/Layout.tsx
@@ -34,7 +34,7 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [desktopSettingsOpen, setDesktopSettingsOpen] = useState(false);
+  const [avatarMenuOpen, setAvatarMenuOpen] = useState(false);
   const [showServiceStatus, setShowServiceStatus] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const router = useRouter();
@@ -63,14 +63,6 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
     router.push("/");
   };
 
-  const getNavButtonClass = (path: string, isActive: boolean) => {
-    const baseClass = "px-3 py-2 text-sm font-medium transition-all duration-200 relative";
-    if (isActive) {
-      return `${baseClass} text-slate-900 dark:text-emerald-400 border-b-2 border-slate-900 dark:border-emerald-400`;
-    }
-    return `${baseClass} text-gray-700 dark:text-gray-300 hover:text-slate-900 dark:hover:text-emerald-400 hover:border-b-2 hover:border-gray-300 dark:hover:border-gray-600`;
-  };
-
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-slate-100 dark:bg-slate-950">
@@ -94,140 +86,16 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
       {user && (
         <nav className="hidden md:block sticky top-0 z-50 bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 backdrop-blur-lg bg-opacity-90 dark:bg-opacity-90">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between h-16">
-              <div className="flex items-center"></div>
+            <div className="flex justify-between items-center h-16">
+              {/* Brand */}
+              <button onClick={() => router.push("/dashboard")} className="flex items-center gap-2">
+                <Image src="/aastar-logo.png" alt="" width={22} height={26} />
+                <span className="font-bold text-slate-900 dark:text-white">Cos72</span>
+              </button>
 
-              {/* Desktop Navigation */}
-              <div className="flex items-center space-x-2">
-                <button
-                  onClick={() => router.push("/dashboard")}
-                  className={getNavButtonClass("/dashboard", pathname === "/dashboard")}
-                >
-                  Dashboard
-                </button>
-                <button
-                  onClick={() => router.push("/role")}
-                  className={getNavButtonClass("/role", pathname === "/role")}
-                >
-                  My Role
-                </button>
-                <button
-                  onClick={() => router.push("/community")}
-                  className={getNavButtonClass("/community", pathname.startsWith("/community"))}
-                >
-                  Community
-                </button>
-                <button
-                  onClick={() => router.push("/operator")}
-                  className={getNavButtonClass("/operator", pathname.startsWith("/operator"))}
-                >
-                  Operator
-                </button>
-                <button
-                  onClick={() => router.push("/admin")}
-                  className={getNavButtonClass("/admin", pathname.startsWith("/admin"))}
-                >
-                  Protocol
-                </button>
-                <button
-                  onClick={() => router.push("/sale")}
-                  className={getNavButtonClass("/sale", pathname.startsWith("/sale"))}
-                >
-                  Sale
-                </button>
-                <button
-                  onClick={() => router.push("/transfer")}
-                  className={getNavButtonClass("/transfer", pathname.startsWith("/transfer"))}
-                >
-                  Transfer
-                </button>
-                <button
-                  onClick={() => router.push("/paymaster")}
-                  className={getNavButtonClass("/paymaster", pathname === "/paymaster")}
-                >
-                  Paymasters
-                </button>
-                <button
-                  onClick={() => router.push("/tasks")}
-                  className={getNavButtonClass("/tasks", pathname.startsWith("/tasks"))}
-                >
-                  Tasks
-                </button>
-                <button
-                  onClick={() => router.push("/recovery")}
-                  className={getNavButtonClass("/recovery", pathname === "/recovery")}
-                >
-                  Recovery
-                </button>
-                {/* Settings Dropdown */}
-                <div className="relative">
-                  <button
-                    onClick={() => setDesktopSettingsOpen(!desktopSettingsOpen)}
-                    className={`${getNavButtonClass("/settings", pathname === "/tokens" || pathname === "/nfts" || pathname === "/address-book")} inline-flex items-center gap-1`}
-                  >
-                    Settings
-                    <ChevronDownIcon
-                      className={`w-4 h-4 transition-transform ${desktopSettingsOpen ? "rotate-180" : ""}`}
-                    />
-                  </button>
-                  {desktopSettingsOpen && (
-                    <>
-                      <div
-                        className="fixed inset-0 z-10"
-                        onClick={() => setDesktopSettingsOpen(false)}
-                      />
-                      <div className="absolute right-0 mt-2 w-56 rounded-xl shadow-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 z-20">
-                        <div className="py-2">
-                          <button
-                            onClick={() => {
-                              router.push("/tokens");
-                              setDesktopSettingsOpen(false);
-                            }}
-                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
-                          >
-                            <WalletIcon className="w-5 h-5 mr-3" />
-                            Tokens
-                          </button>
-                          <button
-                            onClick={() => {
-                              router.push("/nfts");
-                              setDesktopSettingsOpen(false);
-                            }}
-                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
-                          >
-                            <svg
-                              className="w-5 h-5 mr-3"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              stroke="currentColor"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                              />
-                            </svg>
-                            NFTs
-                          </button>
-                          <button
-                            onClick={() => {
-                              router.push("/address-book");
-                              setDesktopSettingsOpen(false);
-                            }}
-                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
-                          >
-                            <BookOpenIcon className="w-5 h-5 mr-3" />
-                            Address Book
-                          </button>
-                        </div>
-                      </div>
-                    </>
-                  )}
-                </div>
-                {/* Language Switcher */}
+              {/* Right: language, theme, account avatar menu */}
+              <div className="flex items-center gap-1.5">
                 <LanguageSwitcher />
-                {/* Theme Toggle Button */}
                 <button
                   onClick={toggleTheme}
                   className="p-2 text-gray-700 dark:text-gray-300 hover:text-slate-900 dark:hover:text-emerald-400 rounded-md transition-colors"
@@ -239,16 +107,112 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
                     <SunIcon className="h-5 w-5" />
                   )}
                 </button>
-                <div className="flex items-center space-x-2">
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
-                    {user.username || user.email}
-                  </span>
+
+                {/* Account avatar dropdown (GitHub-style) */}
+                <div className="relative">
                   <button
-                    onClick={handleLogout}
-                    className="bg-slate-900 hover:bg-slate-800 dark:bg-slate-700 dark:hover:bg-slate-600 text-white px-3 py-2 rounded-lg text-sm font-medium transition-all shadow-sm hover:shadow-md"
+                    onClick={() => setAvatarMenuOpen(!avatarMenuOpen)}
+                    className="flex items-center gap-1 rounded-full focus:outline-none"
+                    aria-label="Account menu"
+                    aria-expanded={avatarMenuOpen}
                   >
-                    Logout
+                    <span className="flex items-center justify-center w-8 h-8 rounded-full bg-slate-900 dark:bg-emerald-600 text-white text-sm font-semibold">
+                      {(user.username || user.email || "?").charAt(0).toUpperCase()}
+                    </span>
+                    <ChevronDownIcon
+                      className={`w-4 h-4 text-gray-400 transition-transform ${avatarMenuOpen ? "rotate-180" : ""}`}
+                    />
                   </button>
+                  {avatarMenuOpen && (
+                    <>
+                      <div
+                        className="fixed inset-0 z-10"
+                        onClick={() => setAvatarMenuOpen(false)}
+                      />
+                      <div className="absolute right-0 mt-2 w-64 rounded-xl shadow-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 z-20 py-1">
+                        {/* Account header */}
+                        <div className="flex items-center gap-3 px-4 py-3">
+                          <span className="flex items-center justify-center w-9 h-9 rounded-full bg-slate-900 dark:bg-emerald-600 text-white text-sm font-semibold shrink-0">
+                            {(user.username || user.email || "?").charAt(0).toUpperCase()}
+                          </span>
+                          <div className="min-w-0">
+                            <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+                              {user.username || "Account"}
+                            </p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                              {user.email}
+                            </p>
+                          </div>
+                        </div>
+
+                        {[
+                          {
+                            title: "Profile",
+                            items: [
+                              { label: "Dashboard", path: "/dashboard", Icon: HomeIcon },
+                              { label: "My Role", path: "/role", Icon: ShieldCheckIcon },
+                              { label: "Transfer", path: "/transfer", Icon: PaperAirplaneIcon },
+                              { label: "Recovery", path: "/recovery", Icon: ShieldCheckIcon },
+                              { label: "Tasks", path: "/tasks", Icon: ClipboardDocumentListIcon },
+                            ],
+                          },
+                          {
+                            title: "Organizations",
+                            items: [
+                              { label: "Community", path: "/community", Icon: UserGroupIcon },
+                              { label: "Operator", path: "/operator", Icon: ServerStackIcon },
+                              { label: "Protocol", path: "/admin", Icon: Cog6ToothIcon },
+                              { label: "Sale", path: "/sale", Icon: CreditCardIcon },
+                              { label: "Paymasters", path: "/paymaster", Icon: WalletIcon },
+                            ],
+                          },
+                          {
+                            title: "Settings",
+                            items: [
+                              { label: "Tokens", path: "/tokens", Icon: WalletIcon },
+                              { label: "NFTs", path: "/nfts", Icon: BookOpenIcon },
+                              { label: "Address Book", path: "/address-book", Icon: BookOpenIcon },
+                            ],
+                          },
+                        ].map(group => (
+                          <div
+                            key={group.title}
+                            className="border-t border-gray-100 dark:border-gray-700 py-1"
+                          >
+                            <p className="px-4 pt-1 pb-0.5 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                              {group.title}
+                            </p>
+                            {group.items.map(item => {
+                              const Icon = item.Icon;
+                              return (
+                                <button
+                                  key={item.path}
+                                  onClick={() => {
+                                    router.push(item.path);
+                                    setAvatarMenuOpen(false);
+                                  }}
+                                  className="flex items-center w-full px-4 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
+                                >
+                                  <Icon className="w-4 h-4 mr-3 text-gray-400" />
+                                  {item.label}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        ))}
+
+                        <div className="border-t border-gray-100 dark:border-gray-700 mt-1 pt-1">
+                          <button
+                            onClick={handleLogout}
+                            className="flex items-center w-full px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
+                          >
+                            <ChevronRightIcon className="w-4 h-4 mr-3" />
+                            Sign out
+                          </button>
+                        </div>
+                      </div>
+                    </>
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Replaces the long horizontal desktop nav with a minimal top bar (🍄 Cos72 brand left) + an **account avatar** on the right. Click → GitHub-style dropdown grouped into **Profile / Organizations / Settings** (the old nav items reorganized), with an account header + **Sign out**.

Default avatar = the user's initial in a circle (avatar upload/management is a planned follow-up). Theme + language stay in the bar.

type-check ✓ · lint ✓ (--max-warnings 0) · next build ✓. Grouping is easy to tweak — tell me what to move.