### PR TITLE
chore(sdk): bump 0.26.18 -> 0.28.0 (contract v0.20.2)

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.18",
+    "@aastar/sdk": "^0.28.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.26.18",
+    "@aastar/sdk": "^0.28.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.26.18",
+        "@aastar/sdk": "^0.28.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.26.18",
+        "@aastar/sdk": "^0.28.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.26.18",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.26.18.tgz",
-      "integrity": "sha512-hBhSW4YLYt09H6/CWcwAqkahQ5E/CohoyEfWiiniA7VPC3Y08DGkCoNfZDu4PESVCpTIbPRMNjWk2IY+6XC+qQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.28.0.tgz",
+      "integrity": "sha512-5GaSzcrq2DgcxSkSIwvbEQjoTPMS9rH/FrVUqecwYzj/L60c9X7nQqPxVbzLt43jFPPYPD6LHhcezQPBm+Gwqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
Routine SDK bump to 0.28.0 (contract v0.20.2: P-256 guardians #127, tierLimitNonce #132, accountId fix). type-check/build green front+back. **Does NOT include airaccount-contract#140** (self-call gasless fix) — verified still NotOwner on a new-factory account; #1/#3 tier-config stay blocked pending the real #140.