### PR TITLE
feat(paymaster): recommended presets (PaymasterV4 + SuperPaymaster) sourced from SDK

### DIFF
--- a/aastar-frontend/app/paymaster/page.tsx
+++ b/aastar-frontend/app/paymaster/page.tsx
@@ -12,8 +12,20 @@ interface Paymaster {
   configured: boolean;
 }
 
+interface PaymasterPreset {
+  name: string;
+  address: string;
+  type: "custom";
+  recommended: boolean;
+  requiresCommunity: boolean;
+  gasToken: string;
+  gasTokenAddress: string | null;
+  description: string;
+}
+
 export default function PaymasterPage() {
   const [paymasters, setPaymasters] = useState<Paymaster[]>([]);
+  const [presets, setPresets] = useState<PaymasterPreset[]>([]);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string>("");
   const [showAddForm, setShowAddForm] = useState(false);
@@ -32,13 +44,38 @@ export default function PaymasterPage() {
   const loadPaymasters = async () => {
     setLoading(true);
     try {
-      const response = await paymasterAPI.getAvailable();
-      setPaymasters(response.data);
+      const [available, presetList] = await Promise.all([
+        paymasterAPI.getAvailable(),
+        paymasterAPI.getPresets().catch(() => ({ data: [] })),
+      ]);
+      setPaymasters(available.data);
+      setPresets(presetList.data);
     } catch (error) {
       console.error("Failed to load paymasters:", error);
       toast.error("Failed to load paymasters");
     } finally {
       setLoading(false);
+    }
+  };
+
+  // Add a recommended preset (address comes from the SDK canonical table).
+  const handleAddPreset = async (preset: PaymasterPreset) => {
+    setActionLoading(`preset-${preset.name}`);
+    try {
+      await paymasterAPI.addCustom({
+        name: preset.name,
+        address: preset.address,
+        type: preset.type,
+      });
+      toast.success(`${preset.name} added`);
+      await loadPaymasters();
+    } catch (error) {
+      const message =
+        (error as { response?: { data?: { message?: string } } }).response?.data?.message ||
+        `Failed to add ${preset.name}`;
+      toast.error(message);
+    } finally {
+      setActionLoading("");
     }
   };
 
@@ -147,6 +184,75 @@ export default function PaymasterPage() {
           >
             <PlusIcon className="w-6 h-6" />
           </button>
+        )}
+
+        {/* Recommended presets (addresses from the SDK) */}
+        {presets.length > 0 && (
+          <div className="mb-6">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+              Recommended
+            </h2>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+              Gas sponsorship options. Addresses are provided by the AAStar SDK.
+            </p>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              {presets.map(preset => {
+                const added = paymasters.some(
+                  p => p.address.toLowerCase() === preset.address.toLowerCase()
+                );
+                return (
+                  <div
+                    key={preset.address}
+                    className={`rounded-xl border p-4 flex flex-col ${
+                      preset.recommended
+                        ? "border-emerald-400 bg-emerald-50 dark:bg-emerald-900/20"
+                        : "border-amber-300 bg-amber-50 dark:bg-amber-900/20"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold text-gray-900 dark:text-white">
+                        {preset.name}
+                      </span>
+                      {preset.recommended ? (
+                        <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-emerald-600 text-white">
+                          Recommended
+                        </span>
+                      ) : (
+                        <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full bg-amber-500 text-white">
+                          Needs community points
+                        </span>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">
+                      Pay gas with <span className="font-medium">{preset.gasToken}</span>
+                    </p>
+                    <p className="mt-2 text-xs leading-relaxed text-gray-600 dark:text-gray-400 flex-1">
+                      {preset.description}
+                    </p>
+                    <p className="mt-2 text-[11px] font-mono text-gray-400 break-all">
+                      {preset.address}
+                    </p>
+                    <button
+                      type="button"
+                      disabled={added || actionLoading === `preset-${preset.name}`}
+                      onClick={() => handleAddPreset(preset)}
+                      className={`mt-3 inline-flex items-center justify-center rounded-lg px-3 py-2 text-sm font-semibold transition disabled:opacity-60 ${
+                        preset.recommended
+                          ? "bg-emerald-600 text-white hover:bg-emerald-500"
+                          : "bg-amber-500 text-white hover:bg-amber-400"
+                      }`}
+                    >
+                      {added
+                        ? "✓ Added"
+                        : actionLoading === `preset-${preset.name}`
+                          ? "Adding…"
+                          : "Add"}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         )}
 
         {/* Add Paymaster Form */}

--- a/aastar-frontend/lib/api.ts
+++ b/aastar-frontend/lib/api.ts
@@ -134,6 +134,9 @@ export const blsAPI = {
 export const paymasterAPI = {
   getAvailable: () => api.get("/paymaster/available"),
 
+  // Recommended presets (addresses sourced from @aastar/sdk canonical table)
+  getPresets: () => api.get("/paymaster/presets"),
+
   sponsor: (data: { paymasterName: string; userOp: any; entryPoint?: string }) =>
     api.post("/paymaster/sponsor", data),
 

--- a/aastar/src/paymaster/paymaster.controller.ts
+++ b/aastar/src/paymaster/paymaster.controller.ts
@@ -32,6 +32,15 @@ export class PaymasterController {
     return this.paymasterService.getAvailablePaymasters(userId);
   }
 
+  @Get("presets")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Recommended paymaster presets (addresses from @aastar/sdk)" })
+  @ApiResponse({ status: 200, description: "AAStar PaymasterV4 + SuperPaymaster presets" })
+  getPaymasterPresets() {
+    return this.paymasterService.getPaymasterPresets();
+  }
+
   @Post("sponsor")
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()

--- a/aastar/src/paymaster/paymaster.service.ts
+++ b/aastar/src/paymaster/paymaster.service.ts
@@ -2,7 +2,19 @@ import { Injectable, Inject } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
 import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
+import { getCanonicalAddresses } from "@aastar/sdk/core";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
+
+export interface PaymasterPreset {
+  name: string;
+  address: string;
+  type: "custom";
+  recommended: boolean;
+  requiresCommunity: boolean;
+  gasToken: string;
+  gasTokenAddress: string | null;
+  description: string;
+}
 
 @Injectable()
 export class PaymasterService {
@@ -22,6 +34,47 @@ export class PaymasterService {
     userId: string
   ): Promise<{ name: string; address: string; configured: boolean }[]> {
     return this.client.paymaster.getAvailablePaymasters(userId);
+  }
+
+  /**
+   * Recommended paymaster presets, addresses sourced from the @aastar/sdk canonical
+   * table (never hardcoded). Two options:
+   *  - AAStar PaymasterV4: official, pay gas with aPNTs, no community needed.
+   *  - SuperPaymaster: pay gas with community points (xPNTs) — requires joining a
+   *    community + earning points, so it's unusable without them.
+   */
+  getPaymasterPresets(): PaymasterPreset[] {
+    const chainId = this.configService.get<number>("chainId") || 11155111;
+    const a = getCanonicalAddresses(chainId) as Record<string, string> | undefined;
+    if (!a) return [];
+    const presets: PaymasterPreset[] = [];
+    if (a.paymasterV4) {
+      presets.push({
+        name: "AAStar PaymasterV4",
+        address: a.paymasterV4,
+        type: "custom",
+        recommended: true,
+        requiresCommunity: false,
+        gasToken: "aPNTs",
+        gasTokenAddress: a.aPNTs ?? null,
+        description:
+          "Official AAStar-operated paymaster. Buy aPNTs and it sponsors your gas — available to everyone (you're in the default AAStar community by default). No community membership or points required.",
+      });
+    }
+    if (a.superPaymaster) {
+      presets.push({
+        name: "SuperPaymaster",
+        address: a.superPaymaster,
+        type: "custom",
+        recommended: false,
+        requiresCommunity: true,
+        gasToken: "xPNTs (community points)",
+        gasTokenAddress: null,
+        description:
+          "Pay gas with community points (xPNTs). Requires joining a community and earning points by completing community tasks — it will not work until you hold that community's points.",
+      });
+    }
+    return presets;
   }
 
   async addCustomPaymaster(


### PR DESCRIPTION
## What
`/paymaster` now shows a **Recommended** section with two one-tap presets — addresses from the `@aastar/sdk` canonical table (`getCanonicalAddresses(chainId)`), not hardcoded:

| Preset | Gas token | Requirement |
|---|---|---|
| **AAStar PaymasterV4** (recommended) | aPNTs | None — everyone can use it (default AAStar community). Buy aPNTs → gas sponsored. |
| **SuperPaymaster** | xPNTs (community points) | Must join a community + earn points via tasks; the card says so and it won't work without points. |

## How
- Backend `GET /paymaster/presets` → `PaymasterService.getPaymasterPresets()` reads `paymasterV4` / `superPaymaster` / `aPNTs` from the SDK canonical table for the configured chain.
- Frontend renders preset cards (explanation + gas token + address + Add button; reuses `addCustom`, shows ✓ Added if already configured).

Verified: `GET /paymaster/presets` returns both with SDK addresses (PaymasterV4 `0x1f0D4eF…`, SuperPaymaster `0x030025f4…`). type-check ✅ (both).