### PR TITLE
refactor(config): source contract addresses from @aastar/sdk, not .env

### DIFF
--- a/aastar/.env.example
+++ b/aastar/.env.example
@@ -11,14 +11,10 @@ CHAIN_ID=11155111
 ETH_RPC_URL=https://eth-sepolia.g.alchemy.com/v2/<YOUR_ALCHEMY_KEY>
 BUNDLER_RPC_URL=https://api.pimlico.io/v2/11155111/rpc?apikey=<YOUR_PIMLICO_KEY>
 
-# EntryPoint v0.7 (primary)
-ENTRY_POINT_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
-ENTRY_POINT_V7_ADDRESS=0x0000000071727De22E5E9d8BAf0edAc6f37da032
-# Canonical Sepolia v0.7 deployment (must match @aastar/sdk CANONICAL_ADDRESSES —
-# stale factory/validator here causes factory getAddress() to revert on create).
-AASTAR_ACCOUNT_FACTORY_V7_ADDRESS=0x99C9300d52EDD9f4B7135DEd1811fBa6FFa1DDC6
-VALIDATOR_CONTRACT_V7_ADDRESS=0xfcDfd17a373E037c3F9C8ffE2c781915E7Ae6e11
-DEFAULT_ENTRYPOINT_VERSION=0.7
+# EntryPoint / account factory / validator addresses are NO LONGER configured here.
+# They are sourced at runtime from the @aastar/sdk canonical table (sepoliaV07Config)
+# so they always match the installed SDK version. Bump @aastar/sdk to get new
+# deployments — never hardcode contract addresses in env.
 
 BLS_SEED_NODES=https://v1.aastar.io
 

--- a/aastar/src/config/configuration.ts
+++ b/aastar/src/config/configuration.ts
@@ -15,25 +15,9 @@ export default () => {
     throw new Error('DATABASE_URL is required when DB_TYPE is "postgres"');
   }
 
-  // Check if at least one EntryPoint version is configured
-  const hasV6Config =
-    process.env.ENTRY_POINT_ADDRESS &&
-    process.env.AASTAR_ACCOUNT_FACTORY_ADDRESS &&
-    process.env.VALIDATOR_CONTRACT_ADDRESS;
-
-  const hasV7Config =
-    process.env.ENTRY_POINT_V7_ADDRESS &&
-    process.env.AASTAR_ACCOUNT_FACTORY_V7_ADDRESS &&
-    process.env.VALIDATOR_CONTRACT_V7_ADDRESS;
-
-  const hasV8Config =
-    process.env.ENTRY_POINT_V8_ADDRESS &&
-    process.env.AASTAR_ACCOUNT_FACTORY_V8_ADDRESS &&
-    process.env.VALIDATOR_CONTRACT_V8_ADDRESS;
-
-  if (!hasV6Config && !hasV7Config && !hasV8Config) {
-    throw new Error("At least one EntryPoint version must be configured");
-  }
+  // EntryPoint / factory / validator addresses are sourced from the @aastar/sdk
+  // canonical table (sepoliaV07Config) in sdk.providers.ts — NOT from .env — so
+  // there is nothing to validate here.
 
   console.log("✅ Environment configuration validated successfully");
 
@@ -54,20 +38,8 @@ export default () => {
     ethPrivateKey: process.env.ETH_PRIVATE_KEY,
     resendApiKey: process.env.RESEND_API_KEY,
     emailFrom: process.env.EMAIL_FROM || "hi@aastar.io",
-    // v0.6 configuration (backward compatibility)
-    entryPointAddress: process.env.ENTRY_POINT_ADDRESS,
-    aastarAccountFactoryAddress: process.env.AASTAR_ACCOUNT_FACTORY_ADDRESS,
-    validatorContractAddress: process.env.VALIDATOR_CONTRACT_ADDRESS,
-    // v0.7 configuration
-    entryPointV7Address: process.env.ENTRY_POINT_V7_ADDRESS,
-    aastarAccountFactoryV7Address: process.env.AASTAR_ACCOUNT_FACTORY_V7_ADDRESS,
-    validatorContractV7Address: process.env.VALIDATOR_CONTRACT_V7_ADDRESS,
-    // v0.8 configuration
-    entryPointV8Address: process.env.ENTRY_POINT_V8_ADDRESS,
-    aastarAccountFactoryV8Address: process.env.AASTAR_ACCOUNT_FACTORY_V8_ADDRESS,
-    validatorContractV8Address: process.env.VALIDATOR_CONTRACT_V8_ADDRESS,
-    // Default version (can be overridden per account)
-    defaultEntryPointVersion: process.env.DEFAULT_ENTRYPOINT_VERSION || "0.6",
+    // EntryPoint / factory / validator addresses are NOT configured here — they come
+    // from the @aastar/sdk canonical table (sepoliaV07Config) in sdk.providers.ts.
     blsSeedNodes: process.env.BLS_SEED_NODES,
     chainId: parseInt(process.env.CHAIN_ID, 10) || 10,
     // Single source for the operations-portal chain (registry/admin/operator/community).

--- a/aastar/src/config/env.config.ts
+++ b/aastar/src/config/env.config.ts
@@ -21,13 +21,10 @@ export interface EnvironmentConfig {
   webauthnRpId: string;
   webauthnOrigin: string;
 
-  // Ethereum & Contracts
+  // Ethereum (contract addresses come from @aastar/sdk canonical table, not env)
   ethRpcUrl: string;
   bundlerRpcUrl: string;
   ethPrivateKey?: string;
-  entryPointAddress: string;
-  aastarAccountFactoryAddress: string;
-  validatorContractAddress: string;
 
   // BLS Network (Optional)
   blsSeedNodes?: string;
@@ -70,9 +67,6 @@ export class EnvConfigService {
       ethRpcUrl: this.configService.get<string>("ETH_RPC_URL"),
       bundlerRpcUrl: this.configService.get<string>("BUNDLER_RPC_URL"),
       ethPrivateKey: this.configService.get<string>("ETH_PRIVATE_KEY"),
-      entryPointAddress: this.configService.get<string>("ENTRY_POINT_ADDRESS"),
-      aastarAccountFactoryAddress: this.configService.get<string>("AASTAR_ACCOUNT_FACTORY_ADDRESS"),
-      validatorContractAddress: this.configService.get<string>("VALIDATOR_CONTRACT_ADDRESS"),
 
       // BLS Network (Optional)
       blsSeedNodes: this.configService.get<string>("BLS_SEED_NODES"),
@@ -99,18 +93,6 @@ export class EnvConfigService {
 
     if (!config.bundlerRpcUrl) {
       errors.push("BUNDLER_RPC_URL is required");
-    }
-
-    if (!config.entryPointAddress) {
-      errors.push("ENTRY_POINT_ADDRESS is required");
-    }
-
-    if (!config.aastarAccountFactoryAddress) {
-      errors.push("AASTAR_ACCOUNT_FACTORY_ADDRESS is required");
-    }
-
-    if (!config.validatorContractAddress) {
-      errors.push("VALIDATOR_CONTRACT_ADDRESS is required");
     }
 
     // Validate database configuration

--- a/aastar/src/sdk/sdk.providers.ts
+++ b/aastar/src/sdk/sdk.providers.ts
@@ -1,6 +1,10 @@
 import { Provider } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { AirAccountServerClient as YAAAServerClient, ServerConfig } from "@aastar/sdk/kms";
+import {
+  AirAccountServerClient as YAAAServerClient,
+  ServerConfig,
+  sepoliaV07Config,
+} from "@aastar/sdk/kms";
 import { BackendStorageAdapter } from "./backend-storage.adapter";
 import { BackendSignerAdapter } from "./backend-signer.adapter";
 
@@ -13,43 +17,11 @@ export const yaaaServerClientProvider: Provider = {
     storageAdapter: BackendStorageAdapter,
     signerAdapter: BackendSignerAdapter
   ): YAAAServerClient => {
-    const entryPoints: ServerConfig["entryPoints"] = {};
-
-    // V0.6
-    const epV6 = configService.get<string>("entryPointAddress");
-    const factoryV6 = configService.get<string>("aastarAccountFactoryAddress");
-    const validatorV6 = configService.get<string>("validatorContractAddress");
-    if (epV6 && factoryV6 && validatorV6) {
-      entryPoints.v06 = {
-        entryPointAddress: epV6,
-        factoryAddress: factoryV6,
-        validatorAddress: validatorV6,
-      };
-    }
-
-    // V0.7
-    const epV7 = configService.get<string>("entryPointV7Address");
-    const factoryV7 = configService.get<string>("aastarAccountFactoryV7Address");
-    const validatorV7 = configService.get<string>("validatorContractV7Address");
-    if (epV7 && factoryV7 && validatorV7) {
-      entryPoints.v07 = {
-        entryPointAddress: epV7,
-        factoryAddress: factoryV7,
-        validatorAddress: validatorV7,
-      };
-    }
-
-    // V0.8
-    const epV8 = configService.get<string>("entryPointV8Address");
-    const factoryV8 = configService.get<string>("aastarAccountFactoryV8Address");
-    const validatorV8 = configService.get<string>("validatorContractV8Address");
-    if (epV8 && factoryV8 && validatorV8) {
-      entryPoints.v08 = {
-        entryPointAddress: epV8,
-        factoryAddress: factoryV8,
-        validatorAddress: validatorV8,
-      };
-    }
+    // Contract addresses come straight from the SDK's canonical table
+    // (sepoliaV07Config) — NEVER hardcoded/maintained in YAA. v0.7 is the only
+    // supported version. This is the single source of truth; updating the SDK
+    // picks up new deployments automatically.
+    const entryPoints: ServerConfig["entryPoints"] = { v07: sepoliaV07Config() };
 
     // BLS seed nodes
     const blsSeedNodesStr =
@@ -57,8 +29,8 @@ export const yaaaServerClientProvider: Provider = {
     const blsSeedNodes = blsSeedNodesStr ? blsSeedNodesStr.split(",").map(s => s.trim()) : [];
 
     // Default version mapping
-    const defaultVersionRaw = configService.get<string>("defaultEntryPointVersion") || "0.6";
-    const defaultVersion = defaultVersionRaw as "0.6" | "0.7" | "0.8";
+    // Only v0.7 is wired (addresses from the SDK canonical table).
+    const defaultVersion = "0.7" as "0.6" | "0.7" | "0.8";
 
     const serverConfig: ServerConfig = {
       rpcUrl: configService.get<string>("ethRpcUrl"),


### PR DESCRIPTION
Follow-up to #346. Stop hardcoding/maintaining EntryPoint/factory/validator in env — source them from the SDK canonical table (`sepoliaV07Config()`) so they always match the installed `@aastar/sdk` and can't go stale (that staleness caused the create-500).

- **sdk.providers.ts**: `entryPoints = { v07: sepoliaV07Config() }`, default version 0.7. Dropped the per-version .env address reads (v0.6/0.7/0.8).
- **configuration.ts**: removed the entrypoint/factory/validator fields and the 'at least one EntryPoint version must be configured' startup check.
- **env.config.ts**: removed ENTRY_POINT_ADDRESS / AASTAR_ACCOUNT_FACTORY_ADDRESS / VALIDATOR_CONTRACT_ADDRESS fields + their required-validation.
- **.env.example**: removed the address lines (documented they now come from the SDK).

Verified: backend boots clean, `create-with-p256-guardians` and `GET /account` both work with addresses now coming from the SDK (factory 0x99C9300d…, validator 0xfcDfd17a…).

Note: this covers the account-creation trio. Other service addresses (registry / paymaster / xPNTs factory etc.) still read from env — a separate follow-up can move those to the SDK canonical table too.