### PR TITLE
fix(frontend): import coseToP256XY from @aastar/sdk/core (browser-safe)

### DIFF
--- a/aastar-frontend/lib/p256-guardian.ts
+++ b/aastar-frontend/lib/p256-guardian.ts
@@ -12,7 +12,9 @@
 // (aastar-sdk#110) and are NOT done here.
 
 import { startRegistration, startAuthentication } from "@simplewebauthn/browser";
-import { coseToP256XY } from "@aastar/sdk";
+// Browser-safe subpath: the root "@aastar/sdk" pulls in the server bundle (imports
+// 'fs') and breaks the client build; "/core" is pure crypto.
+import { coseToP256XY } from "@aastar/sdk/core";
 
 export interface GuardianPasskey {
   /** 0x-prefixed 32-byte secp256r1 X coordinate. */


### PR DESCRIPTION
Regression from #344: importing `coseToP256XY` from the root `@aastar/sdk` pulled in the server bundle (`import * as fs from 'fs'`), which Turbopack can't resolve in a client component → `/dashboard` 500 ("Can't resolve 'fs'").

Fix: import from the browser-safe pure-crypto subpath `@aastar/sdk/core`.

Verified: `type-check` ✅, `/dashboard` now compiles (200).