### PR TITLE
chore(sdk): bump 0.29.1 — canonical factory now the #140-fixed deploy

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.0",
+    "@aastar/sdk": "^0.29.1",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.0",
+    "@aastar/sdk": "^0.29.1",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.29.0",
+        "@aastar/sdk": "^0.29.1",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.29.0",
+        "@aastar/sdk": "^0.29.1",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.0.tgz",
-      "integrity": "sha512-u1NT9tWaCJOWYjWPvDgDAjxxsEZlRYLhlOhcWtUP0M39HLrYsAxc3oq+inaUzDAVmmWMDb3AMZo68Fs+O31xEg==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.1.tgz",
+      "integrity": "sha512-aeMF2L7tmpTQutp0JldWEFbso5W3QKJ43GL3M1RXmcdkm5zl4SRT5MA4CfFTnCH8AAWP29dP9Hfufb0iOzO2bQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
0.29.1 points getCanonicalAddresses(sepolia).airAccountFactoryV7 at 0x78775786 (v0.20.3 onlyOwnerOrSelf, #140). Verified on-chain: setTierLimits self-call passes. Resolves YAA side of aastar-sdk#224. **KNOWN separate blocker**: setWeightConfig now reverts InsecureWeightConfig (SDK profile passkeyWeight=3 >= tier1Threshold=3) — see aastar-sdk issue. type-check/build green.