### PR TITLE
fix(kms): forward Origin so passkey login resolves a consistent rpId

### DIFF
--- a/aastar/src/config/configuration.ts
+++ b/aastar/src/config/configuration.ts
@@ -80,6 +80,12 @@ export default () => {
     kmsEnabled: process.env.KMS_ENABLED === "true",
     kmsEndpoint: process.env.KMS_ENDPOINT || "https://kms1.aastar.io",
     kmsApiKey: process.env.KMS_API_KEY,
+    // HTTP Origin the backend forwards to the KMS so its resolve_rp_id() picks the
+    // SAME rpId the browser used during BeginAuthentication (which the frontend
+    // /kms-api proxy forwards as the browser origin). Without this, server-to-server
+    // SignHash calls send no Origin and the KMS falls back to its first KMS_RP_ID
+    // (aastar.io), causing an rpIdHash mismatch against localhost-origin assertions.
+    kmsWebauthnOrigin: process.env.KMS_WEBAUTHN_ORIGIN || "http://localhost:5173",
     // AAStar contract addresses (fallback to @aastar/core canonical after applyConfig)
     registryAddress: process.env.REGISTRY_ADDRESS,
     stakingAddress: process.env.STAKING_ADDRESS,

--- a/aastar/src/kms/kms.service.ts
+++ b/aastar/src/kms/kms.service.ts
@@ -8,6 +8,7 @@ export type { LegacyPasskeyAssertion };
 @Injectable()
 export class KmsService {
   private readonly kmsManager: KmsManager;
+  private readonly webauthnOrigin: string;
 
   constructor(private configService: ConfigService) {
     this.kmsManager = new KmsManager({
@@ -15,19 +16,60 @@ export class KmsService {
       kmsEnabled: configService.get<boolean>("kmsEnabled") === true,
       kmsApiKey: configService.get<string>("kmsApiKey"),
     });
+    this.webauthnOrigin =
+      configService.get<string>("kmsWebauthnOrigin") ?? "http://localhost:5173";
 
     if (this.kmsManager.isKmsEnabled()) {
       const endpoint = configService.get<string>("kmsEndpoint") ?? "https://kms1.aastar.io";
       console.log(`[KmsService] KMS service enabled with endpoint: ${endpoint}`);
-      this.installDiagnosticInterceptors();
+      console.log(`[KmsService] Forwarding Origin to KMS: ${this.webauthnOrigin}`);
+      this.installOriginForwarding();
+      // Verbose KMS request/response tracing — opt-in via KMS_DIAG=true to avoid
+      // spamming normal logs (it dumps full WebAuthn request bodies).
+      if (process.env.KMS_DIAG === "true") {
+        this.installDiagnosticInterceptors();
+      }
     } else {
       console.log("[KmsService] KMS service disabled");
     }
   }
 
+  /**
+   * Resolve the underlying axios instance. The SDK holds it at
+   * `KmsManager.client.http` (KmsHttpClient); older builds exposed it directly as
+   * `.http`. Try both so interceptors actually attach.
+   */
+  private getKmsHttp(): any {
+    const m = this.kmsManager as any;
+    return m?.client?.http ?? m?.httpClient?.http ?? m?.http ?? null;
+  }
+
+  /**
+   * Inject an Origin header on every backend→KMS request. The KMS resolves the
+   * WebAuthn rpId from the caller's Origin (resolve_rp_id); without this, the
+   * server-to-server SignHash call sends no Origin and the KMS falls back to its
+   * first configured rpId (aastar.io), mismatching localhost-origin assertions
+   * produced during BeginAuthentication (which the /kms-api proxy forwards as the
+   * browser origin). Forwarding the same Origin keeps begin + sign consistent.
+   */
+  private installOriginForwarding() {
+    const http = this.getKmsHttp();
+    if (!http) {
+      console.warn("[KmsService] Could not resolve KMS axios instance — Origin not forwarded");
+      return;
+    }
+    http.interceptors.request.use((config: any) => {
+      config.headers = config.headers ?? {};
+      if (!config.headers["Origin"] && !config.headers["origin"]) {
+        config.headers["Origin"] = this.webauthnOrigin;
+      }
+      return config;
+    });
+  }
+
   /** Attach axios request/response interceptors to log full KMS traffic for debugging. */
   private installDiagnosticInterceptors() {
-    const http = (this.kmsManager as any).http;
+    const http = this.getKmsHttp();
     if (!http) return;
 
     http.interceptors.request.use((config: any) => {


### PR DESCRIPTION
## Problem

Passkey (KMS) login showed success then bounced back to the login page. Root cause traced via the KMS WebAuthn flow:

- The KMS resolves the WebAuthn **rpId from the caller's HTTP `Origin`** (`resolve_rp_id`), falling back to the first configured `KMS_RP_ID` (`aastar.io`) when no Origin is present.
- **BeginAuthentication** reaches the KMS through the frontend `/kms-api` proxy, which forwards the **browser** Origin (`http://localhost:5173`) → the assertion is signed with `rpId=localhost`.
- **completeKmsLogin → SignHash** is a **server-to-server** call from the backend via the SDK, which sends **no Origin** → the KMS falls back to `aastar.io` and rejects the localhost-origin assertion (host-layer `rpIdHash mismatch`) → backend wraps as 401 → frontend 401 interceptor redirects to login.

Verified empirically against the live KMS:
```
SignHash no Origin            → resolve_rp_id → aastar.io   (KMS_RP_ID[0])
SignHash Origin=localhost:5173 → resolve_rp_id → localhost
```

(The original 500 came from the hardware TA hardcoding `SHA256("aastar.io")`; that was fixed on the airaccount/KMS side by reflashing the TA+CA to support localhost. This PR is the **backend-side** half required for the localhost dev flow to work end-to-end.)

## Fix

- Inject a configurable `Origin` header (**`KMS_WEBAUTHN_ORIGIN`**, default `http://localhost:5173`) on every backend→KMS request so **begin and sign resolve the same rpId** in both dev and prod. (Flipping `KMS_RP_ID` order on the board instead would break prod aastar.io, so forwarding is the correct fix.)
- Fix the axios-instance lookup to `client.http` (the SDK moved it off the manager), which had silently disabled the diagnostic interceptors. Those are now gated behind **`KMS_DIAG=true`** to avoid noisy logs by default.

## Test
- `npm run type-check -w aastar` ✅
- Manual: passkey login on `localhost:5173` succeeds and stays on /dashboard (with the reflashed TA).