### PR TITLE
feat(auth/ui): graceful passkey-login errors + hide EntryPoint v0.6

### DIFF
--- a/aastar-frontend/app/auth/login/page.tsx
+++ b/aastar-frontend/app/auth/login/page.tsx
@@ -57,12 +57,38 @@ export default function LoginPage() {
       router.push("/dashboard");
     } catch (error: any) {
       if (t) toast.dismiss(t);
-      if (error?.name === "NotAllowedError") {
-        toast.error("Authentication was cancelled.");
-      } else if (error?.response?.data?.message) {
-        toast.error(error.response.data.message);
+
+      const httpMsg: string | undefined = error?.response?.data?.message;
+      const status: number | undefined = error?.response?.status;
+      // Recoverable failures → guide the user to the email-code path (which both
+      // registers and logs in), pre-filling their email so it's one tap away.
+      const offerEmailCode = (msg: string) => {
+        toast.error(msg, { duration: 6000 });
+        setOtpEmail(email.trim());
+        setOtpStep("email");
+        setLoginMode("otp");
+      };
+
+      if (status === 404 || /user not found/i.test(httpMsg || "")) {
+        offerEmailCode(
+          "No account exists for this email yet. Sign in with an email code — it creates your account."
+        );
+      } else if (/no wallet|not initialized|passkey first/i.test(httpMsg || "")) {
+        offerEmailCode(
+          "This account hasn't set up a passkey yet. Sign in with an email code, then add a passkey."
+        );
+      } else if (error?.name === "NotAllowedError" || error?.name === "AbortError") {
+        // WebAuthn found no matching passkey on THIS device, or the prompt was dismissed —
+        // the two are indistinguishable in the spec, so cover both and offer the fallback.
+        offerEmailCode(
+          "No matching passkey on this device (or the prompt was dismissed). If you created it on another device, turn on iCloud Keychain / Google Password Manager sync — or just sign in with an email code."
+        );
+      } else if (status === 401 || /verification failed/i.test(httpMsg || "")) {
+        offerEmailCode(
+          "Passkey verification failed. You can sign in with an email code instead."
+        );
       } else {
-        toast.error(error.message || "Authentication failed");
+        toast.error(httpMsg || error?.message || "Sign-in failed. Try an email code instead.");
       }
     } finally {
       setLoading(false);

--- a/aastar-frontend/components/EntryPointVersionSelector.tsx
+++ b/aastar-frontend/components/EntryPointVersionSelector.tsx
@@ -9,13 +9,15 @@ interface EntryPointVersionSelectorProps {
   showDescription?: boolean;
 }
 
-const versionInfo = {
-  [EntryPointVersion.V0_6]: {
-    label: "v0.6",
-    description: "Original ERC-4337 implementation with standard UserOperation format",
-    badge: "Stable",
-    badgeColor: "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400",
-  },
+// Only versions listed here are shown. v0.6 is hidden by default (uncomment to
+// re-enable when needed); new accounts default to v0.7.
+const versionInfo: Partial<Record<EntryPointVersion, { label: string; description: string; badge: string; badgeColor: string }>> = {
+  // [EntryPointVersion.V0_6]: {
+  //   label: "v0.6",
+  //   description: "Original ERC-4337 implementation with standard UserOperation format",
+  //   badge: "Stable",
+  //   badgeColor: "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400",
+  // },
   [EntryPointVersion.V0_7]: {
     label: "v0.7",
     description: "Optimized with PackedUserOperation format and improved gas efficiency",
@@ -49,8 +51,8 @@ export default function EntryPointVersionSelector({
       )}
 
       <div className="grid grid-cols-1 gap-2">
-        {Object.values(EntryPointVersion).map(version => {
-          const info = versionInfo[version];
+        {(Object.keys(versionInfo) as EntryPointVersion[]).map(version => {
+          const info = versionInfo[version]!;
           const isSelected = value === version;
 
           return (


### PR DESCRIPTION
## Passkey login error handling
Previously *any* passkey-login failure showed "Authentication was cancelled." — misleading when the real cause is e.g. **no matching passkey on this device** (which is exactly what happened for an account registered/synced elsewhere).

Now each case is detected and the UI **auto-falls back to email-code sign-in** (pre-filling the email):
| Case | Message |
|---|---|
| No account (404 / "user not found") | sign in with an email code — it creates your account |
| Account has no passkey wallet | use an email code, then add a passkey |
| `NotAllowedError`/`AbortError` (no passkey on this device, or dismissed) | explains + suggests iCloud/Google sync, or email code |
| Verification failed | offer email code |

## Hide EntryPoint v0.6
Per request: only v0.7 shows by default (v0.6 kept commented for easy re-enable); selector renders only configured versions.

type-check ✅