### PR TITLE
feat(#193): SDK 0.29.0 + out-of-band approval contact (binding) page

### DIFF
--- a/aastar-frontend/app/binding/page.tsx
+++ b/aastar-frontend/app/binding/page.tsx
@@ -105,6 +105,9 @@ export default function BindingPage() {
 
   const remove = async (channel: ContactChannel) => {
     if (!client || !account) return;
+    // Removing a contact silently disables the Scheme-2 out-of-band approval path —
+    // confirm so an accidental tap can't strip a security channel.
+    if (!window.confirm(t("binding.removeConfirm", { channel }))) return;
     setBusy(true);
     const id = toast.loading(t("binding.removing"));
     try {

--- a/aastar-frontend/app/binding/page.tsx
+++ b/aastar-frontend/app/binding/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowPathIcon,
+  CheckCircleIcon,
+  TrashIcon,
+  BellAlertIcon,
+} from "@heroicons/react/24/outline";
+import { startAuthentication } from "@simplewebauthn/browser";
+import {
+  createContactBindingClient,
+  type ContactRecord,
+  type ContactChannel,
+} from "@aastar/sdk/airaccount";
+import type { Address } from "viem";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import Layout from "@/components/Layout";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { kmsClient } from "@/lib/yaaa";
+import { getStoredAuth } from "@/lib/auth";
+
+// Out-of-band confirmation contact binding (Scheme 2 / aastar-sdk#193). Binds a Telegram
+// channel to the AirAccount so the DVT can reach the owner for high-value approvals. The
+// KMS api key is NEVER in the browser: the client points at the /kms-api proxy, which injects
+// it server-side (apiKey: "" here). Every begin/confirm/unbind is gated by an owner passkey
+// ceremony (BeginAuthentication → navigator.credentials.get → {ChallengeId, Credential}).
+export default function BindingPage() {
+  const { t } = useTranslation();
+  const { data } = useDashboard();
+  const account = data.account?.address as Address | undefined;
+  const ownerWallet = getStoredAuth().user?.walletAddress;
+
+  const [contacts, setContacts] = useState<ContactRecord[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  // Active Telegram binding awaiting the verifyToken the @AAStarBot hands back.
+  const [pending, setPending] = useState<{ bindingCode: string } | null>(null);
+  const [verifyToken, setVerifyToken] = useState("");
+
+  const client = useMemo(() => {
+    if (!ownerWallet) return null;
+    return createContactBindingClient({
+      kmsEndpoint: "/kms-api", // proxy injects the KMS x-api-key server-side
+      apiKey: "",
+      ceremony: async () => {
+        // Owner WebAuthn ceremony against the KMS wallet (not the smart-account address).
+        const auth = await kmsClient.beginAuthentication({ Address: ownerWallet });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const credential = await startAuthentication({ optionsJSON: auth.Options as any });
+        return { ChallengeId: auth.ChallengeId, Credential: credential };
+      },
+    });
+  }, [ownerWallet]);
+
+  const loadContacts = useCallback(async () => {
+    if (!client || !account) return;
+    try {
+      setContacts(await client.getContacts(account));
+    } catch {
+      setContacts([]); // no contacts yet / KMS unreachable → show empty, not a crash
+    }
+  }, [client, account]);
+
+  useEffect(() => {
+    void loadContacts();
+  }, [loadContacts]);
+
+  const startBind = async () => {
+    if (!client || !account) return;
+    setBusy(true);
+    const id = toast.loading(t("binding.starting"));
+    try {
+      const { bindingCode } = await client.beginContactBinding({ account, channel: "telegram" });
+      setPending({ bindingCode });
+      setVerifyToken("");
+      toast.success(t("binding.codeReady"), { id });
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : t("binding.failed"), { id });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const confirmBind = async () => {
+    if (!client || !account || !pending || !verifyToken.trim()) return;
+    setBusy(true);
+    const id = toast.loading(t("binding.confirming"));
+    try {
+      await client.confirmContactBinding({
+        account,
+        bindingCode: pending.bindingCode,
+        verifyToken: verifyToken.trim(),
+      });
+      toast.success(t("binding.verified"), { id });
+      setPending(null);
+      setVerifyToken("");
+      await loadContacts();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : t("binding.failed"), { id });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async (channel: ContactChannel) => {
+    if (!client || !account) return;
+    setBusy(true);
+    const id = toast.loading(t("binding.removing"));
+    try {
+      await client.removeContact({ account, channel });
+      toast.success(t("binding.removed"), { id });
+      await loadContacts();
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : t("binding.failed"), { id });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!account || !ownerWallet) {
+    return (
+      <Layout requireAuth>
+        <div className="max-w-xl mx-auto px-4 py-10">
+          <p className="text-sm text-gray-500 dark:text-gray-400">{t("binding.noAccount")}</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout requireAuth>
+      <div className="max-w-xl mx-auto px-4 py-8">
+        <div className="flex items-center gap-2">
+          <BellAlertIcon className="h-6 w-6 text-emerald-500" />
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {t("binding.title")}
+          </h1>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t("binding.subtitle")}</p>
+
+        {/* Current contacts */}
+        <div className="mt-5">
+          {contacts === null ? (
+            <ArrowPathIcon className="h-5 w-5 animate-spin text-gray-400 mx-auto mt-6" />
+          ) : contacts.length === 0 ? (
+            <p className="text-xs text-gray-400">{t("binding.none")}</p>
+          ) : (
+            <ul className="space-y-2">
+              {contacts.map(c => (
+                <li
+                  key={c.channel}
+                  className="flex items-center justify-between rounded-xl border border-gray-200 dark:border-gray-700 p-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium capitalize text-gray-900 dark:text-white">
+                      {c.channel}
+                    </span>
+                    <span
+                      className={`text-[11px] px-2 py-0.5 rounded-full ${
+                        c.status === "verified"
+                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                          : "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+                      }`}
+                    >
+                      {c.status}
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => void remove(c.channel)}
+                    disabled={busy}
+                    className="text-gray-400 hover:text-red-500 disabled:opacity-50"
+                    aria-label={t("binding.remove")}
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Bind Telegram flow */}
+        {!pending ? (
+          <button
+            onClick={() => void startBind()}
+            disabled={busy}
+            className="mt-5 w-full py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium disabled:opacity-50"
+          >
+            {t("binding.bindTelegram")}
+          </button>
+        ) : (
+          <div className="mt-5 rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50/40 dark:bg-emerald-900/10 p-4">
+            <p className="text-sm text-gray-900 dark:text-white font-medium">
+              {t("binding.step2Title")}
+            </p>
+            <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
+              {t("binding.step2Hint")}
+            </p>
+            <code className="mt-2 block text-center text-sm font-mono bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg py-2">
+              /bind {pending.bindingCode}
+            </code>
+            <input
+              value={verifyToken}
+              onChange={e => setVerifyToken(e.target.value)}
+              placeholder={t("binding.verifyTokenPlaceholder")}
+              className="mt-3 w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+            />
+            <div className="flex gap-2 mt-3">
+              <button
+                onClick={() => void confirmBind()}
+                disabled={busy || !verifyToken.trim()}
+                className="flex-1 py-2 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium disabled:opacity-50"
+              >
+                <CheckCircleIcon className="h-4 w-4 inline mr-1" />
+                {t("binding.confirm")}
+              </button>
+              <button
+                onClick={() => {
+                  setPending(null);
+                  setVerifyToken("");
+                }}
+                disabled={busy}
+                className="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300 disabled:opacity-50"
+              >
+                {t("binding.cancel")}
+              </button>
+            </div>
+          </div>
+        )}
+
+        <p className="mt-4 text-[11px] text-gray-400">{t("binding.privacyNote")}</p>
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/components/Layout.tsx
+++ b/aastar-frontend/components/Layout.tsx
@@ -25,6 +25,7 @@ import {
   UserGroupIcon,
   ServerStackIcon,
   ClipboardDocumentListIcon,
+  BellAlertIcon,
 } from "@heroicons/react/24/outline";
 
 interface LayoutProps {
@@ -175,6 +176,7 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
                             { label: "Recovery", path: "/recovery", Icon: ShieldCheckIcon },
                             { label: "Guard", path: "/guard", Icon: ShieldExclamationIcon },
                             { label: "Tier Security", path: "/tier-setup", Icon: ShieldCheckIcon },
+                            { label: "Approval Contact", path: "/binding", Icon: BellAlertIcon },
                             { label: "Tasks", path: "/tasks", Icon: ClipboardDocumentListIcon },
                           ],
                         },

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -934,6 +934,7 @@
     "confirm": "Confirm",
     "cancel": "Cancel",
     "remove": "Remove",
-    "privacyNote": "Your contact is stored by the KMS, not in the browser. The bot can only message you after you /start it."
+    "privacyNote": "Your contact is stored by the KMS, not in the browser. The bot can only message you after you /start it.",
+    "removeConfirm": "Remove the {{channel}} approval contact? High-value transfers will no longer reach you out-of-band."
   }
 }

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -914,5 +914,26 @@
         "desc": "Tight limits, experienced users"
       }
     }
+  },
+  "binding": {
+    "title": "Out-of-band approval contact",
+    "subtitle": "Bind a Telegram channel so high-value transfers can be approved out-of-band (Scheme 2). The bot only pings you — approval is your passkey, never a token.",
+    "noAccount": "Create your smart account first.",
+    "none": "No contact bound yet.",
+    "starting": "Starting binding (confirm with passkey)…",
+    "codeReady": "Binding code ready — send it to the bot",
+    "confirming": "Verifying (confirm with passkey)…",
+    "verified": "Telegram bound",
+    "removing": "Removing…",
+    "removed": "Contact removed",
+    "failed": "Binding failed",
+    "bindTelegram": "Bind Telegram",
+    "step2Title": "Send this to @AAStarBot on Telegram",
+    "step2Hint": "Open @AAStarBot, send the command below, then paste the verify token it replies with.",
+    "verifyTokenPlaceholder": "Verify token from the bot",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "remove": "Remove",
+    "privacyNote": "Your contact is stored by the KMS, not in the browser. The bot can only message you after you /start it."
   }
 }

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -934,6 +934,7 @@
     "confirm": "确认",
     "cancel": "取消",
     "remove": "移除",
-    "privacyNote": "联系方式存在 KMS,不在浏览器。你 /start 之后 bot 才能给你发消息。"
+    "privacyNote": "联系方式存在 KMS,不在浏览器。你 /start 之后 bot 才能给你发消息。",
+    "removeConfirm": "移除 {{channel}} 审批联系方式?大额转账将无法再带外通知到你。"
   }
 }

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -914,5 +914,26 @@
         "desc": "收紧额度，有经验"
       }
     }
+  },
+  "binding": {
+    "title": "带外批准联系方式",
+    "subtitle": "绑定 Telegram,让大额转账能带外批准(方案2)。bot 只给你发提醒——批准用你的 passkey,绝不是 token。",
+    "noAccount": "请先创建智能账户。",
+    "none": "还没绑定联系方式。",
+    "starting": "开始绑定(用 passkey 确认)…",
+    "codeReady": "绑定码已生成——发给 bot",
+    "confirming": "验证中(用 passkey 确认)…",
+    "verified": "Telegram 已绑定",
+    "removing": "移除中…",
+    "removed": "联系方式已移除",
+    "failed": "绑定失败",
+    "bindTelegram": "绑定 Telegram",
+    "step2Title": "在 Telegram 发给 @AAStarBot",
+    "step2Hint": "打开 @AAStarBot,发送下面的命令,然后把它回复的 verify token 粘贴进来。",
+    "verifyTokenPlaceholder": "bot 回复的 verify token",
+    "confirm": "确认",
+    "cancel": "取消",
+    "remove": "移除",
+    "privacyNote": "联系方式存在 KMS,不在浏览器。你 /start 之后 bot 才能给你发消息。"
   }
 }

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.28.0",
+    "@aastar/sdk": "^0.29.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.28.0",
+    "@aastar/sdk": "^0.29.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.28.0",
+        "@aastar/sdk": "^0.29.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.28.0",
+        "@aastar/sdk": "^0.29.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.28.0.tgz",
-      "integrity": "sha512-5GaSzcrq2DgcxSkSIwvbEQjoTPMS9rH/FrVUqecwYzj/L60c9X7nQqPxVbzLt43jFPPYPD6LHhcezQPBm+Gwqg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.0.tgz",
+      "integrity": "sha512-u1NT9tWaCJOWYjWPvDgDAjxxsEZlRYLhlOhcWtUP0M39HLrYsAxc3oq+inaUzDAVmmWMDb3AMZo68Fs+O31xEg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
Two things, both on 0.29.0:

1. **chore**: bump @aastar/sdk 0.28.0→0.29.0 (x402 + the browser-safe binding/confirm 6-API). type-check/build green front+back.
2. **feat (#193)**: new /binding page (nav 'Approval Contact') — binds Telegram to the AirAccount for Scheme-2 out-of-band approval. createContactBindingClient (begin/confirm/list/remove) via the **/kms-api proxy so the KMS api key never enters the bundle** (verified: /binding chunk has no crypto). Owner passkey ceremony reuses the existing KMS WebAuthn. i18n en+zh.

**NOTE**: contract #140 still unfixed → #1/#3 tier-config stay blocked (independent of this). The approval half of Scheme 2 stays pending DVT Validator#124.