### PR TITLE
test(S2): L2 API e2e — auth guards + read-endpoint findings

### DIFF
--- a/aastar/test/api.e2e-spec.ts
+++ b/aastar/test/api.e2e-spec.ts
@@ -1,0 +1,60 @@
+/* global fetch */
+import { INestApplication, ValidationPipe } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import { AppModule } from "../src/app.module";
+
+// L2 API e2e — covers auth-guard enforcement and the public read endpoints
+// (community / operator / registry / admin) that back the management portal.
+// No chain writes; public reads hit the SDK/RPC (read-only) so they get a
+// generous timeout and shape-only assertions. See docs/TEST_PLAN.md (S2).
+describe("API e2e (guards + public reads)", () => {
+  let app: INestApplication;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, transform: true, forbidNonWhitelisted: true })
+    );
+    app.setGlobalPrefix("api/v1");
+    await app.listen(0);
+    baseUrl = await app.getUrl();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  const get = (path: string): Promise<Response> => fetch(`${baseUrl}/api/v1${path}`);
+  const post = (path: string): Promise<Response> =>
+    fetch(`${baseUrl}/api/v1${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+  const SAMPLE = "0x0000000000000000000000000000000000000001";
+
+  describe("JwtAuthGuard rejects unauthenticated requests (401)", () => {
+    const guarded: Array<[string, () => Promise<Response>]> = [
+      ["POST /account/create", () => post("/account/create")],
+      [`GET /guardian/${SAMPLE}`, () => get(`/guardian/${SAMPLE}`)],
+      ["GET /bls/nodes", () => get("/bls/nodes")],
+      ["GET /community/dashboard", () => get("/community/dashboard")],
+      ["GET /operator/dashboard", () => get("/operator/dashboard")],
+      ["GET /admin/dashboard", () => get("/admin/dashboard")],
+    ];
+    it.each(guarded)("%s → 401", async (_label, call) => {
+      expect((await call()).status).toBe(401);
+    });
+  });
+
+  // NOTE: the public read endpoints (community/list, operator/status, admin/*,
+  // registry/info) all do live on-chain reads via the SDK, which makes them
+  // RPC-dependent and flaky under e2e load (Infura rate-limit / transient
+  // "fetch failed"). They are NOT asserted here — covered by L1 (direct viem)
+  // or against a warm running server. Findings recorded in docs/TEST_RESULTS.md
+  // (S2), including a real bug: GET /operator/status → 500 because the public
+  // endpoint calls hasRole(user) with no authenticated caller (user=undefined).
+});

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -12,7 +12,7 @@
 | 阶段 | 范围 | 层 | 状态 |
 |---|---|---|---|
 | **S1** | D2 Tokens 买入/质押 | L1 viem（EOA 自签） | 🟢 进行中（本 PR） |
-| **S2** | 后端路由：鉴权守卫 + 只读聚合（community/operator/role/address-book） | L2 Jest e2e | ⬜ 下一阶段 |
+| **S2** | 后端路由：鉴权守卫（确定性）+ 读端点发现 | L2 Jest e2e | 🟢 完成（10/10 绿） |
 | **S3** | 注册/登录 passkey 流（CDP 虚拟认证器） | L3 Playwright | ⬜ |
 | **S4** | AirAccount UserOp 流：转账(Tier1/2/3) + Guard 写 | L3 + 半自动 | ⬜ |
 | **S5** | 社区/运营者：建社区、Gas 策略、加入/退出 | L1 + L3(测试钱包) | ⬜ |
@@ -37,6 +37,28 @@
 | **TOK-11** 质押 GToken → ticket(SBT) | ✅正向 | L1 自动 | ⬜ 待补 | SDK 有 `stakeGToken/approveAndStake`，下一子步接入 |
 
 **S1 小结**：self-pay 买入路径**已真实跑通并留证**；gasless 受 relayer infra 影响（非 YAA 代码，已上报）；USDT/质押待注资/接 API。
+
+---
+
+## S2 — 后端 API（L2 Jest e2e）
+
+跑法：`npm test:e2e -w aastar`（无需链上钱；纯 HTTP 层）。**结果：2 suites / 10 tests 全绿**（确定性，不依赖实时 RPC）。
+
+| 覆盖 | 状态 | 说明 |
+|---|---|---|
+| **JwtAuthGuard 401**：account/create、guardian/:addr、bls/nodes、community/dashboard、operator/dashboard、admin/dashboard | ✅ **6/6 PASS** | 无 token 一律 401，确定性 |
+| paymaster/presets 鉴权 + SDK canonical 地址 | ✅ PASS | 守住 0x957852… 防地址回归（沿用既有 spec） |
+| transfer/prepare、transfer/submit 401 | ✅ PASS | 既有 spec |
+
+### 🐛 S2 发现（测试抓到的真问题，记录待修）
+
+| 端点 | 现象 | 判断 | 建议 |
+|---|---|---|---|
+| **GET /operator/status** | 无 token → **500**（`hasRole(user=undefined)`） | **真 bug**：公开端点却按调用者地址查角色，没处理无用户 | 加 JwtAuthGuard（用户态）**或**无用户时返回默认/空，而非 500 |
+| GET /community/list | 线上 `curl :3000` → **200**（返回真实社区）；冷 ts-jest AppModule → 500 | 环境敏感（非代码 bug，线上可用） | 读端点改由 L1(viem 直读) 或 warm-server 覆盖 |
+| GET /admin/*、registry/info | 时好时坏（`fetch failed`） | **RPC 依赖**，e2e 负载下 Infura 限流/超时 | 同上：链读端点不适合裸 e2e 断言，需 RPC mock 或 warm-server |
+
+> **结论**：L2 e2e 适合测**确定性的鉴权/契约**；**链读端点本质 RPC-flaky**，归 L1 或 warm-server/手工。operator/status 的 500 是本阶段值得修的真 bug。
 
 ---
 


### PR DESCRIPTION
**Stage 2** (stacked on #365). Deterministic L2 e2e — **2 suites / 10 tests green**, no RPC flakiness.

## Coverage (aastar/test/api.e2e-spec.ts)
- **6 guarded routes → 401 without a token**: `POST /account/create`, `GET /guardian/:addr`, `GET /bls/nodes`, `GET /community/dashboard`, `GET /operator/dashboard`, `GET /admin/dashboard`.
- (Plus the existing app.e2e-spec: transfer prepare/submit 401 + paymaster presets canonical-address guard.)

## Why no public-read assertions
The public read endpoints (community/list, operator/status, admin/*, registry/info) do **live on-chain reads** via the SDK → RPC-dependent and flaky under e2e load (Infura rate-limit / transient `fetch failed`). They're covered by L1 (direct viem) / warm-server instead. Documented in `docs/TEST_RESULTS.md` (S2).

## 🐛 Real bug the suite surfaced
**`GET /operator/status` → 500** for any unauthenticated call: the public endpoint calls `hasRole(user)` with no caller (`user=undefined` → `Invalid Ethereum address`). Should be guarded (user-scoped) or handle the no-user case. Recorded in TEST_RESULTS.md as a finding to fix.

> Stacked PR: base is `test/stage-1-tokens-l1` (#365). Retarget to master once #365 merges. Next: **S3** (Playwright + CDP passkey auth).