### PR TITLE
test(S1b+S3): Tokens L1 (SDK 0.26.7) + Playwright/CDP passkey e2e — Codex-approved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,8 @@ Thumbs.db
 .playwright-mcp
 # Keep test env templates tracked (the real .env.test stays ignored above)
 !scripts/test/.env.test.example
+
+# Foundry dependency dirs — embedded git repos (forge install), never commit them.
+# Stops a stray add from staging lib/forge-std, 7702/lib/openzeppelin-contracts, etc.
+/lib/
+/7702/lib/

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,8 @@ Thumbs.db
 # Stops a stray add from staging lib/forge-std, 7702/lib/openzeppelin-contracts, etc.
 /lib/
 /7702/lib/
+
+# Playwright (L3 e2e) artifacts
+/aastar-frontend/test-results/
+/aastar-frontend/playwright-report/
+/aastar-frontend/e2e/.results.json

--- a/aastar-frontend/e2e/helpers/webauthn.ts
+++ b/aastar-frontend/e2e/helpers/webauthn.ts
@@ -1,0 +1,22 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Install a CDP virtual WebAuthn authenticator on the page so passkey
+ * register/get ceremonies complete automatically (no real Face ID / device).
+ * Returns the authenticatorId. See docs/TEST_PLAN.md §4.3.
+ */
+export async function installVirtualAuthenticator(page: Page): Promise<string> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("WebAuthn.enable");
+  const { authenticatorId } = await cdp.send("WebAuthn.addVirtualAuthenticator", {
+    options: {
+      protocol: "ctap2",
+      transport: "internal",
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  });
+  return authenticatorId;
+}

--- a/aastar-frontend/e2e/public.spec.ts
+++ b/aastar-frontend/e2e/public.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+import { installVirtualAuthenticator } from "./helpers/webauthn";
+
+// S3 — deterministic browser checks that need no auth/OTP. Covers AUTH-10
+// (guarded routes redirect), the public landing, and the register entry, plus a
+// smoke test that the CDP virtual authenticator installs (the basis for passkey
+// flows in register.spec.ts).
+
+test("landing page loads", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/Cos72/i);
+});
+
+test("AUTH-10: a guarded route redirects to login when unauthenticated", async ({ page }) => {
+  await page.goto("/dashboard");
+  // The Layout guard sends unauthenticated users to the login/auth page.
+  await page.waitForURL(/\/auth\/(login|register)|\/login/, { timeout: 15_000 });
+  expect(page.url()).toMatch(/auth\/(login|register)|login/);
+});
+
+test("register page shows the email step", async ({ page }) => {
+  await page.goto("/auth/register");
+  await expect(page.locator('input[type="email"]')).toBeVisible({ timeout: 15_000 });
+});
+
+test("CDP virtual authenticator installs (passkey-automation basis)", async ({ page }) => {
+  await page.goto("/auth/register");
+  const id = await installVirtualAuthenticator(page);
+  expect(id).toBeTruthy();
+});

--- a/aastar-frontend/e2e/register.spec.ts
+++ b/aastar-frontend/e2e/register.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { installVirtualAuthenticator } from "./helpers/webauthn";
+
+// AUTH-01/02/03 — full passwordless registration, fully automated:
+//   email → OTP (read from the gated devCode, OTP_TEST_MODE=true) → passkey
+//   register ceremony (CDP virtual authenticator) → KMS AirAccount.
+// Requires the backend started with OTP_TEST_MODE=true. See docs/TEST_PLAN.md S3.
+
+test("AUTH-02: register an account end-to-end (OTP + passkey via CDP)", async ({ page }) => {
+  await installVirtualAuthenticator(page);
+
+  // Capture the gated devCode from the OTP request, and the verify response so we
+  // can assert the backend actually created/authenticated the account.
+  let devCode: string | null = null;
+  let verifyBody: { access_token?: string; user?: { email?: string } } | null = null;
+  page.on("response", async resp => {
+    if (resp.url().includes("/auth/otp/request")) {
+      try {
+        const j = await resp.json();
+        if (j?.devCode) devCode = String(j.devCode);
+      } catch {
+        /* non-JSON */
+      }
+    }
+    if (resp.url().includes("/auth/otp/verify")) {
+      try {
+        verifyBody = await resp.json();
+      } catch {
+        /* non-JSON */
+      }
+    }
+  });
+
+  const email = `e2e-${Date.now()}@test.local`;
+  await page.goto("/auth/register");
+
+  // Step 1 — email → send code.
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('button[type="submit"]').click();
+
+  // Wait for the OTP step + the captured code.
+  const otp = page.locator('input[inputMode="numeric"]');
+  await expect(otp).toBeVisible({ timeout: 15_000 });
+  await expect.poll(() => devCode, { timeout: 15_000 }).not.toBeNull();
+
+  // Step 2 — enter code → verify → passkey register (CDP) → KMS account.
+  await otp.fill(devCode!);
+  await page.locator('button[type="submit"]').click();
+
+  // The passkey ceremony auto-completes via the virtual authenticator; the KMS
+  // wallet/account setup then runs. Land on the dashboard (off the auth pages).
+  await page.waitForURL(/\/dashboard|\/$/, { timeout: 45_000 });
+  expect(page.url()).not.toContain("/auth/register");
+
+  // Prove the account was really created — not just a stray redirect:
+  // 1) the verify response authenticated THIS email and returned a token,
+  expect(verifyBody?.access_token, "verifyOtp returned a JWT").toBeTruthy();
+  expect(verifyBody?.user?.email).toBe(email);
+  // 2) the token is persisted, and /auth/profile confirms it server-side.
+  const token = await page.evaluate(() => localStorage.getItem("token"));
+  expect(token).toBeTruthy();
+  const profile = await page.request.get("/api/v1/auth/profile", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(profile.status()).toBe(200);
+  expect((await profile.json())?.email).toBe(email);
+});

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -14,7 +14,8 @@
     "type-check": "tsc --noEmit",
     "i18n:check": "node scripts/check-i18n-parity.mjs",
     "test": "echo \"⚠️  No tests yet - skipping\"",
-    "test:ci": "echo \"⚠️  No tests yet - skipping\""
+    "test:ci": "echo \"⚠️  No tests yet - skipping\"",
+    "test:e2e:ui": "playwright test"
   },
   "dependencies": {
     "@aastar/sdk": "^0.26.7",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.1.16",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -17,7 +17,7 @@
     "test:ci": "echo \"⚠️  No tests yet - skipping\""
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.6",
+    "@aastar/sdk": "^0.26.7",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/playwright.config.ts
+++ b/aastar-frontend/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// L3 browser E2E (see docs/TEST_PLAN.md S3). Runs against the already-running dev
+// servers (frontend :5173 → proxies /api to backend :3000). passkey ceremonies are
+// driven by a CDP virtual authenticator (e2e/helpers/webauthn.ts) — no real device.
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false, // on-chain/KMS side effects — keep serial + stable
+  workers: 1,
+  retries: 0,
+  reporter: [["list"], ["json", { outputFile: "e2e/.results.json" }]],
+  timeout: 60_000,
+  use: {
+    baseURL: process.env.E2E_BASE_URL || "http://localhost:5173",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.6",
+    "@aastar/sdk": "^0.26.7",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/src/auth/auth.service.ts
+++ b/aastar/src/auth/auth.service.ts
@@ -51,7 +51,13 @@ export class AuthService {
       attempts: 0,
     });
     await this.emailService.sendOtp(email, code);
-    return { ok: true, message: "Verification code sent" };
+    // Test affordance (gated): expose the code so e2e (Playwright) can complete the
+    // passwordless flow without a real inbox. Fail-CLOSED — active ONLY when
+    // NODE_ENV === "test" AND OTP_TEST_MODE === "true" (not dev/staging/prod). The
+    // boot guard in AppConfigModule additionally aborts prod startup with the flag.
+    // See docs/TEST_PLAN.md S3.
+    const testMode = process.env.NODE_ENV === "test" && process.env.OTP_TEST_MODE === "true";
+    return { ok: true, message: "Verification code sent", ...(testMode ? { devCode: code } : {}) };
   }
 
   /**

--- a/aastar/src/config/configuration.ts
+++ b/aastar/src/config/configuration.ts
@@ -15,6 +15,14 @@ export default () => {
     throw new Error('DATABASE_URL is required when DB_TYPE is "postgres"');
   }
 
+  // Refuse to boot if the e2e OTP test affordance is enabled outside a test env —
+  // it exposes the real OTP in the request response (see auth.service.requestOtp).
+  if (process.env.OTP_TEST_MODE === "true" && process.env.NODE_ENV !== "test") {
+    throw new Error(
+      "OTP_TEST_MODE=true is only allowed with NODE_ENV=test (it exposes OTP codes). Refusing to start."
+    );
+  }
+
   // EntryPoint / factory / validator addresses are sourced from the @aastar/sdk
   // canonical table (sepoliaV07Config) in sdk.providers.ts — NOT from .env — so
   // there is nothing to validate here.

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -13,7 +13,7 @@
 |---|---|---|---|
 | **S1** | D2 Tokens 买入/质押 | L1 viem（EOA 自签） | 🟢 进行中（本 PR） |
 | **S2** | 后端路由：鉴权守卫（确定性）+ 读端点发现 | L2 Jest e2e | 🟢 完成（10/10 绿） |
-| **S3** | 注册/登录 passkey 流（CDP 虚拟认证器） | L3 Playwright | ⬜ |
+| **S3** | 注册 passkey 流（CDP 虚拟认证器）+ 公开页/鉴权重定向 | L3 Playwright | 🟢 完成（5/5 绿） |
 | **S4** | AirAccount UserOp 流：转账(Tier1/2/3) + Guard 写 | L3 + 半自动 | ⬜ |
 | **S5** | 社区/运营者：建社区、Gas 策略、加入/退出 | L1 + L3(测试钱包) | ⬜ |
 | **L4** | 真机 passkey / 真 MetaMask / 主网真金 | 🧑 人工 | ⬜ 全程人工 |
@@ -62,6 +62,24 @@
 | GET /admin/*、registry/info | 时好时坏（`fetch failed`） | **RPC 依赖**，e2e 负载下 Infura 限流/超时 | 同上：链读端点不适合裸 e2e 断言，需 RPC mock 或 warm-server |
 
 > **结论**：L2 e2e 适合测**确定性的鉴权/契约**；**链读端点本质 RPC-flaky**，归 L1 或 warm-server/手工。operator/status 的 500 是本阶段值得修的真 bug。
+
+---
+
+## S3 — 浏览器 E2E（L3 Playwright + CDP 虚拟认证器）
+
+跑法：`npm run test:e2e:ui -w aastar-frontend`（前端 :5173 + 后端 :3000 需在跑；注册流需后端 `OTP_TEST_MODE=true`）。**结果：5/5 绿。** passkey 用 **CDP `WebAuthn.addVirtualAuthenticator` 全自动**，无需真机。
+
+| 用例 | 型 | 状态 | 说明 |
+|---|---|---|---|
+| **AUTH-02** 注册全流程 | ✅正向 | ✅ **PASS（6s）** | email → **devCode OTP**（gated 测试模式）→ **passkey 注册 ceremony（CDP 虚拟认证器）→ KMS AirAccount** → 落 dashboard，**完全自动** |
+| **AUTH-10** 鉴权重定向 | ⛔逆向 | ✅ PASS | 未登录访问 `/dashboard` → 跳 `/auth/login` |
+| 公开 landing 加载 | ✅正向 | ✅ PASS | 标题 Cos72 |
+| register email step | ✅正向 | ✅ PASS | email 输入可见 |
+| CDP 虚拟认证器装载 | — | ✅ PASS | passkey 自动化基础设施 smoke |
+
+**OTP mock（已确认方案 1）**：后端 `requestOtp` 在 `OTP_TEST_MODE=true` 且**非 production** 时，于响应里附带 `devCode`（6 位真验证码，验证逻辑不变），e2e 读取即可完成注册——**仅测试模式暴露，prod 永不**。
+
+> 基础设施：`aastar-frontend/playwright.config.ts` + `e2e/helpers/webauthn.ts`（CDP 虚拟认证器）+ `e2e/{public,register}.spec.ts`。
 
 ---
 

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -30,13 +30,16 @@
 | 用例 | 型 | 方法 | 状态 | 凭证 / 说明 |
 |---|---|---|---|---|
 | **TOK-03** self-pay 买 GToken（USDC，自付 gas） | ✅正向 | L1 自动 | ✅ **PASS** | tx [`0xab98b5b2…`](https://sepolia.etherscan.io/tx/0xab98b5b26d446be3df3c124642aebc8d446d74a4b4420c2da618ee3a3ea2e111) · block 11127417 · 自付 gas · 6.667 GToken · 证据 `test-evidence/sepolia/TOK-03.json` |
-| **TOK-01** gasless 买 aPNTs（USDC EIP-3009 → DVT relay） | ✅正向 | L1 自动 | 🟡 **部分** | 0.26.4 曾成功（tx `0x49040263…`）；0.26.5 签名回归→0.26.6 已修（relayer 接受）；当前 relayer 侧 tx **pending 未挖出** = infra 层，已报 [aastar-sdk#163](https://github.com/AAStarCommunity/aastar-sdk/issues/163) |
+| **TOK-01** gasless 买 aPNTs（USDC EIP-3009 → DVT relay） | ✅正向 | L1 自动 | ✅ **PASS（0.26.7）** | tx [`0x2360ce02…`](https://sepolia.etherscan.io/tx/0x2360ce021be026e9c3f7db9b8daae723d5d33649c3a4a5de5bcf86598b179832) · relayer 代付 · aPNTs 到账。回归史：0.26.4 成功 → 0.26.5 签名回归 → 0.26.6 relayer pending（[sdk#163](https://github.com/AAStarCommunity/aastar-sdk/issues/163)）→ **0.26.7 EIP-3009 改签 ReceiveWithAuthorization 闭合窗口**，本仓已 bump 0.26.7 |
 | **TOK-04** self-pay 买（USDT） | ✅正向 | L1 自动 | ⛔ **阻塞** | 测试 EOA **USDT 余额 = 0**，需注资后再跑（体检会提示） |
-| **TOK-06** 滑点保护（minOut=quoted×98%） | ⚠️异常 | L1 | ⬜ 待补 | 已在买入脚本内置 2% floor；专项构造劣价用例待补 |
+| **TOK-06** 滑点保护（demand 10× minOut 必须被拒） | ⚠️异常 | L1 自动 | ✅ **PASS** | **断言为合约 revert**（viem `ContractFunctionRevertedError`，非网络/余额错误才算）→ `buyTokens reverted`，滑点保护生效 · 证据 `TOK-06.json` |
 | **TOK-09** gasless 非法收款人拦截 | ⛔逆向 | L3 | ⬜ S3 | UI 层 `isAddress` 校验，归 L3 |
-| **TOK-11** 质押 GToken → ticket(SBT) | ✅正向 | L1 自动 | ⬜ 待补 | SDK 有 `stakeGToken/approveAndStake`，下一子步接入 |
+| **TOK-11** 质押 GToken → ticket(SBT) | ✅正向 | L1 | ⛔ **阻塞** | 见下 🐛：FinanceClient 实例方法在 node 解析错链；且质押是**角色制**（`getStakeInfo{operator,roleId}`），ticket→SBT 非简单 `stake(amount)`，需 SDK 澄清 ticket-mint 流程 |
 
-**S1 小结**：self-pay 买入路径**已真实跑通并留证**；gasless 受 relayer infra 影响（非 YAA 代码，已上报）；USDT/质押待注资/接 API。
+**S1 小结**：gasless（TOK-01，0.26.7 解封）+ self-pay（TOK-03）+ 滑点保护（TOK-06，经 Codex 4 轮加固）**3/3 真实跑通并留证**；USDT 待注资；质押→SBT 阻塞（角色制）。`npm run test:onchain` 默认 3 绿。
+
+### 🐛 S1 发现（待报 SDK）
+- **FinanceClient 实例方法在 node/L1 下解析错链**：`new FinanceClient(pc, wc).getGTokenBalance()/approveAndStake()` 即使先 `applyConfig({chainId:11155111})` 仍命中无代码地址 → `balanceOf returned 0x`。直接 `getCanonicalAddresses(11155111).gToken` 的 `balanceOf` 正常（379.67）。疑似 `@aastar/sdk/core` 与 `/tokens` 两个 entry 的 config state 不共享。**workaround**：用显式 `getCanonicalAddresses(chainId)` + 静态 `stakeGToken`（TOK-11 脚本已采用，但卡在角色制质押语义）。
 
 ---
 

--- a/docs/test-evidence/sepolia/TOK-01.json
+++ b/docs/test-evidence/sepolia/TOK-01.json
@@ -1,0 +1,19 @@
+{
+  "caseId": "TOK-01",
+  "network": "sepolia",
+  "chainId": 11155111,
+  "desc": "Gasless aPNTs buy ($1, USDC) — relayer pays gas",
+  "actor": "0xb5600060e6de5E11D3636731964218E53caadf0E",
+  "txHash": "0x730f0af9950bdb4fd45af18cfeb88c11d03233a34dad623fc9aec0c63a29913e",
+  "blockNumber": 11128317,
+  "gasPayer": "0x214de9df4442e130f095083ece3f67c8f2eab6b7",
+  "status": "success",
+  "artifacts": {
+    "token": "aPNTs",
+    "usdSpent": "1",
+    "expectedOut": "50",
+    "matchedRule": "TOKEN_BUY → aPNTs"
+  },
+  "by": "auto",
+  "runAt": "2026-06-24T07:09:02.298Z"
+}

--- a/docs/test-evidence/sepolia/TOK-03.json
+++ b/docs/test-evidence/sepolia/TOK-03.json
@@ -4,9 +4,9 @@
   "chainId": 11155111,
   "desc": "Self-pay GToken buy ($1, USDC) — EOA pays gas",
   "actor": "0xb5600060e6de5E11D3636731964218E53caadf0E",
-  "txHash": "0xab98b5b26d446be3df3c124642aebc8d446d74a4b4420c2da618ee3a3ea2e111",
+  "txHash": "0xf7c48d6aedf1e01498982fc2c458cb0a8ba745f5fdd9f87bd52884fe09936a62",
   "approveTxHash": null,
-  "blockNumber": 11127417,
+  "blockNumber": 11128319,
   "gasPayer": "0xb5600060e6de5e11d3636731964218e53caadf0e",
   "status": "success",
   "artifacts": {
@@ -16,5 +16,5 @@
     "expectedOut": "6.666666666666666666"
   },
   "by": "auto",
-  "runAt": "2026-06-24T04:06:29.821Z"
+  "runAt": "2026-06-24T07:09:26.149Z"
 }

--- a/docs/test-evidence/sepolia/TOK-06.json
+++ b/docs/test-evidence/sepolia/TOK-06.json
@@ -1,0 +1,18 @@
+{
+  "caseId": "TOK-06",
+  "network": "sepolia",
+  "chainId": 11155111,
+  "desc": "Slippage guard — impossible minOut reverts in buyTokens",
+  "actor": "0xb5600060e6de5E11D3636731964218E53caadf0E",
+  "txHash": null,
+  "status": "rejected-as-expected",
+  "artifacts": {
+    "test": "slippage guard (GToken self-pay)",
+    "usdcBalance": "284",
+    "quoted": "6.666666666666666666",
+    "demandedMinOut": "66.66666666666666666",
+    "contractRevert": "The contract function \"buyTokens\" reverted."
+  },
+  "by": "auto",
+  "runAt": "2026-06-24T07:09:42.264Z"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.26.6",
+        "@aastar/sdk": "^0.26.7",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.26.6",
+        "@aastar/sdk": "^0.26.7",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1427,9 +1427,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.26.6",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.6.tgz",
-      "integrity": "sha512-XvrPJUoyj8vP6LaDZYetorBQG6w29V9kHytC9om6oJp0uVNWXE5YDoWoZd4FwP/homWj0WwGOh3Y+HZa3mwg3Q==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.7.tgz",
+      "integrity": "sha512-GQRmYw5o+gRrud5gcKU061AUHph1B4R+DWSgU2P99a0hFuhqxp3LVI7xTPS2K9hDIKhv9AueQ2iLtjbbDbmx7Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.1.16",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.46.2",
@@ -5122,6 +5123,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmmirror.com/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-aria/focus": {
@@ -15494,6 +15511,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmmirror.com/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmmirror.com/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/scripts/test/onchain/_lib.mjs
+++ b/scripts/test/onchain/_lib.mjs
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import { createPublicClient, createWalletClient, http } from "viem";
 import { sepolia, mainnet, optimism } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
+import { applyConfig } from "@aastar/sdk/core";
 
 export const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
@@ -38,6 +39,9 @@ export function ctx() {
   }
   if (!env.TEST_EOA_PRIVATE_KEY)
     throw new Error("TEST_EOA_PRIVATE_KEY unset (scripts/test/.env.test)");
+  // Point the SDK's global canonical-address config at the target chain. Clients
+  // that don't take an explicit chainId (e.g. FinanceClient) read from this.
+  applyConfig({ chainId });
   const account = privateKeyToAccount(env.TEST_EOA_PRIVATE_KEY);
   const transport = http(env.ETH_RPC_URL);
   return {

--- a/scripts/test/onchain/run.mjs
+++ b/scripts/test/onchain/run.mjs
@@ -13,15 +13,22 @@
 import { ctx, writeEvidence } from "./_lib.mjs";
 import * as tok01 from "./tok-01-gasless-buy.mjs";
 import * as tok03 from "./tok-03-selfpay-buy.mjs";
+import * as tok06 from "./tok-06-slippage.mjs";
+import * as tok11 from "./tok-11-stake.mjs";
 
 // Registry — grows as cases land (one per TEST_PLAN case id).
-const CASES = [tok01, tok03];
+const CASES = [tok01, tok03, tok06, tok11];
 
 const filter = process.argv.find(a => /^[A-Z]+-\d+$/.test(a));
-const selected = filter ? CASES.filter(c => c.id === filter) : CASES;
+// A named case runs even if blocked (to re-check it); the default run skips blocked.
+const selected = filter ? CASES.filter(c => c.id === filter) : CASES.filter(c => !c.blocked);
 if (selected.length === 0) {
   console.error(`No case matches "${filter}". Known: ${CASES.map(c => c.id).join(", ")}`);
   process.exit(1);
+}
+const skipped = filter ? [] : CASES.filter(c => c.blocked);
+if (skipped.length) {
+  console.log(`(skipping blocked: ${skipped.map(c => `${c.id} — ${c.blocked}`).join("; ")})`);
 }
 
 const c = ctx();
@@ -33,7 +40,8 @@ for (const tc of selected) {
   try {
     const record = await tc.run(c);
     const file = writeEvidence(tc.id, c.chainId, { desc: tc.desc, ...record, by: "auto" });
-    console.log(`✅  ${c.explorer}/tx/${record.txHash}`);
+    // Negative tests (slippage/guard rejection) have no tx — show their status instead.
+    console.log(`✅  ${record.txHash ? `${c.explorer}/tx/${record.txHash}` : record.status}`);
     console.log(`   evidence: ${file}`);
   } catch (e) {
     failed++;

--- a/scripts/test/onchain/tok-06-slippage.mjs
+++ b/scripts/test/onchain/tok-06-slippage.mjs
@@ -1,0 +1,69 @@
+// TOK-06 — slippage guard (negative/security test). Demand 10× the quote as
+// minOut; the buy MUST be rejected by the CONTRACT's slippage floor.
+//
+// False-positive hardening (Codex review):
+//  - The caught error must be a revert from `buyTokens` (viem functionName), not a
+//    network/quote error → else rethrow.
+//  - USDC balance is pre-asserted >= spend, so a `buyTokens` revert cannot be the
+//    internal USDC transferFrom failing for lack of funds. (Allowance is exercised
+//    by TOK-03's fair-minOut buy in the same suite — the positive control.)
+// Residual: distinguishing a slippage revert from a (well-funded, approved)
+// transferFrom revert would need the sale's custom-error selector, which the SDK
+// doesn't surface; given the balance pre-check + TOK-03 control, the 10× minOut is
+// the only induced failure, so the revert is the slippage floor.
+import { TokenSaleClient, usd } from "@aastar/sdk/tokens";
+import { BaseError, ContractFunctionExecutionError, formatUnits } from "viem";
+
+export const id = "TOK-06";
+export const desc = "Slippage guard — impossible minOut reverts in buyTokens";
+
+export async function run({ account, chainId, publicClient, walletClient }) {
+  const sale = new TokenSaleClient(publicClient, walletClient, { chainId });
+  const amount = usd(1);
+  const quoted = await sale.quote("GTOKEN", amount);
+  if (quoted === 0n) throw new Error("quote 0 — cannot run slippage test");
+
+  // Rule out a balance-driven transferFrom revert: USDC must cover the spend.
+  const balances = await sale.getBalances(account.address);
+  if (balances.usdc < amount) {
+    throw new Error(`insufficient USDC for slippage test: have ${formatUnits(balances.usdc, 6)}`);
+  }
+
+  const impossibleMinOut = quoted * 10n; // 10× a fair fill — unreachable at any price
+  let revertMsg = null;
+  try {
+    await sale.buySelfPay({
+      token: "GTOKEN",
+      usdAmount: amount,
+      payToken: "USDC",
+      minOut: impossibleMinOut,
+    });
+  } catch (e) {
+    const msg = String(e?.shortMessage || e?.message || "");
+    const execErr =
+      e instanceof BaseError ? e.walk(err => err instanceof ContractFunctionExecutionError) : null;
+    const fromBuyTokens = execErr?.functionName === "buyTokens" || /buyTokens/i.test(msg);
+    if (!/revert/i.test(msg) || !fromBuyTokens) {
+      throw new Error(
+        `expected a buyTokens revert, got: ${msg.slice(0, 160) || String(e).slice(0, 160)}`
+      );
+    }
+    revertMsg = (execErr?.shortMessage || msg).toString().slice(0, 160);
+  }
+  if (revertMsg === null) {
+    throw new Error("SLIPPAGE GUARD FAILED — 10× minOut buy succeeded");
+  }
+
+  return {
+    actor: account.address,
+    txHash: null, // negative test: the proof is the contract revert, no successful tx
+    status: "rejected-as-expected",
+    artifacts: {
+      test: "slippage guard (GToken self-pay)",
+      usdcBalance: formatUnits(balances.usdc, 6),
+      quoted: formatUnits(quoted, 18),
+      demandedMinOut: formatUnits(impossibleMinOut, 18),
+      contractRevert: revertMsg,
+    },
+  };
+}

--- a/scripts/test/onchain/tok-11-stake.mjs
+++ b/scripts/test/onchain/tok-11-stake.mjs
@@ -1,0 +1,83 @@
+// TOK-11 — stake GToken (the ticket/SBT path: GToken stake → ticket).
+// NOTE: FinanceClient's INSTANCE methods (approveAndStake/getGTokenBalance) don't
+// reliably resolve the configured chain's GToken in a node/L1 context (looks like
+// SDK config state isn't shared across /core and /tokens entrypoints) — they hit a
+// no-code address and revert with `balanceOf returned 0x`. Worked around with
+// explicit canonical addresses + the static stakeGToken; reported to the SDK.
+import { FinanceClient } from "@aastar/sdk/tokens";
+import { getCanonicalAddresses, ERC20ABI } from "@aastar/sdk/core";
+import { parseEther, formatEther } from "viem";
+
+export const id = "TOK-11";
+export const desc = "Stake GToken (ticket/SBT path) — 1 GToken";
+// Skipped in the default run: stake() reverts — staking is role-based and the
+// ticket→SBT mint flow needs SDK clarification (see docs/TEST_RESULTS.md S1).
+export const blocked = "stake() reverts — role-based staking / ticket-mint flow TBD";
+
+export async function run({ chainId, account, publicClient, walletClient }) {
+  const { gToken, staking } = getCanonicalAddresses(chainId);
+  const amount = parseEther("1");
+
+  const bal = addr =>
+    publicClient.readContract({
+      address: gToken,
+      abi: ERC20ABI,
+      functionName: "balanceOf",
+      args: [addr],
+    });
+  const before = await bal(account.address);
+  if (before < amount) throw new Error(`insufficient GToken: have ${formatEther(before)}, need 1`);
+
+  // Approve the staking contract for the GToken if needed (standard ERC-20).
+  const allowance = await publicClient.readContract({
+    address: gToken,
+    abi: ERC20ABI,
+    functionName: "allowance",
+    args: [account.address, staking],
+  });
+  let approveTxHash = null;
+  if (allowance < amount) {
+    approveTxHash = await walletClient.writeContract({
+      address: gToken,
+      abi: ERC20ABI,
+      functionName: "approve",
+      args: [staking, amount],
+    });
+    const approveReceipt = await publicClient.waitForTransactionReceipt({
+      hash: approveTxHash,
+      timeout: 120_000,
+      pollingInterval: 5_000,
+    });
+    if (approveReceipt.status !== "success") throw new Error(`approve reverted: ${approveTxHash}`);
+  }
+
+  const txHash = await FinanceClient.stakeGToken(walletClient, staking, amount);
+  const receipt = await publicClient.waitForTransactionReceipt({
+    hash: txHash,
+    timeout: 180_000,
+    pollingInterval: 5_000,
+  });
+  if (receipt.status !== "success") throw new Error(`tx reverted: ${txHash}`);
+
+  // The stake must actually move the GToken out of the account.
+  const after = await bal(account.address);
+  if (after !== before - amount) {
+    throw new Error(
+      `stake did not debit GToken: before ${formatEther(before)}, after ${formatEther(after)}`
+    );
+  }
+  return {
+    actor: account.address,
+    txHash,
+    approveTxHash,
+    blockNumber: Number(receipt.blockNumber),
+    gasPayer: receipt.from,
+    status: receipt.status,
+    artifacts: {
+      staked: "1 GToken",
+      stakingContract: staking,
+      gTokenBefore: formatEther(before),
+      gTokenAfter: formatEther(after),
+    },
+  };
+}


### PR DESCRIPTION
Test build-out — **S1b (Tokens L1)** + **S3 (Playwright L3)**. Bundled because they share `package.json` / `TEST_RESULTS.md` / `.gitignore`; both follow the self-review → Codex → PR flow. Ledger: `docs/TEST_RESULTS.md`.

## S1b — Tokens L1 (SDK 0.26.7)
- **SDK 0.26.6 → 0.26.7** unblocks gasless: 0.26.7 signs EIP-3009 **ReceiveWithAuthorization** matching the relay's BuyHelper, closing the pending-tx window (aastar-sdk#163). **TOK-01 PASSES live** (tx `0x2360ce02…`, relayer-sponsored).
- **TOK-06 slippage guard**: 10× minOut must revert in `buyTokens` (asserts a contract revert + USDC-balance pre-check, no false positives). **4 rounds of Codex → APPROVE.**
- **TOK-11 stake**: documented blocked (role-based staking / ticket-mint TBD), skipped in the default run.
- Harness: `blocked` flag, negative-test status display, `applyConfig(chainId)`.
- **Default `npm run test:onchain` green: TOK-01 / TOK-03 / TOK-06.**

## S3 — Playwright + CDP virtual authenticator (L3)
- passkey ceremonies fully automated via CDP `WebAuthn.addVirtualAuthenticator` — **no real device**. **5/5 green.**
- **AUTH-02**: full register — email → OTP → passkey → KMS AirAccount, asserting `access_token` + `user.email` + `GET /auth/profile` (proves real account creation). Plus AUTH-10 guard redirect + public-page checks.
- **OTP test affordance, fail-CLOSED**: `requestOtp` returns `devCode` ONLY when `NODE_ENV==="test" && OTP_TEST_MODE==="true"`; an AppConfigModule **boot guard** throws if the flag is set outside a test env (prod can't start with it). Verification logic unchanged. Codex's 3 gate/assertion findings → all RESOLVED.

## .gitignore
Ignore Foundry dep dirs `/lib/`, `/7702/lib/` (embedded repos) + Playwright artifacts.

## Deferred (ticketed)
- **#369** — per-email/IP rate limiting on the OTP endpoints (pre-existing; Codex flagged as separate hardening).

Verification: type-check (both) + lint + L1 (3/3 on-chain) + L3 (5/5) all green. Codex-approved (S1b: 4 rounds; S3: 3 findings resolved + 1 deferred to #369).
