### PR TITLE
feat(guard): Layer-1 recipient policy panel + emergency freeze

### DIFF
--- a/aastar-frontend/app/guard/page.tsx
+++ b/aastar-frontend/app/guard/page.tsx
@@ -8,6 +8,7 @@ import {
   LockOpenIcon,
 } from "@heroicons/react/24/outline";
 import {
+  encodeFunctionData,
   formatEther,
   formatUnits,
   isAddress,
@@ -20,6 +21,7 @@ import {
   CHAIN_SEPOLIA,
   AAStarAirAccountV7ABI,
   ERC20ABI,
+  PolicyRegistryABI,
   getCanonicalAddresses,
   type GuardConfig,
   type GuardTokenConfig,
@@ -64,6 +66,18 @@ export default function GuardPage() {
   const [tokenDaily, setTokenDaily] = useState("");
   const [newTokenDaily, setNewTokenDaily] = useState("");
 
+  // Layer-1 PolicyRegistry (per-account on-chain policy the DVT network enforces).
+  type EthPolicy = {
+    dvtTriggerAmount: bigint;
+    perTxHardCap: bigint;
+    dailyLimit: bigint;
+    windowSeconds: bigint;
+    configured: boolean;
+  };
+  const [frozen, setFrozen] = useState<boolean | null>(null);
+  const [ethPol, setEthPol] = useState<EthPolicy | null>(null);
+  const policyAddr = getCanonicalAddresses(CHAIN_SEPOLIA)?.policyRegistry as Address | undefined;
+
   const guard = useMemo(
     () => (guardAddr ? buildGuardClient(publicClient, guardAddr) : null),
     [publicClient, guardAddr]
@@ -77,6 +91,51 @@ export default function GuardPage() {
       /* best-effort */
     }
   }, [guard]);
+
+  // Read the account's Layer-1 policy: frozen flag + native-ETH asset policy.
+  const loadPolicy = useCallback(async () => {
+    if (!account || !policyAddr) return;
+    try {
+      const sentinel = (await publicClient.readContract({
+        address: policyAddr,
+        abi: PolicyRegistryABI,
+        functionName: "ETH_SENTINEL",
+      })) as Address;
+      const [fz, pol] = await Promise.all([
+        publicClient.readContract({
+          address: policyAddr,
+          abi: PolicyRegistryABI,
+          functionName: "isFrozen",
+          args: [account],
+        }),
+        publicClient.readContract({
+          address: policyAddr,
+          abi: PolicyRegistryABI,
+          functionName: "getAssetPolicy",
+          args: [account, sentinel],
+        }),
+      ]);
+      setFrozen(fz as boolean);
+      setEthPol(pol as EthPolicy);
+    } catch {
+      /* registry unreachable — leave nulls */
+    }
+  }, [account, policyAddr, publicClient]);
+
+  useEffect(() => {
+    void loadPolicy();
+  }, [loadPolicy]);
+
+  // Freeze / unfreeze the account on the registry, routed through the AirAccount UserOp.
+  const policyCall = (fn: "freezeSender" | "unfreezeSender"): GuardCall => ({
+    to: policyAddr as Address,
+    data: encodeFunctionData({
+      abi: PolicyRegistryABI,
+      functionName: fn,
+      args: [account as Address],
+    }),
+    value: 0n,
+  });
 
   // Resolve the account's guard() and its config.
   useEffect(() => {
@@ -401,6 +460,75 @@ export default function GuardPage() {
                 </div>
               )}
             </section>
+
+            {/* Layer-1 recipient policy (PolicyRegistry) — read state + emergency freeze. */}
+            {policyAddr && (
+              <section className="rounded-2xl border border-gray-200 dark:border-gray-700 p-4 sm:p-5">
+                <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
+                  {t("guardPage.policyTitle")}
+                </h2>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  {t("guardPage.policySubtitle")}
+                </p>
+                {frozen === null ? (
+                  <ArrowPathIcon className="h-5 w-5 animate-spin text-gray-400 mx-auto mt-4" />
+                ) : (
+                  <div className="mt-3 space-y-3">
+                    <div className="grid grid-cols-2 gap-2 text-xs">
+                      <Stat
+                        label={t("guardPage.policyStatus")}
+                        v={frozen ? t("guardPage.policyFrozen") : t("guardPage.policyActive")}
+                      />
+                      {ethPol?.configured ? (
+                        <>
+                          <Stat
+                            label={t("guardPage.policyPerTx")}
+                            v={formatEther(ethPol.perTxHardCap)}
+                          />
+                          <Stat
+                            label={t("guardPage.policyDvtTrigger")}
+                            v={formatEther(ethPol.dvtTriggerAmount)}
+                          />
+                          <Stat
+                            label={t("guardPage.policyDaily")}
+                            v={formatEther(ethPol.dailyLimit)}
+                          />
+                        </>
+                      ) : (
+                        <div className="col-span-2 text-xs text-gray-400">
+                          {t("guardPage.policyNotConfigured")}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      disabled={submitting != null || !account}
+                      onClick={async () => {
+                        await submitGuardCall(
+                          "freeze",
+                          policyCall(frozen ? "unfreezeSender" : "freezeSender")
+                        );
+                        void loadPolicy();
+                      }}
+                      className="w-full flex items-center justify-center gap-2 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm hover:border-gray-300 disabled:opacity-50"
+                    >
+                      {frozen ? (
+                        <LockOpenIcon className="h-4 w-4 text-amber-500" />
+                      ) : (
+                        <LockClosedIcon className="h-4 w-4 text-red-500" />
+                      )}
+                      <span className={frozen ? "text-amber-600" : "text-red-600"}>
+                        {submitting === "freeze"
+                          ? "…"
+                          : frozen
+                            ? t("guardPage.policyUnfreeze")
+                            : t("guardPage.policyFreeze")}
+                      </span>
+                    </button>
+                    <p className="text-[11px] text-gray-400">{t("guardPage.policyLoosenHint")}</p>
+                  </div>
+                )}
+              </section>
+            )}
           </>
         )}
       </div>

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -870,6 +870,19 @@
     "addConfig": "Add token config",
     "confirming": "Confirm with your passkey…",
     "updated": "Guard updated",
-    "failed": "Guard update failed"
+    "failed": "Guard update failed",
+    "policyTitle": "Recipient policy (Layer-1)",
+    "policySubtitle": "On-chain per-account policy the DVT network enforces",
+    "policyStatus": "Status",
+    "policyFrozen": "Frozen",
+    "policyActive": "Active",
+    "policyPerTx": "Per-tx hard cap (ETH)",
+    "policyDvtTrigger": "DVT trigger (ETH)",
+    "policyDaily": "Daily limit (ETH)",
+    "policyWindow": "Window (s)",
+    "policyNotConfigured": "No Layer-1 policy set yet",
+    "policyFreeze": "Emergency freeze",
+    "policyUnfreeze": "Unfreeze",
+    "policyLoosenHint": "Loosening policy needs timelock governance + guardian (SDK #188)."
   }
 }

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -870,6 +870,19 @@
     "addConfig": "添加代币配置",
     "confirming": "请用 passkey 确认…",
     "updated": "守卫已更新",
-    "failed": "守卫更新失败"
+    "failed": "守卫更新失败",
+    "policyTitle": "收款策略 (Layer-1)",
+    "policySubtitle": "DVT 网络强制的链上 per-account 策略",
+    "policyStatus": "状态",
+    "policyFrozen": "已冻结",
+    "policyActive": "正常",
+    "policyPerTx": "单笔上限 (ETH)",
+    "policyDvtTrigger": "DVT 触发额 (ETH)",
+    "policyDaily": "日限额 (ETH)",
+    "policyWindow": "窗口(秒)",
+    "policyNotConfigured": "尚未设置 Layer-1 策略",
+    "policyFreeze": "紧急冻结",
+    "policyUnfreeze": "解冻",
+    "policyLoosenHint": "放宽策略需 timelock 治理 + guardian(待 SDK #188)。"
   }
 }

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.10",
+    "@aastar/sdk": "^0.26.15",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.15",
+    "@aastar/sdk": "^0.26.17",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.10",
+    "@aastar/sdk": "^0.26.15",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.15",
+    "@aastar/sdk": "^0.26.17",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.26.15",
+        "@aastar/sdk": "^0.26.17",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.26.15",
+        "@aastar/sdk": "^0.26.17",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.26.15",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.15.tgz",
-      "integrity": "sha512-HOKtPhMNKc0Yyql9oolbG2L8KNLbljxAh3n4ZZrq7AqjnHAb7sGHz/M/eQghdTJ/KljAWb/AnFUw34p0mctjFg==",
+      "version": "0.26.17",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.17.tgz",
+      "integrity": "sha512-cg1dFVVlbEOfdSfGQ+a6Yxkup/Jz/FGjLrJ2hZG00vTpIdYJErb4YBXUcJn71vsvgmfHoG0etrHKqDxwXdKmPQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.26.10",
+        "@aastar/sdk": "^0.26.15",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.26.10",
+        "@aastar/sdk": "^0.26.15",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.10.tgz",
-      "integrity": "sha512-uOuGt6lYiUXqaLOM99+V+XyVU8SJM9gU4+UsUJEhavZ6VC88NFVPzMt0esKFun3P7ZJjDMfl4pK66wdzincOsw==",
+      "version": "0.26.15",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.15.tgz",
+      "integrity": "sha512-HOKtPhMNKc0Yyql9oolbG2L8KNLbljxAh3n4ZZrq7AqjnHAb7sGHz/M/eQghdTJ/KljAWb/AnFUw34p0mctjFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
Extends /guard into a policy management page: a Layer-1 PolicyRegistry section (per-account on-chain policy the DVT network enforces) — reads the frozen flag + native-ETH asset policy and offers emergency freeze/unfreeze via the existing two-phase passkey UserOp. Loosening ops noted as timelock+guardian gated (aastar-sdk#188).

On @aastar/sdk **0.26.15** (the #189 .d.ts fix; PolicyRegistryABI/GuardClient resolve in /core). type-check/lint/build green, backend tests 34/34.