### PR TITLE
feat(community): show official communities (AAStar + Mycelium) with name/token/owner from chain

### DIFF
--- a/aastar-frontend/app/community/page.tsx
+++ b/aastar-frontend/app/community/page.tsx
@@ -35,6 +35,7 @@ interface CommunityEntry {
   address: string;
   metadata: CommunityMeta | null;
   tokenAddress: string | null;
+  tokenInfo: TokenInfo | null;
 }
 
 interface Dashboard {
@@ -60,7 +61,10 @@ function resolveImageUrl(url: string): string {
 
 function CommunityCard({ entry }: { entry: CommunityEntry }) {
   const { t } = useTranslation();
-  const name = entry.metadata?.name || shortenAddr(entry.address);
+  // Name source priority: on-chain Registry metadata → token's communityName → address.
+  const name =
+    entry.metadata?.name || entry.tokenInfo?.communityName || shortenAddr(entry.address);
+  const ens = entry.metadata?.ensName;
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
       <div className="flex items-start gap-3">
@@ -79,14 +83,22 @@ function CommunityCard({ entry }: { entry: CommunityEntry }) {
         )}
         <div className="flex-1 min-w-0">
           <p className="font-semibold text-gray-900 dark:text-white truncate">{name}</p>
-          <p className="text-xs text-gray-500 font-mono">{shortenAddr(entry.address)}</p>
+          {ens && <p className="text-xs text-indigo-500 truncate">{ens}</p>}
+          <p className="text-xs text-gray-500 font-mono truncate">
+            owner {shortenAddr(entry.address)}
+          </p>
           {entry.metadata?.description && (
             <p className="text-xs text-gray-500 mt-1 line-clamp-2">{entry.metadata.description}</p>
           )}
         </div>
       </div>
-      <div className="mt-3 flex items-center gap-4 text-xs text-gray-500">
-        {entry.tokenAddress ? (
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500">
+        {entry.tokenInfo ? (
+          <span className="flex items-center gap-1 text-green-600 dark:text-green-400">
+            <CheckBadgeIcon className="h-4 w-4" />
+            {entry.tokenInfo.name} ({entry.tokenInfo.symbol})
+          </span>
+        ) : entry.tokenAddress ? (
           <span className="flex items-center gap-1 text-green-600 dark:text-green-400">
             <CheckBadgeIcon className="h-4 w-4" />
             {t("communityPage.card.tokenDeployed")}

--- a/aastar-frontend/app/icon.svg
+++ b/aastar-frontend/app/icon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="92">🍄</text></svg>
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍄</text></svg>

--- a/aastar-frontend/app/layout.tsx
+++ b/aastar-frontend/app/layout.tsx
@@ -32,9 +32,10 @@ export const metadata: Metadata = {
     title: "AAStar",
   },
   icons: {
-    // 🍄 favicon comes from app/icon.svg (file convention); icon-512 for PWA/larger.
-    icon: [{ url: "/icon-512.png", sizes: "512x512", type: "image/png" }],
-    apple: [{ url: "/apple-icon.png", sizes: "180x180", type: "image/png" }],
+    // 🍄 emoji favicon (app/icon.svg) on every page — inline SVG, no raster asset.
+    icon: "/icon.svg",
+    shortcut: "/icon.svg",
+    apple: "/icon.svg",
   },
 };
 

--- a/aastar/src/community/community.service.ts
+++ b/aastar/src/community/community.service.ts
@@ -213,15 +213,22 @@ export class CommunityService implements OnModuleInit {
       address: Address;
       metadata: Awaited<ReturnType<CommunityService["getCommunityMetadata"]>>;
       tokenAddress: Address | null;
+      tokenInfo: Awaited<ReturnType<CommunityService["getTokenInfo"]>> | null;
     }[]
   > {
     const members = await this.getCommunityAdmins();
     const results = await Promise.allSettled(
-      members.map(async addr => ({
-        address: addr,
-        metadata: await this.getCommunityMetadata(addr),
-        tokenAddress: await this.getDeployedTokenAddress(addr),
-      }))
+      members.map(async addr => {
+        const tokenAddress = await this.getDeployedTokenAddress(addr);
+        // Registry metadata (name/ENS/logo) is frequently unset on-chain; the token
+        // carries the authoritative community name + token name/symbol, so include it
+        // here as the display fallback (e.g. "AAStar", "Mycelium Community").
+        const [metadata, tokenInfo] = await Promise.all([
+          this.getCommunityMetadata(addr),
+          tokenAddress ? this.getTokenInfo(tokenAddress).catch(() => null) : Promise.resolve(null),
+        ]);
+        return { address: addr, metadata, tokenAddress, tokenInfo };
+      })
     );
     return results
       .filter(r => r.status === "fulfilled")


### PR DESCRIPTION
## What
`/community` now displays the two official communities with real names + tokens, all read on-chain via the SDK (no hardcoding):

| Community | Token | Owner |
|---|---|---|
| **AAStar** | AAStar PNTs (aPNTs) | 0xb560…0E |
| **Mycelium Community** | Mycelium PNTs (PNTs) | 0xEcAA…c9 |

## How
- Backend `getAllCommunities` now includes `tokenInfo` (communityName + token name/symbol + owner), read via the SDK `tokenActions`/`xPNTsFactoryActions` from the community's deployed token.
- Frontend card: name = Registry metadata → token `communityName` → address; shows token name+symbol, ENS (when set), and owner.

## Note (data not yet on-chain)
The Registry `CommunityRoleData` metadata (**ENS, IPFS logo, website, description**) is currently **null** on-chain for both — so those don't show yet. To display ENS/logo, that metadata needs to be registered on-chain (admin action) or exposed by the SDK. The community 'contract address' shown is the **admin/owner EOA** (later to be transferred to a multisig Safe), per design.