### PR TITLE
fix(dashboard): stale 'no account' cache hid a created account (kept showing Create)

### DIFF
--- a/aastar-frontend/contexts/DashboardContext.tsx
+++ b/aastar-frontend/contexts/DashboardContext.tsx
@@ -52,7 +52,16 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(() => {
     if (typeof window !== "undefined") {
-      return sessionStorage.getItem("dashboardDataLoaded") === "true";
+      // Only treat the cache as authoritative if it actually has an account. A cached
+      // "no account yet" state must NOT short-circuit the fetch — otherwise an account
+      // created after that cache (e.g. via create-with-guardians) never shows up until
+      // the session is cleared.
+      if (sessionStorage.getItem("dashboardDataLoaded") !== "true") return false;
+      try {
+        return !!JSON.parse(sessionStorage.getItem("dashboardData") || "{}").account;
+      } catch {
+        return false;
+      }
     }
     return false;
   });
@@ -161,10 +170,20 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           lastUpdated: new Date(),
         };
         setData(newData);
-        setHasLoaded(true);
-        if (typeof window !== "undefined") {
-          sessionStorage.setItem("dashboardDataLoaded", "true");
-          sessionStorage.setItem("dashboardData", JSON.stringify(newData));
+        // Only cache as "loaded" once an account exists; never make a no-account
+        // state sticky (so a freshly-created account is picked up on the next load).
+        if (accountData) {
+          setHasLoaded(true);
+          if (typeof window !== "undefined") {
+            sessionStorage.setItem("dashboardDataLoaded", "true");
+            sessionStorage.setItem("dashboardData", JSON.stringify(newData));
+          }
+        } else {
+          setHasLoaded(false);
+          if (typeof window !== "undefined") {
+            sessionStorage.removeItem("dashboardDataLoaded");
+            sessionStorage.removeItem("dashboardData");
+          }
         }
       } catch (error) {
         console.error("Failed to load dashboard data:", error);


### PR DESCRIPTION
## Symptom
Logged in as firsttorch66 (whose account **exists** in the DB — `GET /account` returns it, `0x299b…`, 2 guardians), but the dashboard still showed **Create account**, and clicking it opened an empty dialog.

## Cause
`DashboardContext` caches `dashboardData` (including `account: null`) in `sessionStorage` and sets `hasLoaded=true`, then `loadDashboardData` short-circuits (`hasLoaded && !force`). So a "no account yet" snapshot taken earlier (when every create was failing) became sticky for the whole browser session — an account created afterwards (server-side, or once create started working) was never re-fetched.

## Fix
- `hasLoaded` initialises `true` only when the cached snapshot actually has an `account`.
- Never persist / mark-loaded a null-account result.

Net: a freshly-created account shows up on the next dashboard load; backend was always correct (`GET /account` 200). Reload the dashboard to pick it up.