### PR TITLE
feat(tokens): DVT relay connectivity badge for gasless buys

### DIFF
--- a/aastar-frontend/app/tokens/page.tsx
+++ b/aastar-frontend/app/tokens/page.tsx
@@ -9,7 +9,7 @@ import {
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
 import { formatUnits, isAddress, type Address, type PublicClient, type WalletClient } from "viem";
-import { CHAIN_SEPOLIA } from "@aastar/sdk/core";
+import { CHAIN_SEPOLIA, checkDvtConnectivity } from "@aastar/sdk/core";
 import {
   usd,
   type SaleTokenKind,
@@ -58,6 +58,7 @@ export default function TokensPage() {
   const [quoteOut, setQuoteOut] = useState<bigint | null>(null);
   const [buying, setBuying] = useState(false);
   const [lastTx, setLastTx] = useState<string | null>(null);
+  const [dvt, setDvt] = useState<{ online: number; total: number } | null>(null);
 
   // Read-only sale client for prices/quotes before a wallet connects.
   const readSale = useMemo(() => buildTokenSaleClient(publicClient), [publicClient]);
@@ -75,6 +76,20 @@ export default function TokensPage() {
       .then(setPrices)
       .catch(() => null);
   }, [readSale]);
+
+  // DVT relay health — gasless buys are served by independent DVT nodes resolved
+  // from the SDK (no hardcoded URLs). Best-effort; never blocks the page.
+  useEffect(() => {
+    let cancelled = false;
+    checkDvtConnectivity()
+      .then(nodes => {
+        if (!cancelled) setDvt({ online: nodes.filter(n => n.ok).length, total: nodes.length });
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const refreshBalances = useCallback(
     async (addr: Address) => {
@@ -297,6 +312,16 @@ export default function TokensPage() {
           <p className="text-xs text-gray-500 dark:text-gray-400">
             {mode === "GASLESS" ? t("tokensPage.gaslessDesc") : t("tokensPage.selfpayDesc")}
           </p>
+          {mode === "GASLESS" && dvt && (
+            <p className="text-xs text-emerald-700 dark:text-emerald-400 flex items-center gap-1.5">
+              <span
+                className={`inline-block w-2 h-2 rounded-full ${
+                  dvt.online > 0 ? "bg-emerald-500" : "bg-red-500"
+                }`}
+              />
+              {t("tokensPage.dvtRelays", { online: dvt.online, total: dvt.total })}
+            </p>
+          )}
 
           {/* Pay token (self-pay only) */}
           {mode === "SELFPAY" && (

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -837,6 +837,7 @@
     "submitted": "Purchase submitted!",
     "purchaseFailed": "Purchase failed",
     "invalidRecipient": "Enter a valid recipient address (0x…)",
-    "amountTooSmall": "Amount too small — increase it to buy at least 1 token"
+    "amountTooSmall": "Amount too small — increase it to buy at least 1 token",
+    "dvtRelays": "Relayed by {{online}}/{{total}} independent DVT nodes — no ETH needed"
   }
 }

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -837,6 +837,7 @@
     "submitted": "购买已提交！",
     "purchaseFailed": "购买失败",
     "invalidRecipient": "请输入有效的收款地址（0x…）",
-    "amountTooSmall": "金额太小——请增加到至少能买 1 个代币"
+    "amountTooSmall": "金额太小——请增加到至少能买 1 个代币",
+    "dvtRelays": "由 {{online}}/{{total}} 个独立 DVT 节点中继 —— 无需 ETH"
   }
 }


### PR DESCRIPTION
Surfaces that gasless GToken/aPNTs buys are served by the SDK's **independent DVT relay pool** (`getDvtRelayerUrlsForChain` → dvt1/2/3.aastar.io — no hardcoded URLs).

- A best-effort `checkDvtConnectivity()` on mount drives a small badge under the **Gasless** tab: green/red dot + *N/N independent DVT nodes — no ETH needed*. Never blocks render; hidden until loaded.
- Bilingual (`dvtRelays` key, en+zh parity 661).

## Verified end-to-end on Sepolia 🎉
A real `buyGasless($1 aPNTs)` (viem-signed EIP-3009 + BuyIntent, no MetaMask) was relayed by **dvt2** (`0x04abac20…`, paid the gas) and landed on-chain **success** — buyer received +50 aPNTs.
- tx: [`0x49040263…`](https://sepolia.etherscan.io/tx/0x49040263946ae87f6ca8cb0eb5a9bda2c1a7912ef15ffcd45b534611b280053d)
- `checkDvtConnectivity()` → 3/3 nodes online.

## Verification
type-check ✅, i18n parity ✅, lint ✅, prettier ✅.