### PR TITLE
feat(marketing): Contact/About/Privacy/Terms + sitemap + footer links

### DIFF
--- a/aastar-frontend/app/about/page.tsx
+++ b/aastar-frontend/app/about/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import MarketingShell from "@/components/MarketingShell";
+
+export const metadata: Metadata = {
+  title: "About — Cos72",
+  description:
+    "Cos72 is an open-source cooperation system with a value-added gas-sponsorship service.",
+};
+
+export default function AboutPage() {
+  return (
+    <MarketingShell title="About Cos72" subtitle="Open source, powerful, easy to use.">
+      <p>
+        <span className="font-medium text-gray-900 dark:text-white">Cos72</span> is an open-source
+        cooperation system — software that helps people and communities work together without
+        handing control to a platform. It is free, open, and self-hostable.
+      </p>
+      <p>
+        On top of the open core, we offer a{" "}
+        <span className="font-medium">value-added gas sponsorship service</span>: powered by
+        AAStar&apos;s ERC-4337 account-abstraction stack (AirAccount + SuperPaymaster), users sign
+        in with a passkey and transact without holding ETH for gas — communities can even sponsor
+        with their own tokens.
+      </p>
+      <p>
+        No seed phrase, no password: your account is a smart account secured by a passkey and
+        protected by social recovery. Cos72 is part of the{" "}
+        <span className="font-medium">Mycelium Protocol</span> ecosystem of digital public goods.
+      </p>
+      <ul className="list-disc list-inside space-y-1">
+        <li>Passkey sign-in (Face ID / fingerprint) — no password</li>
+        <li>Smart accounts (ERC-4337) with social recovery</li>
+        <li>Gasless transactions via SuperPaymaster — pay gas in community tokens</li>
+        <li>Open source &amp; self-hostable</li>
+      </ul>
+    </MarketingShell>
+  );
+}

--- a/aastar-frontend/app/contact/page.tsx
+++ b/aastar-frontend/app/contact/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import MarketingShell from "@/components/MarketingShell";
+import EmailImage from "@/components/EmailImage";
+
+export const metadata: Metadata = {
+  title: "Contact — Cos72",
+  description: "Get in touch with the Cos72 / AAStar team.",
+};
+
+const CONTACTS = [
+  {
+    name: "General",
+    role: "Anything else — partnerships, press, hello",
+    user: "hi",
+    domain: "aastar.io",
+  },
+  {
+    name: "David",
+    role: "R&D & Operations",
+    user: "david",
+    domain: "aastar.io",
+  },
+  {
+    name: "Jason",
+    role: "Business & Security",
+    user: "jason",
+    domain: "aastar.io",
+  },
+];
+
+export default function ContactPage() {
+  return (
+    <MarketingShell
+      title="Contact"
+      subtitle="We'd love to hear from you. Reach the right person directly."
+    >
+      <div className="space-y-3">
+        {CONTACTS.map(c => (
+          <div
+            key={c.user}
+            className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+          >
+            <div className="flex items-baseline justify-between gap-3 flex-wrap">
+              <p className="font-semibold text-gray-900 dark:text-white">{c.name}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">{c.role}</p>
+            </div>
+            <div className="mt-2">
+              <EmailImage user={c.user} domain={c.domain} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-gray-400 dark:text-gray-500">
+        Emails are shown as images on purpose, to keep the team out of spam-harvesting bots. Use the
+        “copy” link to grab an address.
+      </p>
+    </MarketingShell>
+  );
+}

--- a/aastar-frontend/app/privacy/page.tsx
+++ b/aastar-frontend/app/privacy/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import MarketingShell from "@/components/MarketingShell";
+
+export const metadata: Metadata = {
+  title: "Privacy — Cos72",
+  description: "How Cos72 handles your data: minimal by design, no passwords.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <MarketingShell title="Privacy" subtitle="Minimal by design.">
+      <p>
+        Cos72 collects as little as possible. We do not sell your data and we do not use it for
+        advertising.
+      </p>
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white">What we store</h2>
+      <ul className="list-disc list-inside space-y-1">
+        <li>
+          <span className="font-medium">Email</span> — used only to sign you in (a one-time code)
+          and to reach you about your account. No password is ever stored.
+        </li>
+        <li>
+          <span className="font-medium">Passkey public key &amp; wallet address</span> — to
+          authenticate you and operate your smart account. Private keys never leave your device /
+          the secure TEE.
+        </li>
+      </ul>
+      <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+        What we don&apos;t do
+      </h2>
+      <ul className="list-disc list-inside space-y-1">
+        <li>No passwords, no seed phrases to leak.</li>
+        <li>One-time login codes are kept in memory only and expire in minutes.</li>
+        <li>No tracking for ads; no selling personal data.</li>
+      </ul>
+      <p className="text-xs text-gray-400 dark:text-gray-500">
+        Questions? See the Contact page. This is a concise summary for an open-source project, not
+        legal advice.
+      </p>
+    </MarketingShell>
+  );
+}

--- a/aastar-frontend/app/sitemap.ts
+++ b/aastar-frontend/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+// Public, crawlable routes. Served at /sitemap.xml by Next's file convention.
+// App pages behind auth (dashboard, transfer, …) are intentionally excluded.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = process.env.NEXT_PUBLIC_SITE_URL || "https://yaa.aastar.io";
+  const routes = ["", "/about", "/contact", "/privacy", "/terms", "/auth/login", "/auth/register"];
+  return routes.map(path => ({
+    url: `${base}${path}`,
+    changeFrequency: "monthly",
+    priority: path === "" ? 1 : 0.6,
+  }));
+}

--- a/aastar-frontend/app/terms/page.tsx
+++ b/aastar-frontend/app/terms/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import MarketingShell from "@/components/MarketingShell";
+
+export const metadata: Metadata = {
+  title: "Terms — Cos72",
+  description: "Terms of use for the Cos72 open-source cooperation system.",
+};
+
+export default function TermsPage() {
+  return (
+    <MarketingShell title="Terms of Use" subtitle="Plain and short.">
+      <p>
+        Cos72 is open-source software provided <span className="font-medium">as is</span>, without
+        warranty of any kind. You are responsible for your account, your keys/passkeys, and the
+        transactions you sign.
+      </p>
+      <ul className="list-disc list-inside space-y-1">
+        <li>
+          The hosted service may run on test networks and can change or pause; do not treat balances
+          as guaranteed.
+        </li>
+        <li>
+          Keep your iCloud / Google account (which syncs your passkey) and your guardians secure —
+          they control account recovery.
+        </li>
+        <li>Don&apos;t use the service for unlawful activity.</li>
+        <li>
+          The open-source code is governed by its repository license; self-hosting is welcome.
+        </li>
+      </ul>
+      <p className="text-xs text-gray-400 dark:text-gray-500">
+        This is a concise summary for an open-source project, not legal advice.
+      </p>
+    </MarketingShell>
+  );
+}

--- a/aastar-frontend/components/EmailImage.tsx
+++ b/aastar-frontend/components/EmailImage.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Renders an email address as a <canvas> image instead of DOM text, so HTML
+ * scrapers / contact-harvesting bots can't read it. The address is assembled at
+ * runtime from user+domain parts (never a literal "x@y" string in the markup),
+ * drawn onto the canvas, and a copy button is offered for humans.
+ */
+export default function EmailImage({
+  user,
+  domain,
+  className = "",
+}: {
+  user: string;
+  domain: string;
+  className?: string;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [copied, setCopied] = useState(false);
+  // Assemble only inside the component (kept out of the rendered HTML).
+  const address = `${user}@${domain}`;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    const fontPx = 16;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const font = `${fontPx}px ui-monospace, SFMono-Regular, Menlo, monospace`;
+    ctx.font = font;
+    const w = Math.ceil(ctx.measureText(address).width) + 4;
+    const h = fontPx + 8;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+    ctx.scale(dpr, dpr);
+    ctx.font = font;
+    ctx.textBaseline = "middle";
+    // Theme-aware colour.
+    const dark = document.documentElement.classList.contains("dark");
+    ctx.fillStyle = dark ? "#e2e8f0" : "#0f172a";
+    ctx.fillText(address, 2, h / 2);
+  }, [address]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <span className={`inline-flex items-center gap-2 ${className}`}>
+      <canvas ref={canvasRef} aria-label="email address (image)" />
+      <button
+        type="button"
+        onClick={copy}
+        className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 underline underline-offset-2"
+      >
+        {copied ? "copied" : "copy"}
+      </button>
+    </span>
+  );
+}

--- a/aastar-frontend/components/Layout.tsx
+++ b/aastar-frontend/components/Layout.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 import { clearStoredAuth, getStoredAuth } from "@/lib/auth";
 import { User } from "@/lib/types";
@@ -226,12 +227,38 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
       {/* Footer — shown on mobile + desktop; extra bottom padding on mobile when the
           fixed bottom nav is present (logged in) so it isn't hidden behind it. */}
       <footer
-        className={`flex items-center justify-center gap-2 pt-4 text-xs text-gray-400 dark:text-gray-600 ${
-          user ? "pb-24 md:pb-4" : "pb-6"
+        className={`flex flex-col items-center justify-center gap-2 pt-6 text-xs text-gray-400 dark:text-gray-600 ${
+          user ? "pb-24 md:pb-6" : "pb-8"
         }`}
       >
-        <Image src="/aastar-logo.png" alt="AAStar" width={20} height={24} className="opacity-80" />
-        <span>Powered by AAStar 2023</span>
+        <div className="flex items-center gap-2">
+          <Image
+            src="/aastar-logo.png"
+            alt="AAStar"
+            width={18}
+            height={22}
+            className="opacity-80"
+          />
+          <span className="text-gray-500 dark:text-gray-400">
+            Cos72 — an open-source cooperation system with value-added gas sponsorship.
+          </span>
+        </div>
+        <div className="flex items-center gap-4">
+          <Link href="/about" className="hover:text-gray-600 dark:hover:text-gray-300">
+            About
+          </Link>
+          <Link href="/contact" className="hover:text-gray-600 dark:hover:text-gray-300">
+            Contact
+          </Link>
+          <Link href="/privacy" className="hover:text-gray-600 dark:hover:text-gray-300">
+            Privacy
+          </Link>
+          <Link href="/terms" className="hover:text-gray-600 dark:hover:text-gray-300">
+            Terms
+          </Link>
+          <span className="text-gray-300 dark:text-gray-700">·</span>
+          <span>Powered by AAStar 2023</span>
+        </div>
       </footer>
 
       {/* Service Status - Desktop only (mobile version is embedded in Me menu) */}

--- a/aastar-frontend/components/MarketingShell.tsx
+++ b/aastar-frontend/components/MarketingShell.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import Image from "next/image";
+import type { ReactNode } from "react";
+
+/** Lightweight public-page shell (no auth nav) for /contact, /about, /privacy, /terms. */
+export default function MarketingShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-slate-100 dark:bg-slate-950 flex flex-col">
+      <header className="px-4 sm:px-6 lg:px-8 py-4">
+        <Link href="/" className="inline-flex items-center gap-2">
+          <Image src="/aastar-logo.png" alt="" width={22} height={26} />
+          <span className="font-bold text-slate-900 dark:text-white">Cos72</span>
+        </Link>
+      </header>
+
+      <main className="flex-1 px-4 sm:px-6 lg:px-8 py-8">
+        <div className="max-w-2xl mx-auto">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{title}</h1>
+          {subtitle && <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{subtitle}</p>}
+          <div className="mt-6 space-y-6 text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+            {children}
+          </div>
+        </div>
+      </main>
+
+      <footer className="px-4 sm:px-6 lg:px-8 py-6 text-center text-xs text-gray-400 dark:text-gray-600">
+        <div className="flex items-center justify-center gap-4 mb-2">
+          <Link href="/about" className="hover:text-gray-600 dark:hover:text-gray-300">
+            About
+          </Link>
+          <Link href="/contact" className="hover:text-gray-600 dark:hover:text-gray-300">
+            Contact
+          </Link>
+          <Link href="/privacy" className="hover:text-gray-600 dark:hover:text-gray-300">
+            Privacy
+          </Link>
+          <Link href="/terms" className="hover:text-gray-600 dark:hover:text-gray-300">
+            Terms
+          </Link>
+        </div>
+        <p>Cos72 — an open-source cooperation system. Powered by AAStar 2023.</p>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
Public (no-auth) pages — also kills the common crawler 404s (/contact /about /privacy /terms /sitemap.xml).

- **/contact** — team emails as **anti-scrape canvas images** (`EmailImage`: address assembled at runtime + drawn to `<canvas>`, never in the DOM; copy button for humans). **David = R&D & Operations, Jason = Business & Security, hi@ = general.** Contacts live only here (not in the footer, per request).
- **/about** — positioning: open-source cooperation system + value-added gas sponsorship (AAStar ERC-4337 / SuperPaymaster), passkey, social recovery, Mycelium.
- **/privacy**, **/terms** — concise, passwordless / data-minimal.
- **app/sitemap.ts** → /sitemap.xml (public routes only).
- **footer** — positioning tagline + About/Contact/Privacy/Terms links (no emails).

type-check ✓ · lint ✓ (--max-warnings 0) · next build ✓.