### PR TITLE
test: testing harness + prereq checker; bump SDK 0.26.6 (fixes gasless regression)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,5 @@ ehthumbs.db
 Thumbs.db
 .secret
 .playwright-mcp
+# Keep test env templates tracked (the real .env.test stays ignored above)
+!scripts/test/.env.test.example

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -17,7 +17,7 @@
     "test:ci": "echo \"⚠️  No tests yet - skipping\""
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.5",
+    "@aastar/sdk": "^0.26.6",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.5",
+    "@aastar/sdk": "^0.26.6",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,286 @@
+# YetAnotherAA (Cos72) — 测试用例与测试方案
+
+> 目标：把整套 Cos72 业务（个人用户 + 社区管理员/用户 + 运营者 + 协议）按**领域 / 角色 / 路径**拆成可执行用例，正向/逆向/异常全覆盖；**自动化为主（Playwright + Chrome DevTools Protocol + viem 链上脚本 + Jest e2e）、手工为辅**；每条涉及链上的用例必须留下**真实可查的凭证**（tx hash / 合约地址 / SBT id / UserOpHash），**测试网（Sepolia）跑通 → 主网（Ethereum / OP）按同一用例复跑**后才算上线。
+
+- 维护者：jason ｜ 适用分支：`master`
+- 关联：菜单见 `components/Layout.tsx`；后端 17 个 controller；前端 29 路由。
+- 当前阶段：**Sepolia 测试网**为主；主网（chainId 1 / 10）的 sale/DVT/Guard 栈未全部部署 → 标记 `mainnet: 待栈就绪`。
+
+---
+
+## 0. 测试方法与工具（自动化优先级从高到低）
+
+| 层 | 工具 | 覆盖 | 能否自动化 passkey/钱包 |
+|---|---|---|---|
+| **L1 链上脚本** | **viem 脚本**（node，持测试 EOA 私钥） | 买币/转账/Guard 写/质押等纯链上路径，直接签名+提交+断言+记 tx | ✅ 完全（本地私钥签名，无需浏览器） |
+| **L2 API e2e** | **Jest + AppModule + fetch**（已有 `aastar/test/`） | 后端路由：鉴权守卫、prepare/submit、presets、community/list 等 | ✅ 完全 |
+| **L3 浏览器 E2E** | **Playwright + CDP `WebAuthn` 虚拟认证器** | 登录/注册/转账/Guard 等真实 UI 流；passkey 用 CDP 虚拟认证器自动完成 ceremony | ✅ passkey 可（CDP 虚拟认证器）；MetaMask 用注入式测试钱包（见 §6） |
+| **L4 手工** | 真机 + 真 MetaMask + 真 Face ID/iCloud | 真实设备 passkey 跨设备同步、MetaMask 弹窗 UX、视觉/暗色/i18n、主网真实资金 | ❌ 必须人工 |
+
+**原则**：能进 L1/L2/L3 的不放 L4。passkey **不是**手工理由——CDP 的 `WebAuthn.addVirtualAuthenticator` 可在自动化里完成 P-256 ceremony。真正必须 L4 的：真实设备/iCloud 同步验证、MetaMask 原生弹窗、人眼视觉验收、主网真金。
+
+### 凭证要求（每条链上用例必须留）
+执行后写入 **证据台账** `docs/test-evidence/<domain>-<caseId>.json`：
+```json
+{ "caseId":"TOK-01","network":"sepolia","actor":"0x…","txHash":"0x…",
+  "explorer":"https://sepolia.etherscan.io/tx/0x…","artifacts":{"aPNTsReceived":"50"},
+  "blockNumber":11121168,"status":"success","runAt":"<ISO>","by":"auto|manual" }
+```
+无 tx hash / 无可查凭证的链上用例 **不算通过**。
+
+---
+
+## 1. 环境与前置
+
+| 项 | 值 |
+|---|---|
+| 测试网 | Sepolia (11155111) — sale/DVT/Guard/Paymaster 全部署 |
+| 主网 | Ethereum (1) / OP (10) — `待栈就绪`，栈部署后同用例复跑 |
+| 后端 | `cd aastar && KMS_DIAG=true npm run start:dev`（:3000，/api/v1） |
+| 前端 | `npm run dev -w aastar-frontend`（:5173） |
+| 地址来源 | **全部经 `@aastar/sdk`**（canonical / launch-sale / DVT）——用例断言地址时以 SDK 为准，禁硬编码 |
+| 测试 EOA | 一个持 Sepolia ETH + USDC + GToken/aPNTs 的私钥（L1 脚本用；当前已验证 `0xb56000…0E` 有 283 USDC） |
+| 测试邮箱 | OTP 注册用；KMS key 用后**勿删**（删了登录 400） |
+
+---
+
+## 2. 领域 / 角色总览
+
+```
+个人用户 (Individual)         社区 (Community)                 运营/协议 (Operator/Protocol)
+├─ D1 注册与账户              ├─ D6 社区管理员                 ├─ D8 运营者(Gas赞助)
+├─ D2 Tokens/门票             │   创建/发币/Gas策略/日常管理     │   PaymasterV4 / SuperPaymaster / xPNTs
+├─ D3 Guard 消费守卫          ├─ D7 社区用户(加入/退出/广场)    ├─ D9 Role / SBT
+├─ D4 Transfer               │                                ├─ D12 Protocol Admin
+├─ D5 社交恢复               D10 NFT(商品+声誉)  D11 Tasks      X 跨领域(i18n/鉴权/网络/暗色/异常)
+```
+角色：`访客` / `个人用户` / `社区管理员` / `运营者` / `Guardian` / `协议管理员`。
+
+---
+
+## 3. 用例表（按领域；类型 = ✅正向 / ⛔逆向 / ⚠️异常）
+
+> 列：ID ｜ 角色 ｜ 类型 ｜ 路径/步骤 ｜ 预期 ｜ 方法 ｜ 凭证
+
+### D1 个人注册与账户（/auth/register, /auth/login, /dashboard, account.*）
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| AUTH-01 | 访客 | ✅ | 注册：填 email → 收 OTP → 验证 | 进入 passkey 注册步骤；JWT 暂存 | L3(Playwright) | — |
+| AUTH-02 | 访客 | ✅ | 注册 passkey（创建 AirAccount，KMS key + P-256 凭证） | 返回反事实账户地址；DB 落 user(kmsKeyId/walletAddress) | L3(CDP 虚拟认证器) | accountAddress |
+| AUTH-03 | 个人 | ✅ | 部署合约账户（首笔 UserOp / create-with-…guardians） | 账户上链；guard 合约同时部署(若 dailyLimit>0) | L1(viem)/L3 | 部署 txHash + guard 地址 |
+| AUTH-04 | 个人 | ✅ | 登录：email + passkey 断言 → /dashboard | 登录成功，停留 dashboard（不回跳首页） | L3(CDP) | — |
+| AUTH-05 | 访客 | ⛔ | 用未注册 email 登录 | 优雅降级到 OTP/提示，不白屏 | L3 | — |
+| AUTH-06 | 访客 | ⛔ | OTP 错误码 / 过期码 | 明确错误提示，不放行 | L2/L3 | — |
+| AUTH-07 | 个人 | ⚠️ | KMS key 被删后登录 | `/SignHash`/begin 400 → 提示"重新注册/恢复"，不静默失败 | L3 + 手工 | KMS 400 响应 |
+| AUTH-08 | 访客 | ⛔ | 设备无 passkey / 用户取消 ceremony | NotAllowedError → 提示，可回退 | L3(CDP 模拟取消) | — |
+| AUTH-09 | 个人 | ✅ | Account info 管理（查看地址/余额/nonce/signer） | 正确显示；rotate-signer 可用 | L2/L3 | — |
+| AUTH-10 | 访客 | ⛔ | 未登录访问 `/dashboard` 等受保护页 | 重定向 `/auth/login`（前端 + 后端 401） | L2(已有 e2e)/L3 | 401 |
+
+### D2 Tokens / 门票（/tokens, tokens/sale/user-token）
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| TOK-01 | 个人 | ✅ | Gasless 买 aPNTs（USDC，EIP-3009 → DVT relay 代付） | relayer 上链 success；aPNTs 到账；买家无需 ETH | **L1(已验证)** | txHash `0x49040263…` + dvt2 代付 |
+| TOK-02 | 个人 | ✅ | Gasless 买 GToken | 同上，GToken 到账 | L1 | txHash |
+| TOK-03 | 个人 | ✅ | Self-pay 买（USDC，approve+buyTokens，自付 ETH gas） | 2 笔 tx 上链；token 到账 | L1/L3 | approve+buy txHash |
+| TOK-04 | 个人 | ✅ | Self-pay 买（USDT） | 同上（USDT 不走 EIP-3009） | L1 | txHash |
+| TOK-05 | 个人 | ✅ | 网络切换 Sepolia→OP→ETH | 要求 MetaMask 切链；非 Sepolia 买入禁用 + "sale 未上线"提示 | L3(测试钱包) | — |
+| TOK-06 | 个人 | ⚠️ | 滑点：minOut=quoted×98% | 价格劣于 floor 时 revert，不被夹 | L1(构造滑点) | revert 凭证 |
+| TOK-07 | 个人 | ⛔ | aPNTs self-pay 传 minOut | SDK 拒（#147）→ 我们 UI 已对 aPNTs self-pay 省略 minOut，不报错 | L1/L3 | — |
+| TOK-08 | 个人 | ⚠️ | 金额过小（quote=0） | 拦截"金额太小"，不发交易 | L3 | — |
+| TOK-09 | 个人 | ⛔ | gasless 收款人填非法地址 | `isAddress` 拦截，不提交 | L3 | — |
+| TOK-10 | 个人 | ✅ | gasless 默认收款人 = 用户 AirAccount | 买到的 token 进 AirAccount | L1 | recipient=AirAccount 的 txHash |
+| TOK-11 | 个人 | ✅ | 质押 GToken → 换取 ticket(SBT) | 获得 SBT(ticket)；可加入社区 | L1/L3 | stake txHash + SBT id |
+| TOK-12 | 个人 | ✅ | DVT relay 连通性徽章 | 显示 N/N 在线（checkDvtConnectivity） | L3 | — |
+| TOK-13 | 个人 | ⚠️ | DVT relay 全挂时 gasless | 兜底到 legacy worker 或明确失败提示 | L1(指向挂的 relay) | — |
+
+### D3 Guard 消费守卫（/guard, GuardClient + transfer 两阶段）
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| GRD-01 | 个人 | ✅ | 查看 Guard：getConfig（ETH 限额/剩余/已用/下限/严格模式） | 正确渲染 | L1/L3 | — |
+| GRD-02 | 个人 | ✅ | 按 token 查 getTokenConfig + 今日消费 | 正确（按 decimals） | L1/L3 | — |
+| GRD-03 | 个人 | ✅ | 降 ETH 每日限额（经账户 UserOp） | 限额降低；链上 config 更新 | L1/L3(CDP) | UserOpHash + 新 config |
+| GRD-04 | 个人 | ✅ | 开/关严格模式 | strictMode 翻转 | L1/L3 | txHash |
+| GRD-05 | 个人 | ✅ | 加 token 配置（tier1/2/daily，add-only） | 新增配置 | L1/L3 | txHash |
+| GRD-06 | 个人 | ✅ | 降某 token 每日限额 | 降低 | L1/L3 | txHash |
+| GRD-07 | 个人 | ⛔ | 试图调高限额 / 改已存在 token 配置 | 合约 revert（单调）；UI 也应预先拦 | L1 | revert |
+| GRD-08 | 个人 | ⛔ | 降到低于 minDailyLimit | revert / UI 拦 | L1/L3 | — |
+| GRD-09 | 个人 | ⚠️ | 无 guard 的纯 agent 账户（guard()==0） | 显示"无守卫"，管理隐藏 | L3 | — |
+| GRD-10 | 个人 | ⚠️ | 严格模式下转未配置 token | 转账被 guard 拒 | L1 | revert |
+
+### D4 Transfer（/transfer, transfer 两阶段 ceremony）
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| XFER-01 | 个人 | ✅ | Tier-2 转账（prepare → 设备 passkey ceremony → submit） | `/SignHash` 200 + 上链 success | **L1/L3(CDP)** | tx `0xb390ef59…`(已验证) |
+| XFER-02 | 个人 | ✅ | Tier-1 小额（单 P-256） | 上链 success | L1/L3 | txHash |
+| XFER-03 | 个人 | ✅ | Tier-3 大额（+guardian ECDSA） | 上链 success | L1/手工 | txHash |
+| XFER-04 | 个人 | ✅ | gasless（usePaymaster + PaymasterV4，aPNTs 付 gas） | 账户无 ETH 也成功 | L1/L3 | txHash + paymaster |
+| XFER-05 | 个人 | ⚠️ | prepare 后 >10min 才 submit（句柄过期） | 提示重新 prepare | L3 | — |
+| XFER-06 | 个人 | ⚠️ | 余额不足 / Guard 限额超 | 明确失败，不静默 | L1/L3 | — |
+| XFER-07 | 个人 | ⛔ | legacy 裸 passkey 路径 | 被 KMS strict 拒（已弃用） | L1 | 400 |
+| XFER-08 | 个人 | ✅ | 转账历史 /transfer/history | 列表正确含 txHash 链接 | L2/L3 | — |
+
+### D5 社交恢复 / Guardian（/recovery, /guardian-sign, guardian.*）
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| REC-01 | 个人 | ✅ | 创建账户时加 2 个 guardian（2-of-3，存不同 provider） | 两 guardian 登记成功 | L3(CDP×2)/手工 | guardian 公钥 |
+| REC-02 | Guardian | ✅ | guardian-sign：已有 AirAccount passkey 渠道签名 | 产出有效断言 | L3(CDP) | — |
+| REC-03 | Guardian | ✅ | guardian-sign：新建 email+FaceID（KMS ECDSA）渠道 | 同上 | L3 | — |
+| REC-04 | Guardian | ✅ | guardian-sign：MetaMask 渠道 | personal_sign 有效 | L3(测试钱包) | — |
+| REC-05 | Guardian | ✅ | **纯客户端 P-256 passkey 渠道**（无 KMS，iCloud/Google） | 产 P-256 断言；后端 encodeWebAuthnAssertion relay proposeRecoveryWithSig 上链 | L3(CDP)/手工 | recovery txHash |
+| REC-06 | 个人 | ✅ | 发起恢复 → guardian 支持 → 执行（换 owner） | owner 更新；guard 不受影响（account immutable） | L1/L3 | initiate/support/execute txHash |
+| REC-07 | 个人 | ⛔ | 不足门限 guardian 支持就执行 | revert | L1 | — |
+| REC-08 | 个人 | ⚠️ | 取消恢复 / 恢复时限 | 状态正确 | L1/L3 | — |
+
+### D6 社区 — 管理员（/community, /operator, community/registry/operator/paymaster.*）
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| COM-A-01 | 社区管理员 | ✅ | 买 GToken（创建社区前置） | GToken 到账 | L1 | txHash |
+| COM-A-02 | 社区管理员 | ✅ | 注册社区：质押 + registerCommunity + ENS/域名/描述/logo(IPFS) | 社区上链；registry 可查 | L1/L3(测试钱包) | community 地址 + tx |
+| COM-A-03 | 社区管理员 | ✅ | 创建即发行社区积分 xPNTs（deployxPNTs + 绑定） | xPNTs 合约部署；与社区绑定 | L1/L3 | xPNTs 地址 + tx |
+| COM-A-04 | 社区管理员 | ✅ | Gas 策略 A：自部署 PaymasterV4（免费、自维护） | 部署向导跑通；EntryPoint depositTo | L3(operator/deploy)/手工 | paymaster 地址 + deposit tx |
+| COM-A-05 | 社区管理员 | ✅ | Gas 策略 B：SuperPaymaster（把 points 注册即可） | points 注册到 SuperPaymaster；可代付 | L1/L3 | 注册 tx |
+| COM-A-06 | 社区管理员 | ✅ | 日常：架设积分兑换台（redeem counter） | 兑换台可用 | L3/手工 | tx |
+| COM-A-07 | 社区管理员 | ✅ | 日常：发行 NFT 商品 | NFT 商品上架 | L3/手工 | mint tx |
+| COM-A-08 | 社区管理员 | ✅ | 日常：发行 reputation NFT（声誉，不可转让 SBT 性质） | 声誉 NFT 发行 | L1/L3 | mint tx |
+| COM-A-09 | 社区管理员 | ✅ | 成员管理：查看/批准/移除成员 | 成员状态正确 | L2/L3 | — |
+| COM-A-10 | 社区管理员 | ⛔ | 无 GToken/未质押就注册社区 | 前置检查拦截 | L1/L3 | — |
+| COM-A-11 | 社区管理员 | ⚠️ | xPNTs 重复绑定 / 域名冲突 | 明确拒绝 | L1/L3 | — |
+
+### D7 社区 — 用户（/community 广场, /role, SBT）
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| COM-U-01 | 个人 | ✅ | 购 ticket：质押 GToken 换 ticket → 领 SBT | 持有 SBT | L1 | stake + SBT mint tx + SBT id |
+| COM-U-02 | 个人 | ✅ | 社区广场：聚合展示所有社区（名称/ENS/token/owner/logo） | 列表正确（含官方 AAStar + Mycelium） | L2(community/list)/L3 | — |
+| COM-U-03 | 个人 | ✅ | 持 SBT 加入社区 | 成为社区成员 | L1/L3 | join tx |
+| COM-U-04 | 个人 | ✅ | 退出社区 | 成员关系解除 | L1/L3 | leave tx |
+| COM-U-05 | 个人 | ⛔ | 无 SBT 试图加入社区 | 拒绝（需先购 ticket） | L1/L3 | — |
+| COM-U-06 | 个人 | ⚠️ | 加入已退出/不存在的社区 | 明确错误 | L2/L3 | — |
+
+### D8 协议运营者 / Gas 赞助节点（/operator, /operator/deploy, /operator/manage/*）
+
+> **D6 社区管理员 vs D8 协议运营者 —— 区别**：D6 是**社区**视角（创建社区、发 xPNTs、为本社区选 Gas 策略）；D8 是**生态/协议运营者**视角——在 SuperPaymaster 生态里**注册运营者角色（ROLE_ANODE / DVT / Paymaster 等）、质押、运营 Paymaster 节点为他人代付 gas**。一个社区管理员若选"自部署 PaymasterV4"策略，就**同时**扮演 D8 运营者（D6 COM-A-04 与 D8 OPR-01 有重叠，但 D8 还含 AOA+/DVT/SuperPaymaster 运营者准入这些非社区必经的协议级动作）。简言之：**D6=开社区，D8=当协议的 gas 运营者**。这不是协议管理员（那是 D12 `/admin` 协议治理）。
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 | 凭证 |
+|---|---|---|---|---|---|---|
+| OPR-01 | 运营者 | ✅ | 运营者准入向导（流程 1 AOA：stake→register→deployxPNTs→deployPaymaster→deposit） | 全步上链 | L3(测试钱包)/手工 | 各步 txHash |
+| OPR-02 | 运营者 | ✅ | AOA+ 准入（lockForSuperPaymaster→registerOperator→depositAPNTs） | 注册成功 | L3/手工 | txHash |
+| OPR-03 | 运营者 | ✅ | ManagePaymaster：PaymasterV4 配置读写 + EntryPoint 充值 | 配置生效 | L3 | tx |
+| OPR-04 | 运营者 | ✅ | SuperPaymasterConfig：账户状态/aPNTs 充值/声誉 | 正确 | L3 | tx |
+| OPR-05 | 运营者 | ✅ | xPNTs 管理（部署/绑定/铸造） | 正确 | L3 | tx |
+| OPR-06 | 运营者 | ⚠️ | 资源前置检查（流程 8 checkResources）不足 | 明确阻断 + 指引 | L2/L3 | — |
+| OPR-07 | 访客 | ⛔ | 非运营者访问运营写操作 | 权限拒绝 | L2 | — |
+
+### D9 / D10 / D11 / D12
+
+| ID | 角色 | 型 | 步骤 | 预期 | 方法 |
+|---|---|---|---|---|---|
+| ROLE-01 | 个人 | ✅ | /role 查看自身角色/SBT/权限 | 正确（ROLE_* + SBT） | L2/L3 |
+| ROLE-02 | 个人 | ⚠️ | 无角色账户 | 显示"无角色" | L3 |
+| NFT-01 | 个人 | ✅ | /nfts 查看持有的 NFT（商品 + 声誉） | 列表正确 | L2/L3 |
+| NFT-02 | 个人 | ✅ | verify-ownership / 领取 SBT | 正确 | L1/L2 |
+| TASK-01 | 个人 | ✅ | /tasks 创建任务 → 详情 → 状态流转 | 任务队列正确 | L3 |
+| TASK-02 | 个人 | ⚠️ | 任务失败/重试 | 状态正确 | L3 |
+| ADM-01 | 协议管理员 | ✅ | /admin 协议状态/配置查看 | 正确（chain 11155111） | L2/L3 |
+| ADM-02 | 非管理员 | ⛔ | 访问 admin 写操作 | 拒绝 | L2 |
+| ADDR-01 | 个人 | ✅ | /address-book 增删查 + 转账后自动记录 | 正确 | L2/L3 |
+| RCV-01 | 个人 | ✅ | /receive 展示收款地址/二维码 | 正确 | L3 |
+| DT-01 | 个人 | ✅ | /data-tools 数据导出/清理 | 正确 | L2/L3 |
+
+### X 跨领域
+
+| ID | 型 | 步骤 | 预期 | 方法 |
+|---|---|---|---|---|
+| X-01 | ✅ | 中英文切换（每个页面） | 所有文案随语言切换（含 tokens/guard/transfer/community…），无写死英文 | L3 + `i18n:check` |
+| X-02 | ✅ | 暗色/亮色切换 | 全页适配 | L3(视觉)/手工 |
+| X-03 | ✅ | 头像菜单 click-outside / Esc 关闭 | 正确 | L3 |
+| X-04 | ⚠️ | 后端不可达 / 502 | 前端优雅降级，不白屏 | L3 |
+| X-05 | ⚠️ | 钱包未安装 / 拒绝连接 | 明确提示 | L3 |
+| X-06 | ✅ | 网络切换全局一致（chainId 贯穿 publicClient/SDK/explorer） | 正确 | L3 |
+| X-07 | ⚠️ | 同一操作并发双击（防重复提交） | 按钮禁用，不重复发交易 | L3 |
+
+---
+
+## 4. 自动化测试方案
+
+### 4.1 L1 — viem 链上脚本（`aastar-frontend/scripts/e2e-onchain/` 或 `scripts/test-onchain/`）
+- 复用本仓已验证的模式（见 TOK-01 实证）：`privateKeyToAccount` → `createPublicClient/WalletClient` → SDK client（`TokenSaleClient`/`GuardClient`/`transfers`）→ 签名+提交 → `getTransactionReceipt` 断言 `status==='success'` → **写证据台账**。
+- 覆盖：TOK-01~04/06/10/11、GRD-03~08/10、XFER-01~04/06、REC-06/07、COM-A-01~03/05/08、COM-U-01/03/04、NFT-02。
+- 优点：无浏览器、无 passkey 弹窗、最快最稳；用例即脚本，CI 可跑（用专用测试 EOA + 测试网）。
+
+### 4.2 L2 — Jest API e2e（扩展 `aastar/test/`）
+- 已有 `app.e2e-spec.ts`（鉴权守卫 + paymaster presets 地址）。
+- 扩展：community/list、operator/status、role、address-book、admin 只读、transfer prepare/submit 鉴权、guardian 列表。
+- 断言后端契约 + SDK 集成（地址、社区聚合、权限 401/403）。
+
+### 4.3 L3 — Playwright + CDP 虚拟认证器（新建 `aastar-frontend/e2e/`）
+- **passkey 自动化关键**：Playwright `context.newCDPSession(page)` → `WebAuthn.enable` → `WebAuthn.addVirtualAuthenticator({ protocol:'ctap2', transport:'internal', hasResidentKey:true, hasUserVerification:true, isUserVerified:true })`。注册/登录/转账 ceremony 全自动完成，无需真机。
+- **MetaMask/EOA**：注入式测试钱包（`window.ethereum` shim，用测试私钥 viem 实现 `request`），或 Synpress；用于 self-pay 买入、运营者写、guardian MetaMask 渠道、网络切换。
+- **OTP**：测试环境后端开 `test mode` 固定/可读 OTP（或 mock email），脚本读取。
+- 覆盖：AUTH-01~10、TOK-05/08/09/12、GRD-01/02/09、XFER-05/08、REC-01~05、COM-A-04/06/07/09、COM-U-02/05/06、OPR-*、ROLE/NFT/TASK/ADM 的 UI 路径、X-01~07。
+- 证据：UI 流触发的链上 tx，从 toast/结果或 `getTransactionReceipt` 抓 txHash 入台账 + Playwright trace/截图归档。
+
+### 4.4 L4 — 手工（清单 `docs/test-evidence/manual-checklist.md`）
+- 真实设备 passkey 跨设备 iCloud/Google 同步（REC-01/05）、真 MetaMask 弹窗 UX（TOK-05、OPR-01）、视觉/暗色（X-02）、**主网真金路径**全部、首次部署向导的运营体验。
+- 每条手工用例同样回填证据台账（截图 + txHash）。
+
+### 4.5 跑测入口（建议加 npm scripts）
+```
+npm run test            -w aastar          # L2 单元
+npm run test:e2e        -w aastar          # L2 API e2e（已有）
+npm run test:onchain    -w aastar-frontend # L1 viem 链上（新增，读测试 EOA + 网络参数）
+npm run test:e2e:ui     -w aastar-frontend # L3 Playwright（新增）
+```
+
+### 4.6 执行模式 —— 全自动 / 人工介入点 / 分阶段
+
+测试条件齐备（见 `TEST_PREPARATION.md` + `check-prereqs` 全绿）后，按"**能全自动就全自动，到必须人介入处暂停并明确呼叫你**"展开：
+
+| 段 | 能否全自动 | 说明 / 人工介入点 |
+|---|---|---|
+| **L1 链上脚本** | ✅ **全自动** | 有测试 EOA 私钥 + 余额即可，无人值守跑完，自动记 tx 台账 |
+| **L2 API e2e** | ✅ **全自动** | 启后端即可 |
+| **L3 浏览器（passkey 经 CDP 虚拟认证器）** | ✅ **可全自动** | 前提：后端开**测试模式可读 OTP**（否则注册卡 OTP，需人工读邮件）；MetaMask 流用注入式测试钱包 |
+| **L3 真 MetaMask 弹窗 / 真设备 passkey** | ⛔ **需人工** | 跑到此**自动暂停 + 通知你**："请在 MetaMask 确认 X / 用 Face ID 确认" |
+| **L4 主网真金 / 视觉 / 跨设备同步** | ⛔ **需人工** | 全程人工，按清单逐条做 + 回填台账 |
+
+**三种推进方式（你选）**：
+1. **全自动批跑**：条件齐 → 一键跑 L1+L2+L3（OTP 测试通道 + 测试钱包就绪）→ 出报告，我只在失败/主网处呼叫你。
+2. **半自动（自动 + 人工接力）**：自动跑到 MetaMask 弹窗/真设备处 → 脚本**暂停并打印"请你介入：<具体操作>"** → 你做完回车继续。
+3. **分阶段**：一个领域一个领域批准着跑（D1 → D2 → …），每段出小报告你确认再下一段。
+
+**我如何呼叫你介入**：脚本在非自动化点会 `console` 明确打印 `⏸ NEEDS YOU: <操作> (case <ID>)` 并等待（stdin 回车 / 或你在另一个终端完成后告诉我），我据此继续；主网用例则整段标 `MANUAL/MAINNET` 让你按清单做。
+
+---
+
+## 5. 执行流程与上线门禁
+
+1. **Sepolia 全量**：L1+L2+L3 自动跑通 → L4 手工补 → 所有用例证据台账齐全（链上有 tx 可查）。
+2. **回归门**：`npm run ci`（format/lint/build/test）全绿 + `i18n:check` 通过 + e2e 全绿。
+3. **主网门**（待栈就绪）：同一套用例在 Ethereum/OP 复跑（金额最小化、真金），证据台账标 `network:mainnet`。**测试网 + 主网都跑通**才算该用例"完整完成"。
+4. **签收**：每领域负责人在台账签字（caseId + 网络 + txHash + 通过/失败 + by）。
+
+### 证据台账目录
+```
+docs/test-evidence/
+  sepolia/<domain>-<caseId>.json
+  mainnet/<domain>-<caseId>.json
+  manual-checklist.md
+  README.md  # 索引 + 当前通过率
+```
+
+---
+
+## 6. 待补 / 风险
+
+- **L3 MetaMask 自动化**：注入式测试钱包 vs Synpress，需选型（建议注入式 viem shim，轻量）。
+- **OTP 测试通道**：后端需提供测试模式可读 OTP（否则 L3 注册卡在 OTP）。
+- **主网栈**：sale/DVT/Guard/SuperPaymaster 主网未全部署 → 主网用例当前 `blocked`，栈就绪后解锁。
+- **测试 EOA 资金**：L1 需持续有测试网 USDC/ETH/GToken；主网需小额真金预算。
+- 本文档随菜单/功能演进更新；新功能 PR 必须**同步加用例**（无用例不合并）。

--- a/docs/TEST_PREPARATION.md
+++ b/docs/TEST_PREPARATION.md
@@ -1,0 +1,116 @@
+# 测试准备（Test Preparation）
+
+> 配套 `TEST_PLAN.md`。**测试前必须先把准备做齐**：环境变量、服务、测试账户、测试 token、API key。
+> 用 `node scripts/test/check-prereqs.mjs` 自动体检——**未全绿不开始测试**。本文档说明每项需要什么、配在哪、怎么检查、缺了怎么补。
+
+---
+
+## 0. 配置放哪
+
+| 文件 | 用途 | 是否提交 |
+|---|---|---|
+| `aastar/.env` | 后端运行配置（已存在，gitignore） | 否 |
+| `aastar/.env.example` | 后端变量清单参考 | 是 |
+| `scripts/test/.env.test` | **测试专用**：测试 EOA 私钥、测试钱包、OTP 测试通道等 | **否（gitignore）** |
+| `scripts/test/.env.test.example` | 测试变量清单参考 | 是 |
+
+> 检查脚本会同时读 `aastar/.env` + `scripts/test/.env.test` + 进程环境。
+
+---
+
+## 1. 服务（跑测前必须在线）
+
+| 服务 | 怎么起 / 怎么查 | 谁用 |
+|---|---|---|
+| 后端 :3000 | `cd aastar && KMS_DIAG=true npm run start:dev`；查 `curl :3000/api-docs`=200 | L2/L3、所有经后端的写 |
+| 前端 :5173 | `npm run dev -w aastar-frontend`；查 `:5173/tokens`=200 | L3 |
+| ETH RPC | `aastar/.env` `ETH_RPC_URL`；查 `eth_chainId`==11155111 | 全部链上 |
+| Bundler | `BUNDLER_RPC_URL`（Pimlico）；查 `eth_supportedEntryPoints` | UserOp 提交（转账/Guard 写） |
+| KMS | `KMS_ENDPOINT`（kms.aastar.io）+ `KMS_API_KEY`；查 `/version` | 登录/转账/Guard 写（设备 passkey ceremony） |
+| DVT relay | SDK `getDvtRelayerUrlsForChain` → dvt1/2/3.aastar.io；`checkDvtConnectivity` 全 ok | gasless 买入 |
+
+---
+
+## 2. 后端必需环境变量（缺则后端启动失败 / 流程不通）
+
+| 变量 | 必需 | 校验点 | 缺了怎样 |
+|---|---|---|---|
+| `JWT_SECRET` | ✅ | 非空 | 启动失败 |
+| `USER_ENCRYPTION_KEY` | ✅ | **正好 32 字符** | 启动失败 |
+| `ETH_RPC_URL` | ✅ | 可连 + chainId 对 | 启动失败 / 链读失败 |
+| `BUNDLER_RPC_URL` | ✅ | 可连 | UserOp 提交失败 |
+| `CHAIN_ID` | ✅ | =11155111（测试网） | 地址/链不一致 |
+| `DB_TYPE` | ✅ | `json`（本地） | — |
+| `KMS_ENABLED` | 登录/写需 | `true` | passkey 流不可用 |
+| `KMS_ENDPOINT` | KMS 开时 | 可连 | KMS 调用失败 |
+| `KMS_API_KEY` | KMS 开时 | 非空 + 401 测试 | KMS 401 |
+| `RESEND_API_KEY` / `EMAIL_FROM` | OTP 邮件 | 非空 | 收不到 OTP（除非测试通道） |
+| 合约地址组 | 从 SDK 取优先 | 见 §5 | 用旧 .env 地址会指错（参考历史 0x1f0D 事故） |
+
+> 地址优先级：**SDK canonical > .env**。用例断言地址以 `@aastar/sdk` 为准。
+
+---
+
+## 3. 测试专用变量（`scripts/test/.env.test`）
+
+| 变量 | 用途 | 怎么准备 |
+|---|---|---|
+| `TEST_EOA_PRIVATE_KEY` | **L1 链上脚本主账户**（买币/转账/Guard/质押） | 一个 Sepolia EOA 私钥，按 §4 注资 |
+| `TEST_EOA_PRIVATE_KEY_2` | 第二钱包（guardian / 收款人 / 社区成员） | 可选，同上 |
+| `TEST_AIR_ACCOUNT` | 已部署、**带 Guard**（dailyLimit>0）的 AirAccount 地址 | 用 D1 流程创建并部署；Guard 写用例需要 |
+| `TEST_COMMUNITY_ADDRESS` | 已注册社区（社区用例查询/加入用） | 用 D6 创建，或用官方 AAStar/Mycelium |
+| `TEST_TOKEN_USDC` / `_USDT` | 覆盖默认（一般不用，SDK 提供） | 留空走 SDK |
+| `OTP_TEST_MODE` | 后端测试模式可读 OTP（L3 注册自动化） | 需后端支持（见 §6 待办） |
+| `MAINNET_ENABLED` | 是否允许主网用例 | 默认 false（栈未就绪） |
+
+---
+
+## 4. 测试账户与 Token 余额（L1/链上用例的硬前置）
+
+`TEST_EOA_PRIVATE_KEY` 对应的 Sepolia EOA 需要：
+
+| 资产 | 用途 | 最低建议 | 怎么补 |
+|---|---|---|---|
+| **Sepolia ETH** | self-pay 买入/转账 gas、部署 | ≥ 0.05 | 公共水龙头 |
+| **USDC** | gasless 买入（EIP-3009）+ self-pay 买入 | ≥ 10 | 测试网 USDC 水龙头 / 转入 |
+| **USDT** | self-pay USDT 买入 | ≥ 5 | 同上 |
+| **GToken** | 质押换 ticket(SBT)、创建社区 | ≥ 数个 | 先用本套 gasless 买入获得 |
+| **aPNTs** | gasless 转账/Guard 写的 PaymasterV4 gas、社区积分 | ≥ 数十 | gasless 买入获得 |
+| **SBT(ticket)** | 加入社区 | 1 | D2 质押 GToken 换取 |
+
+> 余额由 `check-prereqs` 用 SDK `TokenSaleClient.getBalances` 实测；不足会列出缺口。
+
+---
+
+## 5. 按领域的准备矩阵
+
+| 领域 | 需要的准备 | 怎么检查 |
+|---|---|---|
+| D1 注册/账户 | 后端+KMS 在线、测试邮箱（或 OTP 测试通道）、L3 passkey 用 CDP（无需真机） | 服务体检 + OTP 通道 |
+| D2 Tokens/门票 | 测试 EOA + USDC/USDT/ETH、DVT relay 在线、sale 栈(Sepolia) | balances + DVT + getPrices |
+| D3 Guard | `TEST_AIR_ACCOUNT`(带 guard) + aPNTs(付 gas) + 设备 passkey(CDP) | guard() != 0 + aPNTs 余额 |
+| D4 Transfer | 测试 AirAccount + 余额 + KMS + bundler + (gasless 需 aPNTs/paymaster) | 账户余额 + bundler |
+| D5 恢复/Guardian | 带 2 guardian 的账户、第二钱包(MetaMask 渠道)、CDP(passkey 渠道) | guardian 列表 |
+| D6 社区管理员 | 测试 EOA + GToken(创建社区) + registry/xPNTsFactory/SuperPaymaster 地址(SDK) | GToken 余额 + 合约可读 |
+| D7 社区用户 | SBT(ticket) + 已存在社区 | SBT 持有 + community/list |
+| D8 协议运营者 | 测试 EOA + 质押额(GToken/ETH) + SuperPaymaster/PaymasterFactory(SDK) | 余额 + 资源前置检查 |
+| D9–D12 | 视用例：SBT、NFT、admin 权限账户 | 各自 reader |
+
+---
+
+## 6. 待办 / 需你提供
+
+- **OTP 测试通道**：L3 注册要全自动需后端在 `NODE_ENV=test` 暴露可读 OTP（或固定码）。当前没有 → 注册用例先半自动（你读邮件填码）或我加一个测试通道（需你同意改后端）。
+- **测试 EOA 私钥**：放 `scripts/test/.env.test` 的 `TEST_EOA_PRIVATE_KEY`（**勿提交**）。本会话验证过的 `0xb56000…0E` 可用（有 283 USDC）——但其私钥在 7702 实验脚本里，正式测试建议你给一个专用测试私钥。
+- **主网预算**：主网用例需小额真金（USDC/ETH）+ 主网 sale/DVT/Guard 栈就绪（当前 `blocked`）。
+- **第二钱包**：guardian MetaMask 渠道 / 收款人用例。
+
+---
+
+## 7. 检查脚本
+
+```
+node scripts/test/check-prereqs.mjs            # 体检（默认 Sepolia）
+node scripts/test/check-prereqs.mjs --mainnet  # 主网体检（需 MAINNET_ENABLED）
+```
+输出每项 ✅/⚠️/❌ + 缺失项的补法；**有 ❌（critical）则退出码非 0，测试不应开始**。

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.26.5",
+        "@aastar/sdk": "^0.26.6",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.26.5",
+        "@aastar/sdk": "^0.26.6",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1427,9 +1427,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.26.5",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.5.tgz",
-      "integrity": "sha512-BuYQ1ByhhXnLeFIv4wmV1+pi1igieQ9gS7h4zUaw0sSj2d/EjDhkXPu5I4hd7aLYPEimVfDZMbW2ji75J+hBCA==",
+      "version": "0.26.6",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.6.tgz",
+      "integrity": "sha512-XvrPJUoyj8vP6LaDZYetorBQG6w29V9kHytC9om6oJp0uVNWXE5YDoWoZd4FwP/homWj0WwGOh3Y+HZa3mwg3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test": "npm run test -ws",
     "test:ci": "npm run test:ci -ws",
     "audit": "npm audit && npm audit -ws",
+    "test:prereqs": "node scripts/test/check-prereqs.mjs",
+    "test:onchain": "node scripts/test/onchain/run.mjs",
     "ci": "npm run format:check && npm run lint && npm run build && npm run test:ci"
   },
   "devDependencies": {

--- a/scripts/test/.env.test.example
+++ b/scripts/test/.env.test.example
@@ -1,0 +1,21 @@
+# Test-only config — copy to scripts/test/.env.test (gitignored). See docs/TEST_PREPARATION.md.
+
+# L1 on-chain scripts: a funded Sepolia EOA private key (NEVER commit a real one).
+# Needs ETH + USDC (+ USDT/GToken/aPNTs per the domain). check-prereqs reports gaps.
+TEST_EOA_PRIVATE_KEY=0x...
+
+# Optional second wallet (guardian MetaMask channel / recipient / community member).
+TEST_EOA_PRIVATE_KEY_2=
+
+# A deployed AirAccount that HAS a guard (created with dailyLimit>0) — for D3 Guard writes.
+TEST_AIR_ACCOUNT=
+
+# An existing community (for D7 join/leave); leave blank to use official AAStar/Mycelium.
+TEST_COMMUNITY_ADDRESS=
+
+# L3 passkey/OTP automation: requires the backend to expose a readable OTP in test mode.
+OTP_TEST_MODE=false
+
+# Mainnet gate — keep false until the mainnet sale/DVT/Guard stack is deployed.
+MAINNET_ENABLED=false
+MAINNET_CHAIN_ID=1

--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -1,0 +1,52 @@
+# scripts/test — 测试准备 + 链上(L1)用例脚本
+
+配套 `docs/TEST_PLAN.md`（用例）与 `docs/TEST_PREPARATION.md`（准备）。
+
+## 用法
+
+```bash
+# 0) 准备：复制模板，填入测试 EOA 私钥等（.env.test 已 gitignore）
+cp scripts/test/.env.test.example scripts/test/.env.test
+
+# 1) 体检：未全绿(❌)不开始测试
+npm run test:prereqs            # Sepolia
+node scripts/test/check-prereqs.mjs --mainnet
+
+# 2) L1 链上用例（真实交易，写证据台账 docs/test-evidence/）
+npm run test:onchain           # 全部已注册用例
+node scripts/test/onchain/run.mjs TOK-01   # 单条
+```
+
+## 目录
+
+```
+scripts/test/
+  .env.test.example     # 测试变量模板（提交）；.env.test 真值不提交
+  check-prereqs.mjs     # 准备体检（env/服务/RPC/KMS/DVT/余额/AirAccount）
+  onchain/
+    _lib.mjs            # 共享：env 加载、viem 客户端、证据写入
+    run.mjs             # 运行器（注册表 CASES）
+    tok-01-gasless-buy.mjs   # 示例/模板：gasless 买入(已实证)
+docs/test-evidence/<net>/<caseId>.json   # 每条用例的真实凭证(txHash 等)
+```
+
+## 加一条 L1 用例
+
+新建 `onchain/<id>.mjs`，导出 `{ id, desc, run(ctx) }`（`ctx` 见 `_lib.ctx()`：env/chainId/account/publicClient/walletClient/explorer），`run` 返回 `{ actor, txHash, blockNumber, status, artifacts }`；在 `run.mjs` 的 `CASES` 注册。运行器自动写证据台账并按 status 判定。
+
+## L1 路线图（按 TEST_PLAN 用例，逐个补全）
+
+| 脚本 | 用例 | 状态 |
+|---|---|---|
+| `tok-01-gasless-buy.mjs` | TOK-01 gasless 买 aPNTs | ✅ 示例已就绪 |
+| `tok-03-selfpay-buy.mjs` | TOK-03/04 self-pay 买入 | ⏳ 待补 |
+| `tok-11-stake-ticket.mjs` | TOK-11 质押 GToken→SBT | ⏳ |
+| `xfer-01-transfer.mjs` | XFER-01 Tier-2 转账 | ⏳（需 AirAccount + KMS ceremony；半自动） |
+| `grd-03-decrease-limit.mjs` | GRD-03~08 Guard 写 | ⏳（需 AirAccount+guard） |
+| `rec-06-recovery.mjs` | REC-06 社交恢复 | ⏳ |
+| `com-a-02-register.mjs` | COM-A-02 注册社区 | ⏳ |
+| `com-u-01-ticket.mjs` | COM-U-01 购 ticket | ⏳ |
+
+> 凡涉及 AirAccount 设备-passkey ceremony 的（转账/Guard 写/恢复）= **半自动**：L1 脚本走后端 prepare → 在浏览器/CDP 完成 passkey → submit；或用 L3 Playwright + CDP 虚拟认证器全自动。详见 `docs/TEST_PLAN.md §4.6`。
+
+> L2(API e2e) 在 `aastar/test/`；L3(Playwright) 待建 `aastar-frontend/e2e/`。

--- a/scripts/test/check-prereqs.mjs
+++ b/scripts/test/check-prereqs.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Test prerequisite checker — see docs/TEST_PREPARATION.md.
+ * Verifies env vars, services (RPC/bundler/KMS/DVT), and the test EOA's balances.
+ * Exit non-zero if any CRITICAL (❌) item is missing — testing should not start.
+ *
+ *   node scripts/test/check-prereqs.mjs            # Sepolia (default)
+ *   node scripts/test/check-prereqs.mjs --mainnet  # mainnet (needs MAINNET_ENABLED)
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createPublicClient, http, formatEther, formatUnits } from "viem";
+import { sepolia, mainnet, optimism } from "viem/chains";
+import { privateKeyToAccount } from "viem/accounts";
+import { getDvtRelayerUrlsForChain, checkDvtConnectivity } from "@aastar/sdk/core";
+import { TokenSaleClient } from "@aastar/sdk/tokens";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function loadEnv(p) {
+  if (!existsSync(p)) return {};
+  const out = {};
+  for (const line of readFileSync(p, "utf8").split("\n")) {
+    if (line.trim().startsWith("#")) continue;
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+    if (!m) continue;
+    let v = m[2];
+    // Strip an unquoted inline comment ( # …), then surrounding quotes.
+    if (!/^["']/.test(v)) v = v.replace(/\s+#.*$/, "");
+    out[m[1]] = v.replace(/^["']|["']$/g, "").trim();
+  }
+  return out;
+}
+
+const env = {
+  ...loadEnv(join(ROOT, "aastar", ".env")),
+  ...loadEnv(join(ROOT, "scripts", "test", ".env.test")),
+  ...process.env,
+};
+
+const mainnetMode = process.argv.includes("--mainnet");
+const chainId = mainnetMode ? Number(env.MAINNET_CHAIN_ID || 1) : 11155111;
+const chain = chainId === 1 ? mainnet : chainId === 10 ? optimism : sepolia;
+
+let critical = 0;
+let warned = 0;
+const rows = [];
+const ok = (name, detail = "") => rows.push(["✅", name, detail]);
+const bad = (name, detail = "") => {
+  critical++;
+  rows.push(["❌", name, detail]);
+};
+const wrn = (name, detail = "") => {
+  warned++;
+  rows.push(["⚠️ ", name, detail]);
+};
+
+// ── 1. Env vars ───────────────────────────────────────────────
+for (const k of ["JWT_SECRET", "ETH_RPC_URL", "BUNDLER_RPC_URL", "CHAIN_ID"]) {
+  env[k] ? ok(`env ${k}`) : bad(`env ${k}`, "missing (aastar/.env)");
+}
+if (!env.USER_ENCRYPTION_KEY) bad("env USER_ENCRYPTION_KEY", "missing");
+else if (env.USER_ENCRYPTION_KEY.length !== 32)
+  bad("USER_ENCRYPTION_KEY length", `must be 32 chars, got ${env.USER_ENCRYPTION_KEY.length}`);
+else ok("env USER_ENCRYPTION_KEY", "32 chars");
+env.KMS_API_KEY ? ok("env KMS_API_KEY") : wrn("env KMS_API_KEY", "needed for passkey/KMS flows");
+if (mainnetMode && env.MAINNET_ENABLED !== "true")
+  bad("MAINNET_ENABLED", "set true in scripts/test/.env.test to run mainnet cases");
+
+// ── 2. RPC + bundler ──────────────────────────────────────────
+const pc = createPublicClient({ chain, transport: http(env.ETH_RPC_URL) });
+try {
+  const id = await pc.getChainId();
+  id === chainId
+    ? ok("RPC reachable", `chainId ${id}`)
+    : bad("RPC chainId", `expected ${chainId}, got ${id}`);
+} catch (e) {
+  bad("RPC reachable", String(e.message || e).slice(0, 80));
+}
+if (env.BUNDLER_RPC_URL) {
+  try {
+    const r = await fetch(env.BUNDLER_RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_supportedEntryPoints",
+        params: [],
+      }),
+    });
+    r.ok ? ok("Bundler reachable") : wrn("Bundler reachable", `HTTP ${r.status}`);
+  } catch (e) {
+    wrn("Bundler reachable", String(e.message || e).slice(0, 60));
+  }
+}
+
+// ── 3. KMS ────────────────────────────────────────────────────
+if (env.KMS_ENABLED === "true" && env.KMS_ENDPOINT) {
+  try {
+    const r = await fetch(`${env.KMS_ENDPOINT.replace(/\/$/, "")}/version`, {
+      headers: env.KMS_API_KEY ? { "x-api-key": env.KMS_API_KEY } : {},
+    });
+    r.ok ? ok("KMS reachable", env.KMS_ENDPOINT) : wrn("KMS reachable", `HTTP ${r.status}`);
+  } catch (e) {
+    wrn("KMS reachable", String(e.message || e).slice(0, 60));
+  }
+} else {
+  wrn("KMS", "KMS_ENABLED!=true — passkey flows (login/transfer/guard write) unavailable");
+}
+
+// ── 4. DVT relays (gasless buy) — Sepolia only ────────────────
+try {
+  const urls = getDvtRelayerUrlsForChain(chainId);
+  if (urls.length === 0) {
+    wrn("DVT relays", `none for chain ${chainId} (sale/gasless not on this chain)`);
+  } else {
+    const nodes = await checkDvtConnectivity();
+    const online = nodes.filter(n => n.ok).length;
+    online === nodes.length
+      ? ok("DVT relays", `${online}/${nodes.length} online`)
+      : wrn("DVT relays", `${online}/${nodes.length} online`);
+  }
+} catch (e) {
+  wrn("DVT relays", String(e.message || e).slice(0, 60));
+}
+
+// ── 5. Test EOA + balances ────────────────────────────────────
+if (!env.TEST_EOA_PRIVATE_KEY || !/^0x[0-9a-fA-F]{64}$/.test(env.TEST_EOA_PRIVATE_KEY)) {
+  bad("TEST_EOA_PRIVATE_KEY", "set a funded test EOA key in scripts/test/.env.test (L1 on-chain)");
+} else {
+  try {
+    const acct = privateKeyToAccount(env.TEST_EOA_PRIVATE_KEY);
+    ok("TEST_EOA", acct.address);
+    const sale = new TokenSaleClient(pc, undefined, { chainId });
+    const b = await sale.getBalances(acct.address);
+    const check = (label, val, dec, min) => {
+      const human = Number(formatUnits(val, dec));
+      human >= min
+        ? ok(`balance ${label}`, `${human}`)
+        : wrn(`balance ${label}`, `${human} (< ${min} suggested)`);
+    };
+    check("ETH", b.eth, 18, 0.05);
+    check("USDC", b.usdc, 6, 10);
+    check("USDT", b.usdt, 6, 5);
+    check("GToken", b.gToken, 18, 1);
+    check("aPNTs", b.aPNTs, 18, 10);
+  } catch (e) {
+    bad("Test EOA balances", String(e.message || e).slice(0, 80));
+  }
+}
+
+// ── 6. Test AirAccount has a guard (D3) ───────────────────────
+if (env.TEST_AIR_ACCOUNT && /^0x[0-9a-fA-F]{40}$/.test(env.TEST_AIR_ACCOUNT)) {
+  try {
+    const g = await pc.readContract({
+      address: env.TEST_AIR_ACCOUNT,
+      abi: [
+        {
+          type: "function",
+          name: "guard",
+          stateMutability: "view",
+          inputs: [],
+          outputs: [{ type: "address" }],
+        },
+      ],
+      functionName: "guard",
+    });
+    g && g !== "0x0000000000000000000000000000000000000000"
+      ? ok("TEST_AIR_ACCOUNT guard", g)
+      : wrn("TEST_AIR_ACCOUNT guard", "no guard (D3 Guard-write cases will be skipped)");
+  } catch {
+    wrn("TEST_AIR_ACCOUNT", "not deployed / guard() unreadable");
+  }
+} else {
+  wrn("TEST_AIR_ACCOUNT", "unset — D3 Guard-write cases need a deployed account with a guard");
+}
+
+// ── 7. Services (optional) ────────────────────────────────────
+for (const [name, url] of [
+  ["Backend :3000", "http://localhost:3000/api-docs"],
+  ["Frontend :5173", "http://localhost:5173/tokens"],
+]) {
+  try {
+    const r = await fetch(url);
+    r.ok ? ok(name) : wrn(name, `HTTP ${r.status} (start it before L2/L3)`);
+  } catch {
+    wrn(name, "down (start before L2/L3)");
+  }
+}
+
+// ── Report ────────────────────────────────────────────────────
+console.log(`\nTest prerequisites — chain ${chainId} (${chain.name})\n`);
+for (const [icon, name, detail] of rows)
+  console.log(`  ${icon} ${name}${detail ? "  —  " + detail : ""}`);
+console.log(`\n${rows.length} checks · ${critical} critical(❌) · ${warned} warning(⚠️)`);
+if (critical > 0) {
+  console.log(
+    "\n⛔ Critical prerequisites missing — fix the ❌ items before testing (see docs/TEST_PREPARATION.md).\n"
+  );
+  process.exit(1);
+}
+console.log("\n✅ Ready to test (review ⚠️ — some domains may be limited).\n");

--- a/scripts/test/onchain/_lib.mjs
+++ b/scripts/test/onchain/_lib.mjs
@@ -1,0 +1,63 @@
+// Shared helpers for L1 on-chain test cases. See docs/TEST_PLAN.md / TEST_PREPARATION.md.
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createPublicClient, createWalletClient, http } from "viem";
+import { sepolia, mainnet, optimism } from "viem/chains";
+import { privateKeyToAccount } from "viem/accounts";
+
+export const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+export function loadEnv() {
+  const out = {};
+  for (const p of [join(ROOT, "aastar", ".env"), join(ROOT, "scripts", "test", ".env.test")]) {
+    if (!existsSync(p)) continue;
+    for (const line of readFileSync(p, "utf8").split("\n")) {
+      if (line.trim().startsWith("#")) continue;
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+      if (!m) continue;
+      let v = m[2];
+      if (!/^["']/.test(v)) v = v.replace(/\s+#.*$/, "");
+      out[m[1]] = v.replace(/^["']|["']$/g, "").trim();
+    }
+  }
+  return { ...out, ...process.env };
+}
+
+export function chainFor(id) {
+  return id === 1 ? mainnet : id === 10 ? optimism : sepolia;
+}
+
+export function ctx() {
+  const env = loadEnv();
+  const mainnetMode = process.argv.includes("--mainnet");
+  const chainId = mainnetMode ? Number(env.MAINNET_CHAIN_ID || 1) : 11155111;
+  const chain = chainFor(chainId);
+  if (mainnetMode && env.MAINNET_ENABLED !== "true") {
+    throw new Error("Mainnet cases blocked: set MAINNET_ENABLED=true in scripts/test/.env.test");
+  }
+  if (!env.TEST_EOA_PRIVATE_KEY)
+    throw new Error("TEST_EOA_PRIVATE_KEY unset (scripts/test/.env.test)");
+  const account = privateKeyToAccount(env.TEST_EOA_PRIVATE_KEY);
+  const transport = http(env.ETH_RPC_URL);
+  return {
+    env,
+    chainId,
+    chain,
+    account,
+    publicClient: createPublicClient({ chain, transport }),
+    walletClient: createWalletClient({ account, chain, transport }),
+    explorer: chain.blockExplorers?.default?.url ?? "https://sepolia.etherscan.io",
+  };
+}
+
+// Append a real, queryable record to docs/test-evidence/<net>/<caseId>.json.
+export function writeEvidence(caseId, chainId, record) {
+  const net = chainId === 1 ? "mainnet" : chainId === 10 ? "optimism" : "sepolia";
+  const dir = join(ROOT, "docs", "test-evidence", net);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${caseId}.json`);
+  const payload = { caseId, network: net, chainId, ...record, runAt: new Date().toISOString() };
+  writeFileSync(file, JSON.stringify(payload, null, 2));
+  return file;
+}

--- a/scripts/test/onchain/run.mjs
+++ b/scripts/test/onchain/run.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * L1 on-chain test runner. Runs the available cases against the configured chain,
+ * writes a real evidence record (tx hash etc.) per case, and exits non-zero on any
+ * failure. See docs/TEST_PLAN.md (§4.1) and docs/TEST_PREPARATION.md.
+ *
+ *   node scripts/test/onchain/run.mjs                 # all cases, Sepolia
+ *   node scripts/test/onchain/run.mjs TOK-01          # one case
+ *   node scripts/test/onchain/run.mjs --mainnet       # mainnet (needs MAINNET_ENABLED)
+ *
+ * Add a case: drop a `<id>.mjs` exporting { id, desc, run(ctx) } and register it below.
+ */
+import { ctx, writeEvidence } from "./_lib.mjs";
+import * as tok01 from "./tok-01-gasless-buy.mjs";
+
+// Registry — grows as cases land (one per TEST_PLAN case id).
+const CASES = [tok01];
+
+const filter = process.argv.find(a => /^[A-Z]+-\d+$/.test(a));
+const selected = filter ? CASES.filter(c => c.id === filter) : CASES;
+if (selected.length === 0) {
+  console.error(`No case matches "${filter}". Known: ${CASES.map(c => c.id).join(", ")}`);
+  process.exit(1);
+}
+
+const c = ctx();
+console.log(`\nL1 on-chain — chain ${c.chainId} (${c.chain.name}) · actor ${c.account.address}\n`);
+
+let failed = 0;
+for (const tc of selected) {
+  process.stdout.write(`▶ ${tc.id} ${tc.desc} … `);
+  try {
+    const record = await tc.run(c);
+    const file = writeEvidence(tc.id, c.chainId, { desc: tc.desc, ...record, by: "auto" });
+    console.log(`✅  ${c.explorer}/tx/${record.txHash}`);
+    console.log(`   evidence: ${file}`);
+  } catch (e) {
+    failed++;
+    console.log(`❌  ${String(e.message || e).slice(0, 160)}`);
+  }
+}
+
+console.log(`\n${selected.length} case(s) · ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/onchain/tok-01-gasless-buy.mjs
+++ b/scripts/test/onchain/tok-01-gasless-buy.mjs
@@ -1,0 +1,44 @@
+// TOK-01 — gasless aPNTs buy via the DVT relay pool (EIP-3009 + BuyIntent, no ETH).
+// Proven path; see docs/TEST_PLAN.md D2. Buys $1 of aPNTs into the test EOA.
+import { TokenSaleClient, usd } from "@aastar/sdk/tokens";
+import { formatUnits } from "viem";
+
+export const id = "TOK-01";
+export const desc = "Gasless aPNTs buy ($1, USDC) — relayer pays gas";
+
+export async function run({ chainId, account, publicClient, walletClient }) {
+  const sale = new TokenSaleClient(publicClient, walletClient, { chainId });
+  const amount = usd(1);
+  const quoted = await sale.quote("APNTS", amount);
+  if (quoted === 0n) throw new Error("quote 0 — amount too small / sale unavailable");
+  const minOut = (quoted * 98n) / 100n;
+
+  const { txHash, matchedRule } = await sale.buyGasless({
+    token: "APNTS",
+    usdAmount: amount,
+    recipient: account.address,
+    minOut,
+  });
+
+  // Sepolia + relayer can be slow to mine; wait generously before declaring failure.
+  const receipt = await publicClient.waitForTransactionReceipt({
+    hash: txHash,
+    timeout: 180_000,
+    pollingInterval: 5_000,
+  });
+  if (receipt.status !== "success") throw new Error(`tx reverted: ${txHash}`);
+
+  return {
+    actor: account.address,
+    txHash,
+    blockNumber: Number(receipt.blockNumber),
+    gasPayer: receipt.from, // the DVT relayer that sponsored gas
+    status: receipt.status,
+    artifacts: {
+      token: "aPNTs",
+      usdSpent: "1",
+      expectedOut: formatUnits(quoted, 18),
+      matchedRule,
+    },
+  };
+}


### PR DESCRIPTION
## Why SDK 0.26.6 (important)
**0.26.5 — introduced by #362 — regressed the gasless buy.** On 0.26.5, `buyGasless` produces a BuyIntent signature the DVT relayer rejects (`SIGNATURE_INVALID: signer ≠ buyer`), so the /tokens gasless path is **broken on current master**. The new on-chain harness caught this; **0.26.6 fixes the signature** (relayer accepts again). Deps unchanged (viem still a peerDep) — surgical lockfile bump. type-check (both workspaces) + frontend build green.

## Testing harness (per the earlier request)
- **docs/TEST_PLAN.md** — domains × roles × paths (positive/negative/exception), automation-first (viem L1 / Jest L2 / Playwright + CDP virtual-authenticator L3 / manual L4), an execution model with explicit human-intervention points, an on-chain evidence ledger, and a testnet → mainnet promotion gate.
- **docs/TEST_PREPARATION.md** — per-domain prerequisites (env / services / accounts / tokens / keys), where each is configured, how to check.
- **scripts/test/check-prereqs.mjs** (`npm run test:prereqs`) — gates testing: verifies env vars, RPC/bundler/KMS/DVT, test-EOA balances, and the AirAccount's guard; exits non-zero on missing criticals. Already run green on Sepolia (0 critical).
- **scripts/test/onchain/** (`npm run test:onchain`) — L1 runner + shared lib (viem clients + evidence writer) + `tok-01-gasless-buy.mjs` as the first case/template.
- **scripts/test/.env.test.example** — test-var template (real `.env.test` gitignored).

## Note
The harness's TOK-01 run is what surfaced the 0.26.5 regression — exactly its purpose. After the 0.26.6 fix the relayer accepts the buy; the test tx then sat pending on the relayer side (an infra matter, to be raised with the SDK/DVT team separately).