### PR TITLE
fix(ui): use the 🍄 emoji SVG favicon on every page

### DIFF
--- a/aastar-frontend/app/icon.svg
+++ b/aastar-frontend/app/icon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="92">🍄</text></svg>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍄</text></svg>

--- a/aastar-frontend/app/layout.tsx
+++ b/aastar-frontend/app/layout.tsx
@@ -32,9 +32,10 @@ export const metadata: Metadata = {
     title: "AAStar",
   },
   icons: {
-    // 🍄 favicon comes from app/icon.svg (file convention); icon-512 for PWA/larger.
-    icon: [{ url: "/icon-512.png", sizes: "512x512", type: "image/png" }],
-    apple: [{ url: "/apple-icon.png", sizes: "180x180", type: "image/png" }],
+    // 🍄 emoji favicon (app/icon.svg) on every page — inline SVG, no raster asset.
+    icon: "/icon.svg",
+    shortcut: "/icon.svg",
+    apple: "/icon.svg",
   },
 };
 


### PR DESCRIPTION
metadata.icons.icon was overriding the app/icon.svg 🍄 emoji with the old mushroom PNG (/icon-512.png), so tabs showed the old mushroom. Point icon/shortcut/apple at /icon.svg (inline 🍄 emoji SVG) so all pages show the emoji favicon. app/icon.svg set to the exact inline SVG snippet.