### PR TITLE
feat(transfer/#3a): Tier-3 guardian co-sign (B1 backend + B2 UI) [B3 e2e pending]

### DIFF
--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -16,10 +16,41 @@ import {
   WalletIcon,
   InformationCircleIcon,
 } from "@heroicons/react/24/outline";
-import { parseEther, parseUnits, type Address, type PublicClient } from "viem";
+import {
+  createWalletClient,
+  custom,
+  parseEther,
+  parseUnits,
+  type Address,
+  type PublicClient,
+} from "viem";
 import { CHAIN_SEPOLIA } from "@aastar/sdk/core";
 import { resolveTransfer, type TransferResolution } from "@aastar/sdk/airaccount";
 import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
+
+// Tier-3 only: collect a guardian co-signature over the prepared userOpHash from the
+// user's self-hosted guardian wallet (injected EIP-1193). signMessage({ raw }) is
+// eth-prefixed, matching the SDK GuardianSigner the backend wraps it in.
+async function collectGuardianSignature(userOpHash: string): Promise<string> {
+  const eth =
+    typeof window === "undefined"
+      ? undefined
+      : (
+          window as unknown as {
+            ethereum?: { request: (a: { method: string; params?: unknown[] }) => Promise<unknown> };
+          }
+        ).ethereum;
+  if (!eth) {
+    throw new Error("A guardian wallet (e.g. MetaMask) is required to co-sign a Tier-3 transfer.");
+  }
+  const accounts = (await eth.request({ method: "eth_requestAccounts" })) as Address[];
+  if (!accounts?.length) throw new Error("No guardian account available to co-sign.");
+  const wallet = createWalletClient({ transport: custom(eth) });
+  return wallet.signMessage({
+    account: accounts[0],
+    message: { raw: userOpHash as `0x${string}` },
+  });
+}
 
 export default function TransferPage() {
   const { data, refreshBalance: contextRefreshBalance } = useDashboard();
@@ -328,14 +359,28 @@ export default function TransferPage() {
         optionsJSON: prep.data.publicKeyOptions as any,
       });
 
+      // Phase 2.5: Tier-3 guardian co-sign. When prepare resolves to Tier 3, a
+      // guardian must co-sign the userOpHash on top of the passkey + DVT/BLS. We
+      // collect it from the user's self-hosted guardian wallet (injected EIP-1193)
+      // via signMessage({ raw: userOpHash }) — eth-prefixed, matching the SDK
+      // GuardianSigner semantics the backend wraps it in (B1).
+      let guardianSignature: string | undefined;
+      if ((prep.data.requiredSigs?.guardian ?? 0) > 0) {
+        toast.dismiss(loadingToast);
+        loadingToast = toast.loading("Tier 3 — co-sign with your guardian wallet…");
+        guardianSignature = await collectGuardianSignature(prep.data.userOpHash);
+      }
+
       // Phase 3: submit. The committed digest matches what prepare bound, so the
-      // KMS accepts the assertion under strict mode.
+      // KMS accepts the assertion under strict mode. guardianSignature is sent only
+      // for Tier 3 (undefined otherwise).
       toast.dismiss(loadingToast);
       loadingToast = toast.loading("Processing transfer...");
       const response = await transferAPI.submit({
         transferId: prep.data.transferId,
         challengeId: prep.data.challengeId,
         credential,
+        guardianSignature,
       });
       setTransferResult(response.data);
 

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect, type Page } from "@playwright/test";
+import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
+import { parseEther, formatEther, type Address } from "viem";
+import {
+  encodeSetTierLimits,
+  encodeSetWeightConfig,
+  DEFAULT_WEIGHT_CONFIG,
+} from "@aastar/sdk/airaccount";
+import { installVirtualAuthenticator } from "./helpers/webauthn";
+import { installTestWallet } from "./helpers/wallet";
+import { fundWithEth, getEthBalance, withRetry } from "./helpers/fund";
+
+// XFER-T3 — #3a B3: a real Tier-3 transfer (passkey + DVT/BLS + guardian co-sign) end to
+// end. Builds a guardian-equipped, tier-configured account from scratch (the only way to
+// exercise Tier 3 — YAA's free-form accounts have no guardians, see #382), sets a tiny
+// tier2 so a small amount lands in Tier 3, then transfers > tier2 and asserts the guardian
+// co-sign (collected client-side over the userOpHash) is accepted on-chain.
+//
+// Requires: backend NODE_ENV=test OTP_TEST_MODE=true, frontend up, DVT + bundler reachable
+// (SDK defaults), and a funded TEST_EOA_PRIVATE_KEY (the fund helper's funder).
+//
+// The two self-hosted guardian keys are generated fresh per run and NEVER committed.
+
+async function authHeaders(page: Page) {
+  const token = (await page.evaluate(() => localStorage.getItem("token"))) as string;
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
+// Register a passwordless account WITHOUT creating it (so we can create-with-guardians).
+async function registerOnly(page: Page): Promise<{ token: string }> {
+  let devCode: string | null = null;
+  page.on("response", async resp => {
+    if (resp.url().includes("/auth/otp/request")) {
+      try {
+        const j = await resp.json();
+        if (j?.devCode) devCode = String(j.devCode);
+      } catch {
+        /* non-JSON */
+      }
+    }
+  });
+  await page.goto("/auth/register");
+  await page.locator('input[type="email"]').fill(`e2e-t3-${Date.now()}@test.local`);
+  await page.locator('button[type="submit"]').click();
+  const otp = page.locator('input[inputMode="numeric"]');
+  await expect(otp).toBeVisible({ timeout: 15_000 });
+  await expect.poll(() => devCode, { timeout: 15_000 }).not.toBeNull();
+  await otp.fill(devCode!);
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL(/\/dashboard|\/$/, { timeout: 45_000 });
+  const token = (await page.evaluate(() => localStorage.getItem("token"))) as string;
+  expect(token).toBeTruthy();
+  return { token };
+}
+
+// Submit one account self-call (setTierLimits / setWeightConfig) via the two-phase
+// device-passkey UserOp, driven by the CDP virtual authenticator.
+async function submitAccountCall(page: Page, to: string, data: string) {
+  const auth = await authHeaders(page);
+  const prep = await page.request.post("/api/v1/transfer/prepare", {
+    ...auth,
+    data: { to, amount: "0", data, usePaymaster: false },
+  });
+  expect(prep.ok(), `prepare: ${prep.status()} ${await prep.text()}`).toBeTruthy();
+  const p = await prep.json();
+  // The virtual authenticator auto-asserts; drive it through the page context by
+  // calling startAuthentication with the returned options.
+  const credential = await page.evaluate(async opts => {
+    const { startAuthentication } = await import("@simplewebauthn/browser");
+    return startAuthentication({ optionsJSON: opts as never });
+  }, p.publicKeyOptions);
+  const sub = await page.request.post("/api/v1/transfer/submit", {
+    ...auth,
+    data: { transferId: p.transferId, challengeId: p.challengeId, credential },
+  });
+  expect(sub.ok(), `submit: ${sub.status()} ${await sub.text()}`).toBeTruthy();
+  return sub.json();
+}
+
+test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)", async ({
+  page,
+}) => {
+  test.setTimeout(300_000);
+  await installVirtualAuthenticator(page);
+  // The guardian that co-signs the transfer = the injected wallet (g1). Fresh keys, uncommitted.
+  const g1Pk = generatePrivateKey();
+  const g1 = privateKeyToAccount(g1Pk);
+  const g2 = privateKeyToAccount(generatePrivateKey());
+  await installTestWallet(page, g1Pk); // window.ethereum = g1 signer (the guardian)
+
+  // 1) Register (passkey + KMS owner), no account yet.
+  await registerOnly(page);
+  const auth = await authHeaders(page);
+
+  // 2) Create-with-guardians: prepare → guardians accept (eth-prefixed) → create.
+  const prep = await page.request.post("/api/v1/account/guardian-setup/prepare", {
+    ...auth,
+    data: { dailyLimit: parseEther("1").toString() },
+  });
+  expect(prep.ok(), `guardian-setup/prepare: ${prep.status()}`).toBeTruthy();
+  const gp = await prep.json();
+  const acceptanceHash = gp.acceptanceHash as `0x${string}`;
+  const g1Sig = await g1.signMessage({ message: { raw: acceptanceHash } });
+  const g2Sig = await g2.signMessage({ message: { raw: acceptanceHash } });
+  const created = await page.request.post("/api/v1/account/create-with-guardians", {
+    ...auth,
+    data: {
+      guardian1: g1.address,
+      guardian1Sig: g1Sig,
+      guardian2: g2.address,
+      guardian2Sig: g2Sig,
+      dailyLimit: parseEther("1").toString(),
+      salt: gp.salt,
+      entryPointVersion: "0.7",
+    },
+  });
+  expect(
+    created.ok(),
+    `create-with-guardians: ${created.status()} ${await created.text()}`
+  ).toBeTruthy();
+  const acctResp = await page.request.get("/api/v1/account", auth);
+  const acctJson = (await acctResp.json()) as { address?: string; account?: { address?: string } };
+  const account = (acctJson.address ?? acctJson.account?.address) as Address;
+  expect(account).toBeTruthy();
+
+  // 3) Fund + deploy. dailyLimit>0 means the factory also deployed a guard; the first
+  // UserOp deploys the account itself.
+  await withRetry(() => fundWithEth(account, "0.08"));
+  await expect.poll(() => getEthBalance(account), { timeout: 60_000 }).toBeGreaterThan(0n);
+
+  // 4) Arm tiers: tiny tier2 (0.002 ETH) so a 0.003 ETH transfer is Tier 3; default weights.
+  const tier1 = parseEther("0.001");
+  const tier2 = parseEther("0.002");
+  const setTiers = encodeSetTierLimits(account, tier1, tier2) as { to: string; data: string };
+  await submitAccountCall(page, setTiers.to, setTiers.data);
+  const setW = encodeSetWeightConfig(account, DEFAULT_WEIGHT_CONFIG) as {
+    to: string;
+    data: string;
+  };
+  await submitAccountCall(page, setW.to, setW.data);
+
+  // 5) Tier-3 transfer: 0.003 ETH > tier2 → needs passkey + BLS + guardian. The UI flow
+  // collects the guardian co-sign from window.ethereum (g1) over the userOpHash.
+  await page.goto("/transfer");
+  await page.locator('input[name="to"]').fill(g2.address); // recipient = g2 (recoverable)
+  await page.locator('input[name="amount"]').fill("0.003");
+  // Wait for the judging indicator to confirm Tier 3.
+  await expect(page.getByText(/Tier 3 signing/i)).toBeVisible({ timeout: 20_000 });
+  const before = await getEthBalance(g2.address);
+  await page
+    .getByRole("button", { name: /send|transfer/i })
+    .first()
+    .click();
+
+  // The passkey ceremony + guardian co-sign auto-complete; assert the transfer lands.
+  await expect(page.getByText(/submitted|success/i)).toBeVisible({ timeout: 60_000 });
+  await expect.poll(() => getEthBalance(g2.address), { timeout: 120_000 }).toBeGreaterThan(before);
+  console.log(`Tier-3 transfer OK: g2 ${formatEther(before)} → received 0.003 ETH`);
+});

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -129,6 +129,9 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   await expect.poll(() => getEthBalance(account), { timeout: 60_000 }).toBeGreaterThan(0n);
 
   // 4) Arm tiers: tiny tier2 (0.002 ETH) so a 0.003 ETH transfer is Tier 3; default weights.
+  // GATE: setWeightConfig with DEFAULT_WEIGHT_CONFIG currently reverts InsecureWeightConfig on
+  // v0.20.3 (passkeyWeight 3 >= tier1Threshold 3) — see aastar-sdk#227. This step (and thus the
+  // whole run) only passes once the SDK profile weights / contract tier1 rule are reconciled.
   const tier1 = parseEther("0.001");
   const tier2 = parseEther("0.002");
   const setTiers = encodeSetTierLimits(account, tier1, tier2) as { to: string; data: string };
@@ -144,8 +147,10 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   await page.goto("/transfer");
   await page.locator('input[name="to"]').fill(g2.address); // recipient = g2 (recoverable)
   await page.locator('input[name="amount"]').fill("0.003");
-  // Wait for the judging indicator to confirm Tier 3.
-  await expect(page.getByText(/Tier 3 signing/i)).toBeVisible({ timeout: 20_000 });
+  // Wait for the judging indicator to confirm Tier 3. Match the guardian-co-signature line of
+  // the resolved-tier indicator (unambiguous to Tier 3) rather than the "Tier N signing" header,
+  // whose inline {tier} span splits the text node.
+  await expect(page.getByText(/guardian co-signature/i)).toBeVisible({ timeout: 20_000 });
   const before = await getEthBalance(g2.address);
   await page
     .getByRole("button", { name: /send|transfer/i })

--- a/aastar-frontend/lib/api.ts
+++ b/aastar-frontend/lib/api.ts
@@ -104,13 +104,23 @@ export const transferAPI = {
     paymasterData?: string;
     tokenAddress?: string;
   }) =>
-    api.post<{ transferId: string; challengeId: string; publicKeyOptions: unknown }>(
-      "/transfer/prepare",
-      data
-    ),
+    api.post<{
+      transferId: string;
+      challengeId: string;
+      publicKeyOptions: unknown;
+      // Tier-aware fields (surfaced so the UI can collect a Tier-3 guardian co-sign).
+      tier: number | null;
+      requiredSigs: { passkey: boolean; bls: boolean; guardian: number };
+      userOpHash: string;
+    }>("/transfer/prepare", data),
   // Phase 3: submit the prepared transfer with the browser ceremony credential.
-  submit: (data: { transferId: string; challengeId: string; credential: unknown }) =>
-    api.post("/transfer/submit", data),
+  // guardianSignature is sent only for Tier-3 transfers (over the prepared userOpHash).
+  submit: (data: {
+    transferId: string;
+    challengeId: string;
+    credential: unknown;
+    guardianSignature?: string;
+  }) => api.post("/transfer/submit", data),
 
   estimate: (data: {
     to: string;

--- a/aastar/src/transfer/dto/submit-transfer.dto.ts
+++ b/aastar/src/transfer/dto/submit-transfer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString, IsObject, IsOptional } from "class-validator";
+import { IsString, IsObject, IsOptional, Matches } from "class-validator";
 
 /**
  * Phase-3 of the strict device-passkey transfer. Carries the opaque prepared
@@ -33,5 +33,8 @@ export class SubmitTransferDto {
   })
   @IsOptional()
   @IsString()
+  @Matches(/^0x[0-9a-fA-F]+$/, {
+    message: "guardianSignature must be a 0x-prefixed hex string",
+  })
   guardianSignature?: string;
 }

--- a/aastar/src/transfer/dto/submit-transfer.dto.ts
+++ b/aastar/src/transfer/dto/submit-transfer.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsString, IsObject } from "class-validator";
+import { IsString, IsObject, IsOptional } from "class-validator";
 
 /**
  * Phase-3 of the strict device-passkey transfer. Carries the opaque prepared
@@ -22,4 +22,16 @@ export class SubmitTransferDto {
   })
   @IsObject()
   credential: unknown;
+
+  @ApiProperty({
+    required: false,
+    description:
+      "Guardian co-signature (hex) over the prepared userOpHash — REQUIRED for a Tier-3 " +
+      "transfer (prepare returns tier:3 / requiredSigs.guardian>0). Collected client-side from " +
+      "the user's self-hosted guardian; the backend wraps it as the SDK GuardianSigner. Omit for " +
+      "Tier 1/2.",
+  })
+  @IsOptional()
+  @IsString()
+  guardianSignature?: string;
 }

--- a/aastar/src/transfer/transfer.service.ts
+++ b/aastar/src/transfer/transfer.service.ts
@@ -49,12 +49,16 @@ export class TransferService {
       });
       // Hand the frontend exactly what the ceremony needs. publicKeyOptions.challenge
       // must be used verbatim (it is the SDK-computed commitment); challengeId is
-      // paired back with the credential in submit. userOpHash is omitted — the
-      // frontend signs the commitment, not the hash directly.
+      // paired back with the credential in submit. The passkey signs the commitment,
+      // NOT the userOpHash. We also surface tier/requiredSigs/userOpHash so the UI
+      // knows whether a guardian co-sign is needed (Tier 3) and what to sign for it.
       return {
         transferId: prep.transferId,
         challengeId: prep.challengeId,
         publicKeyOptions: prep.publicKeyOptions,
+        tier: prep.tier,
+        requiredSigs: prep.requiredSigs,
+        userOpHash: prep.userOpHash,
       };
     } catch (err: any) {
       this.logger.error(`prepareTransfer FAILED: ${err?.message ?? err}`, err?.stack);
@@ -75,6 +79,15 @@ export class TransferService {
       result = await this.client.transfers.submitPreparedTransfer(userId, {
         transferId: dto.transferId,
         webAuthnAssertion: { ChallengeId: dto.challengeId, Credential: dto.credential },
+        // Tier 3 only: the client already collected the guardian's co-signature over
+        // the prepared userOpHash (self-hosted guardian). Wrap it as the SDK's
+        // GuardianSigner — signMessage returns the pre-collected sig verbatim (the
+        // SDK asks for exactly the userOpHash the guardian signed; no re-derivation
+        // drift per #143). Omitted for Tier 1/2; if a Tier-3 transfer arrives without
+        // it, the SDK fail-fasts before any gas.
+        ...(dto.guardianSignature
+          ? { guardianSigner: { signMessage: async () => dto.guardianSignature as string } }
+          : {}),
       });
     } catch (err: any) {
       // Surface the real KMS/BLS/bundler failure (#68 commitment, TTL expiry, tier


### PR DESCRIPTION
#3a (part of #382): wire a guardian co-signature into Tier-3 transfers.

**B1 (backend)** — prepare surfaces `tier/requiredSigs/userOpHash`; submit accepts an optional `guardianSignature` and wraps it as the SDK `GuardianSigner` for `submitPreparedTransfer` (passed only when present; SDK fail-fasts a Tier-3 transfer that arrives without it).
**B2 (frontend)** — when prepare resolves to Tier 3, a Phase 2.5 collects the guardian co-sign over the prepared userOpHash from the user's self-hosted guardian wallet (injected EIP-1193, viem `signMessage({ raw })` = eth-prefixed). Tier 1/2 unchanged.

type-check/lint/build green (front+back); backend tests 34/34.

**⚠️ B3 (on-chain e2e) pending** — needs a guardian-equipped, tier-configured account doing a real Tier-3 transfer through DVT + bundler. That run is the definitive check that the collected guardian sig (signMessage over userOpHash) is exactly what the SDK/contract expects. Do not merge until B3 passes.