### PR TITLE
chore(account): surface create-with-p256-guardians failures + KMS assertion logging

### DIFF
--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, NotFoundException, BadRequestException } from "@nestjs/common";
+import { Injectable, Inject, NotFoundException, BadRequestException, Logger } from "@nestjs/common";
 import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 import { CreateAccountDto, EntryPointVersionDto } from "./dto/create-account.dto";
@@ -13,6 +13,8 @@ import { ethers } from "ethers";
 
 @Injectable()
 export class AccountService {
+  private readonly logger = new Logger(AccountService.name);
+
   constructor(
     @Inject(YAAA_SERVER_CLIENT) private client: YAAAServerClient,
     private databaseService: DatabaseService,
@@ -211,15 +213,34 @@ export class AccountService {
     };
     const version = versionMap[versionDto] as any;
 
-    return this.client.accounts.createAccountWithP256Guardians(userId, {
-      p256Guardians: dto.p256Guardians.map(g => ({
-        x: g.x as `0x${string}`,
-        y: g.y as `0x${string}`,
-      })),
-      dailyLimit: dailyLimitWei,
-      salt: dto.salt,
-      entryPointVersion: version,
-    });
+    this.logger.log(
+      `createWithP256Guardians: userId=${userId} guardians=${dto.p256Guardians.length} ` +
+        `version=${version} dailyLimitWei=${dailyLimitWei} salt=${dto.salt ?? "random"}`
+    );
+
+    try {
+      const account = await this.client.accounts.createAccountWithP256Guardians(userId, {
+        p256Guardians: dto.p256Guardians.map(g => ({
+          x: g.x as `0x${string}`,
+          y: g.y as `0x${string}`,
+        })),
+        dailyLimit: dailyLimitWei,
+        salt: dto.salt,
+        entryPointVersion: version,
+      });
+      this.logger.log(
+        `createWithP256Guardians OK: address=${account.address} deployed=${account.deployed}`
+      );
+      return account;
+    } catch (err: any) {
+      // Surface the real SDK/KMS/on-chain failure (otherwise it bubbles up as an
+      // opaque 500). Includes the KMS "No pending challenge" challenge-binding case.
+      this.logger.error(
+        `createWithP256Guardians FAILED: ${err?.message ?? err}`,
+        err?.stack
+      );
+      throw err;
+    }
   }
 
   /**

--- a/aastar/src/sdk/backend-signer.adapter.ts
+++ b/aastar/src/sdk/backend-signer.adapter.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { ISignerAdapter, PasskeyAssertionContext } from "@aastar/sdk/kms";
 import { AuthService } from "../auth/auth.service";
 
@@ -11,6 +11,8 @@ import { AuthService } from "../auth/auth.service";
  */
 @Injectable()
 export class BackendSignerAdapter implements ISignerAdapter {
+  private readonly logger = new Logger(BackendSignerAdapter.name);
+
   constructor(private authService: AuthService) {}
 
   async getAddress(userId: string): Promise<`0x${string}`> {
@@ -26,6 +28,16 @@ export class BackendSignerAdapter implements ISignerAdapter {
   ): Promise<`0x${string}`> {
     // Callers pass a 32-byte digest (raw bytes / 0x hex); KmsSigner.signMessage
     // applies EIP-191 personal-sign semantics. The assertion gates the KMS sign.
+    // No assertion here ⇒ the KMS SignHash will fail (challenge-binding: assertion
+    // required / "No pending challenge"), so log its presence to pinpoint such 500s.
+    const hasAssertion = !!ctx?.assertion;
+    this.logger.debug(`signMessage: userId=${userId} hasAssertion=${hasAssertion}`);
+    if (!hasAssertion) {
+      this.logger.warn(
+        `signMessage called WITHOUT a passkey assertion (userId=${userId}); ` +
+          `the KMS SignHash will be rejected (challenge-binding requires a fresh assertion).`
+      );
+    }
     const assertionProvider = ctx?.assertion ? () => Promise.resolve(ctx.assertion) : undefined;
     const signer = await this.authService.getUserWallet(userId, assertionProvider);
     return (await signer.signMessage(message)) as `0x${string}`;
@@ -33,6 +45,8 @@ export class BackendSignerAdapter implements ISignerAdapter {
 
   async ensureSigner(userId: string): Promise<{ address: `0x${string}` }> {
     const signer = await this.authService.ensureUserWallet(userId);
-    return { address: (await signer.getAddress()) as `0x${string}` };
+    const address = (await signer.getAddress()) as `0x${string}`;
+    this.logger.debug(`ensureSigner: userId=${userId} address=${address}`);
+    return { address };
   }
 }


### PR DESCRIPTION
Adds NestJS Logger instrumentation so create-with-passkey 500s aren't opaque:
- `account.service.createWithP256Guardians`: logs entry params + wraps the SDK call to log the real error message + stack on failure.
- `backend-signer.adapter`: logs whether a passkey assertion is present on `signMessage` (warns when missing — the KMS challenge-binding "No pending challenge" case), and the resolved `ensureSigner` address.

Diagnostic-only; no behavior change. Pairs with `KMS_DIAG=true` (gated KMS traffic logging from #342).