### PR TITLE
test(S4): AirAccount transfer e2e — deploy + execute via passkey (passing, Codex-reviewed)

### DIFF
--- a/aastar-frontend/e2e/helpers/fund.ts
+++ b/aastar-frontend/e2e/helpers/fund.ts
@@ -1,11 +1,18 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createPublicClient, createWalletClient, http, parseEther, type Address } from "viem";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  parseEther,
+  parseGwei,
+  type Address,
+} from "viem";
 import { sepolia } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 
-// Fund a fresh AirAccount with Sepolia ETH (for self-pay deploy + transfer gas in
-// S4). Uses the same TEST_EOA_PRIVATE_KEY as the L1 harness. See docs/TEST_PLAN.md S4.
+// On-chain helpers for S4 (fund a fresh AirAccount, read balances/code, wait for an
+// effect). Uses the same TEST_EOA_PRIVATE_KEY as the L1 harness. See TEST_PLAN S4.
 const ROOT = join(process.cwd(), "..");
 
 function env(key: string): string | undefined {
@@ -24,15 +31,59 @@ function env(key: string): string | undefined {
   return process.env[key];
 }
 
+const client = () => createPublicClient({ chain: sepolia, transport: http(env("ETH_RPC_URL")) });
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
 export async function fundWithEth(to: Address, eth: string): Promise<string> {
   const key = env("TEST_EOA_PRIVATE_KEY");
-  const rpc = env("ETH_RPC_URL");
   if (!key) throw new Error("TEST_EOA_PRIVATE_KEY unset (scripts/test/.env.test)");
   const account = privateKeyToAccount(key as `0x${string}`);
-  const transport = http(rpc);
+  const transport = http(env("ETH_RPC_URL"));
   const pc = createPublicClient({ chain: sepolia, transport });
   const wc = createWalletClient({ account, chain: sepolia, transport });
-  const hash = await wc.sendTransaction({ to, value: parseEther(eth) });
-  await pc.waitForTransactionReceipt({ hash, timeout: 120_000, pollingInterval: 5_000 });
+  // Explicit, healthy gas so the fund tx is included promptly (Sepolia mempools
+  // drop / stall under-priced txs).
+  const hash = await wc.sendTransaction({
+    to,
+    value: parseEther(eth),
+    maxFeePerGas: parseGwei("12"),
+    maxPriorityFeePerGas: parseGwei("2"),
+  });
+  const receipt = await pc.waitForTransactionReceipt({
+    hash,
+    timeout: 120_000,
+    pollingInterval: 3_000,
+  });
+  if (receipt.status !== "success") throw new Error(`fund tx reverted: ${hash}`);
   return hash;
+}
+
+export async function getEthBalance(addr: Address): Promise<bigint> {
+  return client().getBalance({ address: addr });
+}
+
+export async function getCode(addr: Address): Promise<string> {
+  return (await client().getBytecode({ address: addr })) ?? "0x";
+}
+
+/**
+ * Poll until `addr`'s ETH balance has risen by at least `minDelta` from `baseline`.
+ * This is the real proof a transfer EXECUTED — an ERC-4337 account can be deployed
+ * (initCode) while the inner call reverts, so "has bytecode" alone is not enough
+ * (Codex review). Returns the new balance; throws on timeout.
+ */
+export async function waitForBalanceIncrease(
+  addr: Address,
+  baseline: bigint,
+  minDelta: bigint,
+  timeoutMs = 150_000
+): Promise<bigint> {
+  const pc = client();
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const bal = await pc.getBalance({ address: addr });
+    if (bal - baseline >= minDelta) return bal;
+    await sleep(4_000);
+  }
+  throw new Error(`${addr} balance did not rise by ${minDelta} wei within ${timeoutMs}ms`);
 }

--- a/aastar-frontend/e2e/helpers/fund.ts
+++ b/aastar-frontend/e2e/helpers/fund.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createPublicClient, createWalletClient, http, parseEther, type Address } from "viem";
+import { sepolia } from "viem/chains";
+import { privateKeyToAccount } from "viem/accounts";
+
+// Fund a fresh AirAccount with Sepolia ETH (for self-pay deploy + transfer gas in
+// S4). Uses the same TEST_EOA_PRIVATE_KEY as the L1 harness. See docs/TEST_PLAN.md S4.
+const ROOT = join(process.cwd(), "..");
+
+function env(key: string): string | undefined {
+  for (const p of [join(ROOT, "scripts", "test", ".env.test"), join(ROOT, "aastar", ".env")]) {
+    if (!existsSync(p)) continue;
+    for (const line of readFileSync(p, "utf8").split("\n")) {
+      if (line.trim().startsWith("#")) continue;
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+      if (m && m[1] === key)
+        return m[2]
+          .replace(/\s+#.*$/, "")
+          .replace(/^["']|["']$/g, "")
+          .trim();
+    }
+  }
+  return process.env[key];
+}
+
+export async function fundWithEth(to: Address, eth: string): Promise<string> {
+  const key = env("TEST_EOA_PRIVATE_KEY");
+  const rpc = env("ETH_RPC_URL");
+  if (!key) throw new Error("TEST_EOA_PRIVATE_KEY unset (scripts/test/.env.test)");
+  const account = privateKeyToAccount(key as `0x${string}`);
+  const transport = http(rpc);
+  const pc = createPublicClient({ chain: sepolia, transport });
+  const wc = createWalletClient({ account, chain: sepolia, transport });
+  const hash = await wc.sendTransaction({ to, value: parseEther(eth) });
+  await pc.waitForTransactionReceipt({ hash, timeout: 120_000, pollingInterval: 5_000 });
+  return hash;
+}

--- a/aastar-frontend/e2e/helpers/register.ts
+++ b/aastar-frontend/e2e/helpers/register.ts
@@ -1,0 +1,58 @@
+import { expect, type Page } from "@playwright/test";
+import { installVirtualAuthenticator } from "./webauthn";
+
+/**
+ * Register a fresh passwordless account end-to-end (email → gated devCode OTP →
+ * passkey via CDP → KMS AirAccount) and return its identifiers. Requires the
+ * backend started with NODE_ENV=test OTP_TEST_MODE=true. See docs/TEST_PLAN.md S4.
+ */
+export async function registerAccount(
+  page: Page
+): Promise<{ email: string; token: string; address: string }> {
+  await installVirtualAuthenticator(page);
+
+  let devCode: string | null = null;
+  page.on("response", async resp => {
+    if (resp.url().includes("/auth/otp/request")) {
+      try {
+        const j = await resp.json();
+        if (j?.devCode) devCode = String(j.devCode);
+      } catch {
+        /* non-JSON */
+      }
+    }
+  });
+
+  const email = `e2e-${Date.now()}@test.local`;
+  await page.goto("/auth/register");
+  await page.locator('input[type="email"]').fill(email);
+  await page.locator('button[type="submit"]').click();
+
+  const otp = page.locator('input[inputMode="numeric"]');
+  await expect(otp).toBeVisible({ timeout: 15_000 });
+  await expect.poll(() => devCode, { timeout: 15_000 }).not.toBeNull();
+  await otp.fill(devCode!);
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL(/\/dashboard|\/$/, { timeout: 45_000 });
+
+  const token = (await page.evaluate(() => localStorage.getItem("token"))) as string;
+  expect(token).toBeTruthy();
+  const auth = { headers: { Authorization: `Bearer ${token}` } };
+
+  // A fresh user has a passkey + KMS wallet but no AirAccount yet (GET /account →
+  // 204). Create it counterfactually (deploy:false) so the first transfer deploys it.
+  let res = await page.request.get("/api/v1/account", auth);
+  if (res.status() === 204) {
+    const created = await page.request.post("/api/v1/account/create", {
+      ...auth,
+      data: { deploy: false, entryPointVersion: "0.7" },
+    });
+    expect(created.ok(), `account/create: ${created.status()}`).toBeTruthy();
+    res = await page.request.get("/api/v1/account", auth);
+  }
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as { address?: string; account?: { address?: string } };
+  const address = body.address ?? body.account?.address;
+  expect(address, "account has an address").toBeTruthy();
+  return { email, token, address: address! };
+}

--- a/aastar-frontend/e2e/transfer.spec.ts
+++ b/aastar-frontend/e2e/transfer.spec.ts
@@ -1,58 +1,61 @@
 import { test, expect } from "@playwright/test";
+import { parseEther } from "viem";
 import { registerAccount } from "./helpers/register";
-import { fundWithEth } from "./helpers/fund";
+import { fundWithEth, getEthBalance, getCode, waitForBalanceIncrease } from "./helpers/fund";
 
-// S4 / XFER-01 — the AirAccount two-phase device-passkey transfer, end to end:
-// register a fresh account (CDP passkey) → fund it with ETH → its FIRST transfer
-// deploys the account (initCode) and executes, with the passkey ceremony driven by
-// the CDP virtual authenticator. Self-pay (usePaymaster off) so it needs only ETH.
-// Requires the backend on NODE_ENV=test OTP_TEST_MODE=true. See docs/TEST_PLAN.md S4.
+// S4 / XFER-01 — a fresh account's first transfer deploys (initCode) + executes via
+// the passkey ceremony (KMS + BLS signer network + bundler). DVT/BLS must be online.
+// Proof of execution is the RECIPIENT's balance rising by the sent amount — not just
+// "account has bytecode" (deploy can succeed while the inner call reverts) — per Codex.
 
-const RECIPIENT = "0xb5600060e6de5E11D3636731964218E53caadf0E"; // the test EOA
+const RECIPIENT = "0xb5600060e6de5E11D3636731964218E53caadf0E" as const; // the test EOA
+const AMOUNT = "0.001";
 
-// WIP / blocked: register → account-create(v0.7) → fund all work (verified), but
-// the /transfer form doesn't render for a fresh UNDEPLOYED account (the page's load
-// path — likely the balance fetch — gates the form behind `loading.page`). Past
-// that lies the full strict ceremony (KMS BeginAuth + BLS signer network + bundler
-// + first-tx deploy), which has external deps. Tracked for follow-up; see
-// docs/TEST_RESULTS.md S4. fixme so the suite stays green.
-test.fixme("XFER-01: fresh account first transfer (deploy + execute via passkey)", async ({
-  page,
-}) => {
-  test.setTimeout(180_000);
+test("XFER-01: fresh account first transfer (deploy + execute via passkey)", async ({ page }) => {
+  test.setTimeout(240_000);
 
   const { address } = await registerAccount(page);
-
-  // Fund the new account for self-pay deploy + transfer gas.
   await fundWithEth(address as `0x${string}`, "0.02");
 
-  // Capture the submit result (UserOpHash / txHash) to confirm on-chain.
-  let submitBody: { userOpHash?: string; txHash?: string; transactionHash?: string } | null = null;
-  page.on("response", async resp => {
-    if (resp.url().includes("/transfer/submit")) {
-      try {
-        submitBody = await resp.json();
-      } catch {
-        /* non-JSON */
-      }
-    }
-  });
+  // Pre-condition: the account is NOT yet deployed (the transfer must deploy it),
+  // so the post-checks can't pass vacuously.
+  expect(await getCode(address as `0x${string}`), "account undeployed before transfer").toBe("0x");
+  const recipientBefore = await getEthBalance(RECIPIENT);
 
+  // Reload /dashboard so DashboardContext caches the just-created account, then
+  // /transfer reads it from cache and renders the form.
+  await page.goto("/dashboard");
+  await page.reload();
+  await page.waitForLoadState("networkidle");
   await page.goto("/transfer");
-  await page.locator('input[name="to"]').fill(RECIPIENT);
-  await page.locator('input[name="amount"]').fill("0.001");
-  // The transfer button text varies; submit the form / click the primary action.
-  await page.locator('button[type="submit"]').first().click();
-
-  // The passkey assertion auto-completes via the virtual authenticator; the strict
-  // two-phase flow (KMS + BLS + bundler) then submits + deploys.
-  await expect(page.getByText(/submitted|success|tracking/i).first()).toBeVisible({
-    timeout: 150_000,
+  await expect(page.locator('input[name="to"]'), "transfer form rendered").toBeVisible({
+    timeout: 30_000,
   });
 
-  // The submit returned an on-chain handle.
+  await page.locator('input[name="to"]').fill(RECIPIENT);
+  await page.locator('input[name="amount"]').fill(AMOUNT);
+  const sendBtn = page.getByRole("button", { name: /^send (transfer|[a-z]+)/i });
+  await expect(sendBtn).toBeEnabled({ timeout: 30_000 });
+
+  // Capture the submit response synchronously (no unawaited listener race).
+  const [submitResp] = await Promise.all([
+    page.waitForResponse(r => r.url().includes("/transfer/submit"), { timeout: 180_000 }),
+    sendBtn.click(),
+  ]);
+  const submitBody = (await submitResp.json()) as {
+    userOpHash?: string;
+    txHash?: string;
+    transactionHash?: string;
+  };
   expect(
-    submitBody?.userOpHash || submitBody?.txHash || submitBody?.transactionHash,
+    submitBody.userOpHash || submitBody.txHash || submitBody.transactionHash,
     "submit returned a UserOpHash/txHash"
   ).toBeTruthy();
+
+  // The real proof the UserOp EXECUTED: the recipient actually received the ETH.
+  await waitForBalanceIncrease(RECIPIENT, recipientBefore, parseEther(AMOUNT));
+  // And the account got deployed in the same op.
+  expect(await getCode(address as `0x${string}`), "account deployed by the transfer").not.toBe(
+    "0x"
+  );
 });

--- a/aastar-frontend/e2e/transfer.spec.ts
+++ b/aastar-frontend/e2e/transfer.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { parseEther } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { registerAccount } from "./helpers/register";
 import { fundWithEth, getEthBalance, getCode, waitForBalanceIncrease } from "./helpers/fund";
 
@@ -7,8 +8,10 @@ import { fundWithEth, getEthBalance, getCode, waitForBalanceIncrease } from "./h
 // the passkey ceremony (KMS + BLS signer network + bundler). DVT/BLS must be online.
 // Proof of execution is the RECIPIENT's balance rising by the sent amount — not just
 // "account has bytecode" (deploy can succeed while the inner call reverts) — per Codex.
+// The recipient is a FRESH per-test EOA (zero balance, no external traffic) so no
+// concurrent tx can race the assertion; the final balance must equal EXACTLY the sent
+// amount.
 
-const RECIPIENT = "0xb5600060e6de5E11D3636731964218E53caadf0E" as const; // the test EOA
 const AMOUNT = "0.001";
 
 test("XFER-01: fresh account first transfer (deploy + execute via passkey)", async ({ page }) => {
@@ -17,10 +20,14 @@ test("XFER-01: fresh account first transfer (deploy + execute via passkey)", asy
   const { address } = await registerAccount(page);
   await fundWithEth(address as `0x${string}`, "0.02");
 
+  // Fresh recipient: a brand-new EOA with zero balance and no external traffic, so
+  // the balance assertion can't be satisfied by a concurrent unrelated tx (Codex).
+  const RECIPIENT = privateKeyToAccount(generatePrivateKey()).address;
+
   // Pre-condition: the account is NOT yet deployed (the transfer must deploy it),
   // so the post-checks can't pass vacuously.
   expect(await getCode(address as `0x${string}`), "account undeployed before transfer").toBe("0x");
-  const recipientBefore = await getEthBalance(RECIPIENT);
+  expect(await getEthBalance(RECIPIENT), "fresh recipient starts empty").toBe(0n);
 
   // Reload /dashboard so DashboardContext caches the just-created account, then
   // /transfer reads it from cache and renders the form.
@@ -52,8 +59,11 @@ test("XFER-01: fresh account first transfer (deploy + execute via passkey)", asy
     "submit returned a UserOpHash/txHash"
   ).toBeTruthy();
 
-  // The real proof the UserOp EXECUTED: the recipient actually received the ETH.
-  await waitForBalanceIncrease(RECIPIENT, recipientBefore, parseEther(AMOUNT));
+  // The real proof the UserOp EXECUTED: the fresh recipient received the ETH, and
+  // since it started at 0 with no other traffic, its balance must equal EXACTLY the
+  // sent amount.
+  const finalBal = await waitForBalanceIncrease(RECIPIENT, 0n, parseEther(AMOUNT));
+  expect(finalBal, "recipient received exactly the sent amount").toBe(parseEther(AMOUNT));
   // And the account got deployed in the same op.
   expect(await getCode(address as `0x${string}`), "account deployed by the transfer").not.toBe(
     "0x"

--- a/aastar-frontend/e2e/transfer.spec.ts
+++ b/aastar-frontend/e2e/transfer.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+import { registerAccount } from "./helpers/register";
+import { fundWithEth } from "./helpers/fund";
+
+// S4 / XFER-01 — the AirAccount two-phase device-passkey transfer, end to end:
+// register a fresh account (CDP passkey) → fund it with ETH → its FIRST transfer
+// deploys the account (initCode) and executes, with the passkey ceremony driven by
+// the CDP virtual authenticator. Self-pay (usePaymaster off) so it needs only ETH.
+// Requires the backend on NODE_ENV=test OTP_TEST_MODE=true. See docs/TEST_PLAN.md S4.
+
+const RECIPIENT = "0xb5600060e6de5E11D3636731964218E53caadf0E"; // the test EOA
+
+// WIP / blocked: register → account-create(v0.7) → fund all work (verified), but
+// the /transfer form doesn't render for a fresh UNDEPLOYED account (the page's load
+// path — likely the balance fetch — gates the form behind `loading.page`). Past
+// that lies the full strict ceremony (KMS BeginAuth + BLS signer network + bundler
+// + first-tx deploy), which has external deps. Tracked for follow-up; see
+// docs/TEST_RESULTS.md S4. fixme so the suite stays green.
+test.fixme("XFER-01: fresh account first transfer (deploy + execute via passkey)", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  const { address } = await registerAccount(page);
+
+  // Fund the new account for self-pay deploy + transfer gas.
+  await fundWithEth(address as `0x${string}`, "0.02");
+
+  // Capture the submit result (UserOpHash / txHash) to confirm on-chain.
+  let submitBody: { userOpHash?: string; txHash?: string; transactionHash?: string } | null = null;
+  page.on("response", async resp => {
+    if (resp.url().includes("/transfer/submit")) {
+      try {
+        submitBody = await resp.json();
+      } catch {
+        /* non-JSON */
+      }
+    }
+  });
+
+  await page.goto("/transfer");
+  await page.locator('input[name="to"]').fill(RECIPIENT);
+  await page.locator('input[name="amount"]').fill("0.001");
+  // The transfer button text varies; submit the form / click the primary action.
+  await page.locator('button[type="submit"]').first().click();
+
+  // The passkey assertion auto-completes via the virtual authenticator; the strict
+  // two-phase flow (KMS + BLS + bundler) then submits + deploys.
+  await expect(page.getByText(/submitted|success|tracking/i).first()).toBeVisible({
+    timeout: 150_000,
+  });
+
+  // The submit returned an on-chain handle.
+  expect(
+    submitBody?.userOpHash || submitBody?.txHash || submitBody?.transactionHash,
+    "submit returned a UserOpHash/txHash"
+  ).toBeTruthy();
+});

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -14,7 +14,7 @@
 | **S1** | D2 Tokens 买入/质押 | L1 viem（EOA 自签） | 🟢 进行中（本 PR） |
 | **S2** | 后端路由：鉴权守卫（确定性）+ 读端点发现 | L2 Jest e2e | 🟢 完成（10/10 绿） |
 | **S3** | 注册 passkey 流（CDP 虚拟认证器）+ 公开页/鉴权重定向 | L3 Playwright | 🟢 完成（5/5 绿） |
-| **S4** | AirAccount UserOp 流：转账(Tier1/2/3) + Guard 写 | L3 + 半自动 | ⬜ |
+| **S4** | AirAccount UserOp 流：转账(Tier1/2/3) + Guard 写 | L3 + 半自动 | 🟡 脚手架就绪，前置已验证，完整转账阻塞 |
 | **S5** | 社区/运营者：建社区、Gas 策略、加入/退出 | L1 + L3(测试钱包) | ⬜ |
 | **L4** | 真机 passkey / 真 MetaMask / 主网真金 | 🧑 人工 | ⬜ 全程人工 |
 
@@ -80,6 +80,21 @@
 **OTP mock（已确认方案 1）**：后端 `requestOtp` 在 `OTP_TEST_MODE=true` 且**非 production** 时，于响应里附带 `devCode`（6 位真验证码，验证逻辑不变），e2e 读取即可完成注册——**仅测试模式暴露，prod 永不**。
 
 > 基础设施：`aastar-frontend/playwright.config.ts` + `e2e/helpers/webauthn.ts`（CDP 虚拟认证器）+ `e2e/{public,register}.spec.ts`。
+
+---
+
+## S4 — AirAccount UserOp 流（L3，进行中）
+
+复用 S3 的 CDP 虚拟认证器。脚手架：`e2e/helpers/register.ts`（注册+建账户）、`e2e/helpers/fund.ts`（注资 ETH）、`e2e/transfer.spec.ts`。
+
+| 步骤 | 状态 | 说明 |
+|---|---|---|
+| 注册（CDP passkey）→ KMS wallet | ✅ 验证 | 复用 S3 |
+| **创建 AirAccount**（`POST /account/create`，`entryPointVersion:"0.7"`，counterfactual） | ✅ 验证 | 默认 v0.6 未配置会 500 → 必须传 0.7 |
+| **注资**（测试 EOA → 新账户 0.02 ETH） | ✅ 验证 | self-pay 部署+转账 gas |
+| **首次转账（部署+执行，passkey ceremony）** | 🟡 **阻塞** | `/transfer` 表单对**未部署新账户不渲染**（`loading.page` gate，疑似 balance 加载路径）；其后是完整严格 ceremony（KMS BeginAuth + **BLS signer 远程网络** + bundler + initCode 部署），含外部依赖。`transfer.spec.ts` 标 `test.fixme` 让套件保持绿 |
+
+**S4 小结**：前置全链路（注册→建账户→注资）**已自动化验证**；完整严格转账是深度多系统集成（含外部 BLS 网络），需 (a) 修 transfer 页对未部署账户的渲染，(b) 跑通 KMS+BLS+bundler+部署 ceremony——建议作为独立专项推进。Guard 写（GRD）依赖一个带 guard 的部署账户，排在转账之后。
 
 ---
 

--- a/docs/TEST_RESULTS.md
+++ b/docs/TEST_RESULTS.md
@@ -14,7 +14,7 @@
 | **S1** | D2 Tokens 买入/质押 | L1 viem（EOA 自签） | 🟢 进行中（本 PR） |
 | **S2** | 后端路由：鉴权守卫（确定性）+ 读端点发现 | L2 Jest e2e | 🟢 完成（10/10 绿） |
 | **S3** | 注册 passkey 流（CDP 虚拟认证器）+ 公开页/鉴权重定向 | L3 Playwright | 🟢 完成（5/5 绿） |
-| **S4** | AirAccount UserOp 流：转账(Tier1/2/3) + Guard 写 | L3 + 半自动 | 🟡 脚手架就绪，前置已验证，完整转账阻塞 |
+| **S4** | AirAccount UserOp 流：转账 + Guard 写 | L3 Playwright | 🟢 转账全自动跑通（XFER-01 ✅）；Guard 写待补 |
 | **S5** | 社区/运营者：建社区、Gas 策略、加入/退出 | L1 + L3(测试钱包) | ⬜ |
 | **L4** | 真机 passkey / 真 MetaMask / 主网真金 | 🧑 人工 | ⬜ 全程人工 |
 
@@ -92,9 +92,10 @@
 | 注册（CDP passkey）→ KMS wallet | ✅ 验证 | 复用 S3 |
 | **创建 AirAccount**（`POST /account/create`，`entryPointVersion:"0.7"`，counterfactual） | ✅ 验证 | 默认 v0.6 未配置会 500 → 必须传 0.7 |
 | **注资**（测试 EOA → 新账户 0.02 ETH） | ✅ 验证 | self-pay 部署+转账 gas |
-| **首次转账（部署+执行，passkey ceremony）** | 🟡 **阻塞** | `/transfer` 表单对**未部署新账户不渲染**（`loading.page` gate，疑似 balance 加载路径）；其后是完整严格 ceremony（KMS BeginAuth + **BLS signer 远程网络** + bundler + initCode 部署），含外部依赖。`transfer.spec.ts` 标 `test.fixme` 让套件保持绿 |
+| **XFER-01 首次转账（部署+执行，passkey ceremony）** | ✅ **PASS（~35s/1.5m）** | `/transfer` 填 to+amount → "Send Transfer" → **CDP passkey 断言 → KMS + BLS signer 网络 + bundler → 首次 UserOp 部署账户(initCode)+执行** → 提交返回 UserOpHash/txHash（断言）。**完全自动化** |
+| Guard 写（GRD-03~06） | ⬜ 待补 | 复用同一 register→create→fund→passkey 链；账户创建时设 dailyLimit>0 即带 guard，再经 `/guard` 页提交 encodeXxx UserOp |
 
-**S4 小结**：前置全链路（注册→建账户→注资）**已自动化验证**；完整严格转账是深度多系统集成（含外部 BLS 网络），需 (a) 修 transfer 页对未部署账户的渲染，(b) 跑通 KMS+BLS+bundler+部署 ceremony——建议作为独立专项推进。Guard 写（GRD）依赖一个带 guard 的部署账户，排在转账之后。
+**S4 小结**：**转账全链路自动化跑通**（注册→建账户(v0.7)→注资→dashboard 刷新→/transfer→passkey ceremony→部署+执行）。两个关键修复：(a) 建账户后回 /dashboard 刷新让 DashboardContext 缓存到新账户，/transfer 才渲染表单；(b) DVT/BLS 在线后完整严格 ceremony（KMS+BLS+bundler+部署）跑通。注资 helper 用显式 12/2 gwei 确保 Sepolia 及时上链。Guard 写沿用同一链路，下一子步。
 
 ---
 


### PR DESCRIPTION
**S4 — AirAccount UserOp transfer, fully automated and passing** (DVT/BLS online). Updated from the earlier scaffold: the transfer now runs end-to-end via the CDP virtual authenticator, with rigorous on-chain proof. Suite: **6/6 green**.

## XFER-01 (passing, ~1.5–1.7m)
register (CDP passkey) → `POST /account/create` (counterfactual, `entryPointVersion:"0.7"` — default 0.6 isn't configured) → fund with ETH → reload `/dashboard` so DashboardContext caches the new account (then `/transfer` renders the form) → **"Send Transfer"** → CDP passkey assertion → **KMS + BLS signer network + bundler** → the first UserOp **deploys the account (initCode) + executes** the transfer.

## Rigorous assertions (Codex review, 2 rounds)
- **pre-condition**: account code `=== "0x"` (undeployed) before the transfer — post-checks can't pass vacuously;
- **proof of execution**: the **recipient's ETH balance rises by the sent amount** (`waitForBalanceIncrease`). Bytecode alone is NOT proof — an ERC-4337 `initCode` deploy can succeed while the inner call reverts, leaving the account deployed but the ETH unmoved (Codex CRITICAL). The balance check fails in that case.
- submit response captured via `page.waitForResponse` (no unawaited-listener race).

## Helpers
- `e2e/helpers/register.ts` — register + create account; `e2e/helpers/fund.ts` — fund (explicit 12/2 gwei) + `getEthBalance`/`getCode`/`waitForBalanceIncrease`.

## Next
Guard writes (GRD) reuse this exact chain (create the account with `dailyLimit>0` → it gets a guard → submit `encodeXxx` UserOps). Tracked in `docs/TEST_RESULTS.md` S4.
