### PR TITLE
feat(tier-setup): tier-security profile page (root-cause fix for inert tiers)

### DIFF
--- a/aastar-frontend/app/tier-setup/page.tsx
+++ b/aastar-frontend/app/tier-setup/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ArrowPathIcon, CheckCircleIcon, ShieldCheckIcon } from "@heroicons/react/24/outline";
+import { formatEther, type Address, type PublicClient } from "viem";
+import { CHAIN_SEPOLIA, AAStarAirAccountV7ABI, getCanonicalAddresses } from "@aastar/sdk/core";
+import { TIER_PROFILES, profileSetupCalls } from "@aastar/sdk/airaccount";
+import { startAuthentication } from "@simplewebauthn/browser";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import Layout from "@/components/Layout";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { transferAPI } from "@/lib/api";
+import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
+
+type ProfileKey = keyof typeof TIER_PROFILES;
+
+export default function TierSetupPage() {
+  const { t } = useTranslation();
+  const { data } = useDashboard();
+  const account = data.account?.address as Address | undefined;
+
+  const [publicClient] = useState<PublicClient>(() => {
+    ensureSdkConfig(CHAIN_SEPOLIA);
+    return getPublicClient();
+  });
+
+  // Current account tier state: undefined = loading, 0n = unconfigured, >0n = configured.
+  const [tier1, setTier1] = useState<bigint | undefined>(undefined);
+  const [selected, setSelected] = useState<ProfileKey>("web3-newbie");
+  const [busy, setBusy] = useState(false);
+
+  const loadTier = useCallback(async () => {
+    if (!account) return;
+    try {
+      const v = (await publicClient.readContract({
+        address: account,
+        abi: AAStarAirAccountV7ABI,
+        functionName: "tier1Limit",
+      })) as bigint;
+      setTier1(v);
+    } catch {
+      setTier1(0n); // not deployed yet / no tiers → treat as unconfigured
+    }
+  }, [account, publicClient]);
+
+  useEffect(() => {
+    void loadTier();
+  }, [loadTier]);
+
+  // Apply the chosen profile: setTierLimits + setWeightConfig, each through the
+  // AirAccount's two-phase device-passkey UserOp (gasless via PaymasterV4).
+  const apply = async () => {
+    if (!account) return;
+    setBusy(true);
+    const loading = toast.loading(t("tierSetup.applying"));
+    try {
+      const calls = profileSetupCalls(account, TIER_PROFILES[selected]) as {
+        to: Address;
+        data: `0x${string}`;
+      }[];
+      const canonical = getCanonicalAddresses(CHAIN_SEPOLIA);
+      for (let i = 0; i < calls.length; i++) {
+        toast.loading(t("tierSetup.step", { i: i + 1, n: calls.length }), { id: loading });
+        const prep = await transferAPI.prepare({
+          to: calls[i].to,
+          amount: "0",
+          data: calls[i].data,
+          usePaymaster: true,
+          paymasterAddress: canonical?.paymasterV4,
+        });
+        const credential = await startAuthentication({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          optionsJSON: prep.data.publicKeyOptions as any,
+        });
+        await transferAPI.submit({
+          transferId: prep.data.transferId,
+          challengeId: prep.data.challengeId,
+          credential,
+        });
+      }
+      toast.success(t("tierSetup.done"));
+      await loadTier();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : t("tierSetup.failed"));
+    } finally {
+      toast.dismiss(loading);
+      setBusy(false);
+    }
+  };
+
+  if (!account) {
+    return (
+      <Layout requireAuth>
+        <div className="max-w-xl mx-auto px-4 py-10">
+          <p className="text-sm text-gray-500 dark:text-gray-400">{t("tierSetup.noAccount")}</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  const configured = tier1 != null && tier1 > 0n;
+
+  return (
+    <Layout requireAuth>
+      <div className="max-w-xl mx-auto px-4 py-8">
+        <div className="flex items-center gap-2">
+          <ShieldCheckIcon className="h-6 w-6 text-emerald-500" />
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {t("tierSetup.title")}
+          </h1>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("tierSetup.subtitle")}</p>
+
+        {tier1 === undefined ? (
+          <ArrowPathIcon className="h-5 w-5 animate-spin text-gray-400 mx-auto mt-8" />
+        ) : (
+          <>
+            {configured && (
+              <div className="mt-4 flex items-center gap-2 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300">
+                <CheckCircleIcon className="h-4 w-4" />
+                {t("tierSetup.alreadyConfigured", { v: formatEther(tier1) })}
+              </div>
+            )}
+
+            <div className="mt-5 space-y-3">
+              {(Object.keys(TIER_PROFILES) as ProfileKey[]).map(k => {
+                const p = TIER_PROFILES[k];
+                const eth = (v: bigint) => formatEther(v);
+                return (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => setSelected(k)}
+                    className={`w-full text-left rounded-xl border p-4 transition ${
+                      selected === k
+                        ? "border-emerald-500 ring-1 ring-emerald-500 bg-emerald-50/40 dark:bg-emerald-900/10"
+                        : "border-gray-200 dark:border-gray-700 hover:border-gray-300"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-gray-900 dark:text-white">
+                        {t(`tierSetup.profile.${k}.name`)}
+                      </span>
+                      {selected === k && <CheckCircleIcon className="h-5 w-5 text-emerald-500" />}
+                    </div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                      {t(`tierSetup.profile.${k}.desc`)}
+                    </p>
+                    <div className="grid grid-cols-3 gap-2 mt-3 text-[11px]">
+                      <span className="text-gray-500 dark:text-gray-400">
+                        {t("tierSetup.tier1")}: <b>{eth(p.tier1Limit)}</b>
+                      </span>
+                      <span className="text-gray-500 dark:text-gray-400">
+                        {t("tierSetup.tier2")}: <b>{eth(p.tier2Limit)}</b>
+                      </span>
+                      <span className="text-gray-500 dark:text-gray-400">
+                        {t("tierSetup.daily")}: <b>{eth(p.dailyLimit)}</b>
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+
+            <p className="mt-3 text-[11px] text-gray-400">{t("tierSetup.tierExplainer")}</p>
+
+            <button
+              disabled={busy}
+              onClick={() => void apply()}
+              className="mt-5 w-full py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium disabled:opacity-50"
+            >
+              {busy ? "…" : configured ? t("tierSetup.reapply") : t("tierSetup.apply")}
+            </button>
+          </>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/components/Layout.tsx
+++ b/aastar-frontend/components/Layout.tsx
@@ -174,6 +174,7 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
                             { label: "Transfer", path: "/transfer", Icon: PaperAirplaneIcon },
                             { label: "Recovery", path: "/recovery", Icon: ShieldCheckIcon },
                             { label: "Guard", path: "/guard", Icon: ShieldExclamationIcon },
+                            { label: "Tier Security", path: "/tier-setup", Icon: ShieldCheckIcon },
                             { label: "Tasks", path: "/tasks", Icon: ClipboardDocumentListIcon },
                           ],
                         },

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -884,5 +884,35 @@
     "policyFreeze": "Emergency freeze",
     "policyUnfreeze": "Unfreeze",
     "policyLoosenHint": "Loosening policy needs timelock governance + guardian (SDK #188)."
+  },
+  "tierSetup": {
+    "title": "Tier security setup",
+    "subtitle": "Pick a profile — it sets your per-tx tiers and daily limit. Larger amounts require more signatures.",
+    "noAccount": "Create your smart account first.",
+    "applying": "Applying tier config…",
+    "step": "Confirm with passkey ({{i}}/{{n}})",
+    "done": "Tier config applied",
+    "failed": "Failed to apply tier config",
+    "alreadyConfigured": "Tiers already configured (tier-1 ≤ {{v}} ETH). Re-apply to change.",
+    "tier1": "Tier1",
+    "tier2": "Tier2",
+    "daily": "Daily",
+    "tierExplainer": "Tier1 = passkey only; Tier2 = + DVT/BLS; above the daily limit is hard-blocked (raising it needs guardians).",
+    "apply": "Apply & secure account",
+    "reapply": "Re-apply",
+    "profile": {
+      "web3-newbie": {
+        "name": "Web3 newbie",
+        "desc": "Small limits, maximum safety"
+      },
+      "trader": {
+        "name": "Trader",
+        "desc": "Higher limits for frequent moves"
+      },
+      "conservative": {
+        "name": "Conservative",
+        "desc": "Tight limits, experienced users"
+      }
+    }
   }
 }

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -884,5 +884,35 @@
     "policyFreeze": "紧急冻结",
     "policyUnfreeze": "解冻",
     "policyLoosenHint": "放宽策略需 timelock 治理 + guardian(待 SDK #188)。"
+  },
+  "tierSetup": {
+    "title": "分层安全设置",
+    "subtitle": "选一个画像——它设定你的分档限额与日限额。金额越大需要的签名越多。",
+    "noAccount": "请先创建智能账户。",
+    "applying": "正在应用分层配置…",
+    "step": "用 passkey 确认（{{i}}/{{n}}）",
+    "done": "分层配置已应用",
+    "failed": "应用分层配置失败",
+    "alreadyConfigured": "分层已配置（tier-1 ≤ {{v}} ETH）。可重新应用以更改。",
+    "tier1": "档1",
+    "tier2": "档2",
+    "daily": "日限",
+    "tierExplainer": "档1=仅 passkey；档2=+ DVT/BLS；超日限额会被硬拦截（提额需 guardian）。",
+    "apply": "应用并加固账户",
+    "reapply": "重新应用",
+    "profile": {
+      "web3-newbie": {
+        "name": "Web3 新手",
+        "desc": "小额度，最高安全"
+      },
+      "trader": {
+        "name": "交易员",
+        "desc": "更高额度，适合频繁操作"
+      },
+      "conservative": {
+        "name": "保守型",
+        "desc": "收紧额度，有经验"
+      }
+    }
   }
 }


### PR DESCRIPTION
New /tier-setup page: pick a TIER_PROFILE (web3-newbie/trader/conservative) → applies profileSetupCalls (setTierLimits + setWeightConfig) via the two-phase passkey UserOp. **Root-cause fix**: both factory create functions leave tier1/tier2/weights at 0 (requiredTier=0), so the account must run these setup calls or tiers are inert. On @aastar/sdk 0.26.17 (browser-safe /airaccount; verified the /tier-setup chunk has no crypto). i18n en+zh, type-check/lint/build green. Nav: 'Tier Security'.