### PR TITLE
chore(ci): fix format:check + add backend e2e suite

### DIFF
--- a/aastar-frontend/app/auth/login/page.tsx
+++ b/aastar-frontend/app/auth/login/page.tsx
@@ -84,9 +84,7 @@ export default function LoginPage() {
           "No matching passkey on this device (or the prompt was dismissed). If you created it on another device, turn on iCloud Keychain / Google Password Manager sync — or just sign in with an email code."
         );
       } else if (status === 401 || /verification failed/i.test(httpMsg || "")) {
-        offerEmailCode(
-          "Passkey verification failed. You can sign in with an email code instead."
-        );
+        offerEmailCode("Passkey verification failed. You can sign in with an email code instead.");
       } else {
         toast.error(httpMsg || error?.message || "Sign-in failed. Try an email code instead.");
       }

--- a/aastar-frontend/app/community/page.tsx
+++ b/aastar-frontend/app/community/page.tsx
@@ -62,8 +62,7 @@ function resolveImageUrl(url: string): string {
 function CommunityCard({ entry }: { entry: CommunityEntry }) {
   const { t } = useTranslation();
   // Name source priority: on-chain Registry metadata → token's communityName → address.
-  const name =
-    entry.metadata?.name || entry.tokenInfo?.communityName || shortenAddr(entry.address);
+  const name = entry.metadata?.name || entry.tokenInfo?.communityName || shortenAddr(entry.address);
   const ens = entry.metadata?.ensName;
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-4">

--- a/aastar-frontend/components/EntryPointVersionSelector.tsx
+++ b/aastar-frontend/components/EntryPointVersionSelector.tsx
@@ -11,7 +11,12 @@ interface EntryPointVersionSelectorProps {
 
 // Only versions listed here are shown. v0.6 is hidden by default (uncomment to
 // re-enable when needed); new accounts default to v0.7.
-const versionInfo: Partial<Record<EntryPointVersion, { label: string; description: string; badge: string; badgeColor: string }>> = {
+const versionInfo: Partial<
+  Record<
+    EntryPointVersion,
+    { label: string; description: string; badge: string; badgeColor: string }
+  >
+> = {
   // [EntryPointVersion.V0_6]: {
   //   label: "v0.6",
   //   description: "Original ERC-4337 implementation with standard UserOperation format",

--- a/aastar-frontend/components/Layout.tsx
+++ b/aastar-frontend/components/Layout.tsx
@@ -149,86 +149,86 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
                   </button>
                   {avatarMenuOpen && (
                     <div className="absolute right-0 mt-2 w-64 rounded-xl shadow-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 z-50 py-1">
-                        {/* Account header */}
-                        <div className="flex items-center gap-3 px-4 py-3">
-                          <span className="flex items-center justify-center w-9 h-9 rounded-full bg-slate-900 dark:bg-emerald-600 text-white text-sm font-semibold shrink-0">
-                            {(user.username || user.email || "?").charAt(0).toUpperCase()}
-                          </span>
-                          <div className="min-w-0">
-                            <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
-                              {user.username || "Account"}
-                            </p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                              {user.email}
-                            </p>
-                          </div>
+                      {/* Account header */}
+                      <div className="flex items-center gap-3 px-4 py-3">
+                        <span className="flex items-center justify-center w-9 h-9 rounded-full bg-slate-900 dark:bg-emerald-600 text-white text-sm font-semibold shrink-0">
+                          {(user.username || user.email || "?").charAt(0).toUpperCase()}
+                        </span>
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+                            {user.username || "Account"}
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                            {user.email}
+                          </p>
                         </div>
+                      </div>
 
-                        {[
-                          {
-                            title: "Profile",
-                            items: [
-                              { label: "Dashboard", path: "/dashboard", Icon: HomeIcon },
-                              { label: "My Role", path: "/role", Icon: ShieldCheckIcon },
-                              { label: "Transfer", path: "/transfer", Icon: PaperAirplaneIcon },
-                              { label: "Recovery", path: "/recovery", Icon: ShieldCheckIcon },
-                              { label: "Tasks", path: "/tasks", Icon: ClipboardDocumentListIcon },
-                            ],
-                          },
-                          {
-                            title: "Organizations",
-                            items: [
-                              { label: "Community", path: "/community", Icon: UserGroupIcon },
-                              { label: "Operator", path: "/operator", Icon: ServerStackIcon },
-                              { label: "Protocol", path: "/admin", Icon: Cog6ToothIcon },
-                              { label: "Tokens", path: "/tokens", Icon: CreditCardIcon },
-                              { label: "Paymasters", path: "/paymaster", Icon: WalletIcon },
-                            ],
-                          },
-                          {
-                            title: "Settings",
-                            items: [
-                              { label: "Tokens", path: "/tokens", Icon: WalletIcon },
-                              { label: "NFTs", path: "/nfts", Icon: BookOpenIcon },
-                              { label: "Address Book", path: "/address-book", Icon: BookOpenIcon },
-                            ],
-                          },
-                        ].map(group => (
-                          <div
-                            key={group.title}
-                            className="border-t border-gray-100 dark:border-gray-700 py-1"
-                          >
-                            <p className="px-4 pt-1 pb-0.5 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
-                              {group.title}
-                            </p>
-                            {group.items.map(item => {
-                              const Icon = item.Icon;
-                              return (
-                                <button
-                                  key={item.path}
-                                  onClick={() => {
-                                    router.push(item.path);
-                                    setAvatarMenuOpen(false);
-                                  }}
-                                  className="flex items-center w-full px-4 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
-                                >
-                                  <Icon className="w-4 h-4 mr-3 text-gray-400" />
-                                  {item.label}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        ))}
-
-                        <div className="border-t border-gray-100 dark:border-gray-700 mt-1 pt-1">
-                          <button
-                            onClick={handleLogout}
-                            className="flex items-center w-full px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
-                          >
-                            <ChevronRightIcon className="w-4 h-4 mr-3" />
-                            Sign out
-                          </button>
+                      {[
+                        {
+                          title: "Profile",
+                          items: [
+                            { label: "Dashboard", path: "/dashboard", Icon: HomeIcon },
+                            { label: "My Role", path: "/role", Icon: ShieldCheckIcon },
+                            { label: "Transfer", path: "/transfer", Icon: PaperAirplaneIcon },
+                            { label: "Recovery", path: "/recovery", Icon: ShieldCheckIcon },
+                            { label: "Tasks", path: "/tasks", Icon: ClipboardDocumentListIcon },
+                          ],
+                        },
+                        {
+                          title: "Organizations",
+                          items: [
+                            { label: "Community", path: "/community", Icon: UserGroupIcon },
+                            { label: "Operator", path: "/operator", Icon: ServerStackIcon },
+                            { label: "Protocol", path: "/admin", Icon: Cog6ToothIcon },
+                            { label: "Tokens", path: "/tokens", Icon: CreditCardIcon },
+                            { label: "Paymasters", path: "/paymaster", Icon: WalletIcon },
+                          ],
+                        },
+                        {
+                          title: "Settings",
+                          items: [
+                            { label: "Tokens", path: "/tokens", Icon: WalletIcon },
+                            { label: "NFTs", path: "/nfts", Icon: BookOpenIcon },
+                            { label: "Address Book", path: "/address-book", Icon: BookOpenIcon },
+                          ],
+                        },
+                      ].map(group => (
+                        <div
+                          key={group.title}
+                          className="border-t border-gray-100 dark:border-gray-700 py-1"
+                        >
+                          <p className="px-4 pt-1 pb-0.5 text-[11px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                            {group.title}
+                          </p>
+                          {group.items.map(item => {
+                            const Icon = item.Icon;
+                            return (
+                              <button
+                                key={item.path}
+                                onClick={() => {
+                                  router.push(item.path);
+                                  setAvatarMenuOpen(false);
+                                }}
+                                className="flex items-center w-full px-4 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
+                              >
+                                <Icon className="w-4 h-4 mr-3 text-gray-400" />
+                                {item.label}
+                              </button>
+                            );
+                          })}
                         </div>
+                      ))}
+
+                      <div className="border-t border-gray-100 dark:border-gray-700 mt-1 pt-1">
+                        <button
+                          onClick={handleLogout}
+                          className="flex items-center w-full px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-slate-50 dark:hover:bg-gray-700 transition-colors"
+                        >
+                          <ChevronRightIcon className="w-4 h-4 mr-3" />
+                          Sign out
+                        </button>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -235,10 +235,7 @@ export class AccountService {
     } catch (err: any) {
       // Surface the real SDK/KMS/on-chain failure (otherwise it bubbles up as an
       // opaque 500). Includes the KMS "No pending challenge" challenge-binding case.
-      this.logger.error(
-        `createWithP256Guardians FAILED: ${err?.message ?? err}`,
-        err?.stack
-      );
+      this.logger.error(`createWithP256Guardians FAILED: ${err?.message ?? err}`, err?.stack);
       throw err;
     }
   }

--- a/aastar/test/app.e2e-spec.ts
+++ b/aastar/test/app.e2e-spec.ts
@@ -1,0 +1,74 @@
+/* global fetch */
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { Test } from "@nestjs/testing";
+import { AppModule } from "../src/app.module";
+
+// The canonical Sepolia PaymasterV4 (aPNTs gas token) from @aastar/sdk@0.26.x.
+// Asserting it here guards against the stale 0x1f0D… address regression (PR #357).
+const CANONICAL_PAYMASTER_V4 = "0x957852251f44570dc2B60Dde0954f191FF3372eE";
+
+describe("App e2e (HTTP layer)", () => {
+  let app: INestApplication;
+  let baseUrl: string;
+  let token: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    // Mirror main.ts so the test exercises the real prefix + validation pipeline.
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true })
+    );
+    app.setGlobalPrefix("api/v1");
+    await app.listen(0); // ephemeral port
+    baseUrl = await app.getUrl();
+    // Sign with the app's own JwtService so the token matches what JwtStrategy verifies.
+    token = app
+      .get(JwtService, { strict: false })
+      .sign({ sub: "e2e", email: "e2e@test.local", username: "e2e" });
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  const get = (path: string, auth = false): Promise<Response> =>
+    fetch(
+      `${baseUrl}/api/v1${path}`,
+      auth ? { headers: { Authorization: `Bearer ${token}` } } : undefined
+    );
+  const post = (path: string, auth = false): Promise<Response> =>
+    fetch(`${baseUrl}/api/v1${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(auth ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: "{}",
+    });
+
+  describe("JwtAuthGuard rejects unauthenticated requests", () => {
+    it("GET /paymaster/presets without a token → 401", async () => {
+      expect((await get("/paymaster/presets")).status).toBe(401);
+    });
+    it("POST /transfer/prepare without a token → 401", async () => {
+      expect((await post("/transfer/prepare")).status).toBe(401);
+    });
+    it("POST /transfer/submit without a token → 401", async () => {
+      expect((await post("/transfer/submit")).status).toBe(401);
+    });
+  });
+
+  describe("paymaster presets are sourced from the SDK canonical table", () => {
+    it("returns PaymasterV4 at the 0.26.x canonical Sepolia address", async () => {
+      const res = await get("/paymaster/presets", true);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{ name: string; address: string }>;
+      expect(Array.isArray(body)).toBe(true);
+      const v4 = body.find(p => /PaymasterV4/i.test(p.name));
+      expect(v4).toBeDefined();
+      expect(String(v4!.address).toLowerCase()).toBe(CANONICAL_PAYMASTER_V4.toLowerCase());
+    });
+  });
+});

--- a/aastar/test/jest-e2e.json
+++ b/aastar/test/jest-e2e.json
@@ -1,0 +1,31 @@
+{
+  "preset": "ts-jest",
+  "testEnvironment": "node",
+  "rootDir": "..",
+  "testRegex": ".e2e-spec.ts$",
+  "moduleFileExtensions": ["ts", "js", "json"],
+  "setupFiles": ["<rootDir>/test/setup-e2e.ts"],
+  "transform": {
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        "tsconfig": {
+          "target": "ES2020",
+          "module": "commonjs",
+          "strict": false,
+          "esModuleInterop": true,
+          "skipLibCheck": true,
+          "experimentalDecorators": true,
+          "emitDecoratorMetadata": true
+        }
+      }
+    ]
+  },
+  "transformIgnorePatterns": ["node_modules/(?!((@aastar|@yaaa)/))"],
+  "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^uuid$": "<rootDir>/test/uuid-stub.js"
+  },
+  "testTimeout": 60000,
+  "forceExit": true
+}

--- a/aastar/test/setup-e2e.ts
+++ b/aastar/test/setup-e2e.ts
@@ -1,0 +1,16 @@
+// Runs before the e2e test module is imported, so AppConfigModule's startup
+// validation sees a complete config. Real services are NOT hit: KMS is disabled,
+// the DB is the file-based JSON adapter, and the RPC/bundler URLs are dummies
+// (the routes under test — auth guards + SDK-canonical paymaster presets — make
+// no network calls). Any value already in the environment wins, so a developer
+// can point these at real services locally.
+process.env.NODE_ENV = process.env.NODE_ENV || "test";
+process.env.JWT_SECRET = process.env.JWT_SECRET || "e2e-test-jwt-secret-not-for-prod";
+// USER_ENCRYPTION_KEY must be exactly 32 chars (AES-256).
+process.env.USER_ENCRYPTION_KEY =
+  process.env.USER_ENCRYPTION_KEY || "0123456789abcdef0123456789abcdef";
+process.env.ETH_RPC_URL = process.env.ETH_RPC_URL || "http://127.0.0.1:8545";
+process.env.BUNDLER_RPC_URL = process.env.BUNDLER_RPC_URL || "http://127.0.0.1:8545";
+process.env.KMS_ENABLED = "false";
+process.env.DB_TYPE = process.env.DB_TYPE || "json";
+process.env.CHAIN_ID = process.env.CHAIN_ID || "11155111";

--- a/aastar/test/uuid-stub.js
+++ b/aastar/test/uuid-stub.js
@@ -1,0 +1,5 @@
+// CJS shim for the ESM-only `uuid` package so ts-jest (commonjs) can load the
+// full AppModule in e2e tests without transforming node_modules ESM. Backed by
+// Node's crypto.randomUUID — good enough for tests that don't assert on the id.
+const { randomUUID } = require("crypto");
+module.exports = { v4: () => randomUUID(), v1: () => randomUUID() };


### PR DESCRIPTION
Two CI/test-hygiene fixes found while running a full regression pass.

## 1. CI `Check formatting` was red on master
CI runs `format:check` per-workspace (aastar / aastar-frontend). 5 tracked files had whitespace/indent drift (no logic change) — mostly from my own earlier PRs not running prettier over the whole file (e.g. `Layout.tsx` indent left from removing the avatar-menu fragment in #355): `Layout.tsx`, `auth/login/page.tsx`, `community/page.tsx`, `EntryPointVersionSelector.tsx`, `account.service.ts`. `prettier --write` only — both workspaces now report *All matched files use Prettier code style!*.

## 2. `test:e2e` was a no-op — added a real e2e suite
The script pointed at a non-existent `./test/jest-e2e.json`. Added a self-contained NestJS e2e harness:
- **`test/jest-e2e.json`** — ts-jest config; `forceExit` (AuthService keeps a `setInterval`); `uuid` → CJS shim via moduleNameMapper (uuid v13 is ESM-only).
- **`test/setup-e2e.ts`** — minimal test env (KMS disabled, JSON DB, dummy RPC) so the real AppModule boots without external services; honours existing env.
- **`test/app.e2e-spec.ts`** — boots the full AppModule on an ephemeral port and asserts over real HTTP:
  1. `JwtAuthGuard` → 401 on `/paymaster/presets`, `/transfer/prepare`, `/transfer/submit` without a token.
  2. `/paymaster/presets` with a `JwtService`-signed token returns **PaymasterV4 at the canonical Sepolia address 0x957852…** — a regression lock on the SDK 0.26.x address fix (PR #357).

## Verification
- ✅ backend unit tests 34/34, **e2e 4/4**, type-check (both), lint (0 errors), prettier, i18n parity 660, frontend `next build`.