### PR TITLE
chore(sdk): bump 0.26.18 — SDK AES leak fixed (verified)

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.17",
+    "@aastar/sdk": "^0.26.18",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.17",
+    "@aastar/sdk": "^0.26.18",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.26.17",
+        "@aastar/sdk": "^0.26.18",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.26.17",
+        "@aastar/sdk": "^0.26.18",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.26.17",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.17.tgz",
-      "integrity": "sha512-cg1dFVVlbEOfdSfGQ+a6Yxkup/Jz/FGjLrJ2hZG00vTpIdYJErb4YBXUcJn71vsvgmfHoG0etrHKqDxwXdKmPQ==",
+      "version": "0.26.18",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.18.tgz",
+      "integrity": "sha512-hBhSW4YLYt09H6/CWcwAqkahQ5E/CohoyEfWiiniA7VPC3Y08DGkCoNfZDu4PESVCpTIbPRMNjWk2IY+6XC+qQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
Bump @aastar/sdk 0.26.17→0.26.18 (CryptoUtil node-only). **Verified in YAA's Next.js build**: the SDK's aes/scrypt chunk is gone (3→2 crypto chunks; the removed one was the SDK/KmsManager path). The 2 remaining are ethers.js (its own crypto) — not the SDK. type-check front+back green. KmsHttpClient is low-level (post/get), not a drop-in for KmsManager's high-level WebAuthn methods — see SDK feedback on #189; deferred since 0.26.18 already removes the SDK leak.