### PR TITLE
feat(auth/#369): per-email rate limit on OTP request + verify

### DIFF
--- a/aastar/src/auth/auth.controller.ts
+++ b/aastar/src/auth/auth.controller.ts
@@ -3,6 +3,13 @@ import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
 import { AuthService } from "./auth.service";
 import { RequestOtpDto, VerifyOtpDto } from "./dto/otp.dto";
 import { JwtAuthGuard } from "./guards/jwt-auth.guard";
+import { OtpRateLimit } from "./guards/otp-rate-limit.guard";
+
+// Per-email OTP limits (15-min sliding window): cap code sends (anti-spam/cost) and verify
+// attempts (anti-brute-force; the code is also single-use + TTL'd in the service).
+const OTP_WINDOW_MS = 15 * 60_000;
+const OTP_REQUEST_MAX = 5;
+const OTP_VERIFY_MAX = 10;
 
 @ApiTags("auth")
 @Controller("auth")
@@ -11,6 +18,7 @@ export class AuthController {
 
   @Post("otp/request")
   @HttpCode(200)
+  @UseGuards(OtpRateLimit("request", OTP_REQUEST_MAX, OTP_WINDOW_MS))
   @ApiOperation({
     summary: "Send a 6-digit sign-in code to an email (passwordless register + login)",
   })
@@ -20,6 +28,7 @@ export class AuthController {
 
   @Post("otp/verify")
   @HttpCode(200)
+  @UseGuards(OtpRateLimit("verify", OTP_VERIFY_MAX, OTP_WINDOW_MS))
   @ApiOperation({
     summary: "Verify the email code → create/login the user and return a JWT",
     description:

--- a/aastar/src/auth/guards/otp-rate-limit.guard.spec.ts
+++ b/aastar/src/auth/guards/otp-rate-limit.guard.spec.ts
@@ -1,0 +1,63 @@
+import { ExecutionContext } from "@nestjs/common";
+import { OtpRateLimit, __resetOtpRateLimit } from "./otp-rate-limit.guard";
+
+function ctx(email?: string): ExecutionContext {
+  const body = email === undefined ? {} : { email };
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ body }) }),
+  } as unknown as ExecutionContext;
+}
+
+describe("OtpRateLimit guard", () => {
+  beforeEach(() => __resetOtpRateLimit());
+
+  it("allows up to max hits, then throws 429", () => {
+    const guard = new (OtpRateLimit("request", 3, 60_000))();
+    for (let i = 0; i < 3; i++) {
+      expect(guard.canActivate(ctx("a@x.io"))).toBe(true);
+    }
+    expect(() => guard.canActivate(ctx("a@x.io"))).toThrow(/Too many OTP request/);
+  });
+
+  it("counts each email independently", () => {
+    const guard = new (OtpRateLimit("request", 1, 60_000))();
+    expect(guard.canActivate(ctx("a@x.io"))).toBe(true);
+    expect(guard.canActivate(ctx("b@x.io"))).toBe(true); // different email → own budget
+    expect(() => guard.canActivate(ctx("a@x.io"))).toThrow();
+  });
+
+  it("normalizes email case + surrounding whitespace", () => {
+    const guard = new (OtpRateLimit("request", 1, 60_000))();
+    expect(guard.canActivate(ctx("A@X.io"))).toBe(true);
+    expect(() => guard.canActivate(ctx("  a@x.io  "))).toThrow(); // same normalized key
+  });
+
+  it("keeps request and verify buckets separate", () => {
+    const req = new (OtpRateLimit("request", 1, 60_000))();
+    const ver = new (OtpRateLimit("verify", 1, 60_000))();
+    expect(req.canActivate(ctx("a@x.io"))).toBe(true);
+    expect(ver.canActivate(ctx("a@x.io"))).toBe(true); // separate bucket, not blocked
+    expect(() => req.canActivate(ctx("a@x.io"))).toThrow();
+  });
+
+  it("never blocks when the body has no email (DTO validation handles that)", () => {
+    const guard = new (OtpRateLimit("request", 1, 60_000))();
+    expect(guard.canActivate(ctx())).toBe(true);
+    expect(guard.canActivate(ctx())).toBe(true);
+    expect(guard.canActivate(ctx(""))).toBe(true);
+  });
+
+  it("frees the budget once the window slides past old hits", () => {
+    let now = 1_000_000;
+    const spy = jest.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const guard = new (OtpRateLimit("request", 1, 1_000))();
+      expect(guard.canActivate(ctx("a@x.io"))).toBe(true);
+      expect(() => guard.canActivate(ctx("a@x.io"))).toThrow(); // within window
+      now += 1_001; // slide past the window
+      expect(guard.canActivate(ctx("a@x.io"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/aastar/src/auth/guards/otp-rate-limit.guard.spec.ts
+++ b/aastar/src/auth/guards/otp-rate-limit.guard.spec.ts
@@ -1,10 +1,13 @@
 import { ExecutionContext } from "@nestjs/common";
 import { OtpRateLimit, __resetOtpRateLimit } from "./otp-rate-limit.guard";
 
-function ctx(email?: string): ExecutionContext {
+function ctx(email?: string, res?: { header: jest.Mock }): ExecutionContext {
   const body = email === undefined ? {} : { email };
   return {
-    switchToHttp: () => ({ getRequest: () => ({ body }) }),
+    switchToHttp: () => ({
+      getRequest: () => ({ body }),
+      getResponse: () => res ?? { header: () => undefined },
+    }),
   } as unknown as ExecutionContext;
 }
 
@@ -40,11 +43,13 @@ describe("OtpRateLimit guard", () => {
     expect(() => req.canActivate(ctx("a@x.io"))).toThrow();
   });
 
-  it("never blocks when the body has no email (DTO validation handles that)", () => {
+  it("never blocks (or tracks) bodies without a plausible email", () => {
     const guard = new (OtpRateLimit("request", 1, 60_000))();
     expect(guard.canActivate(ctx())).toBe(true);
-    expect(guard.canActivate(ctx())).toBe(true);
     expect(guard.canActivate(ctx(""))).toBe(true);
+    // Malformed email is not tracked → can be hit repeatedly (the DTO @IsEmail 400s it later).
+    expect(guard.canActivate(ctx("notanemail"))).toBe(true);
+    expect(guard.canActivate(ctx("notanemail"))).toBe(true);
   });
 
   it("frees the budget once the window slides past old hits", () => {
@@ -59,5 +64,13 @@ describe("OtpRateLimit guard", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+
+  it("sets a Retry-After header on the 429", () => {
+    const header = jest.fn();
+    const guard = new (OtpRateLimit("request", 1, 60_000))();
+    expect(guard.canActivate(ctx("a@x.io", { header }))).toBe(true);
+    expect(() => guard.canActivate(ctx("a@x.io", { header }))).toThrow();
+    expect(header).toHaveBeenCalledWith("Retry-After", expect.stringMatching(/^\d+$/));
   });
 });

--- a/aastar/src/auth/guards/otp-rate-limit.guard.ts
+++ b/aastar/src/auth/guards/otp-rate-limit.guard.ts
@@ -1,0 +1,84 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Type,
+  mixin,
+} from "@nestjs/common";
+
+// In-memory sliding-window rate limit, keyed per (bucket, email). An OTP is email-bound,
+// so limiting per normalized email throttles BOTH code-spam (otp/request) and code-guessing
+// (otp/verify) without needing the client IP. The store is module-level so it is shared
+// across the singleton guards; a periodic sweep + per-key pruning bound its memory.
+//
+// NOTE: this is per-process memory — correct for YAA's single-instance backend. A multi-
+// replica deployment must move the store to a shared backend (e.g. Redis), or each replica
+// would enforce the limit independently.
+//
+// SCOPE: the key is the exact normalized email, so it bounds spam/guessing against ONE
+// address. It does NOT stop an attacker enumerating sub-addresses (victim+1@, victim+2@) to
+// spam one inbox — that needs a per-IP limit or captcha, which belongs at the edge/proxy
+// (the backend sits behind the Next.js rewrite, so req.ip is the proxy here). Tracked as a
+// follow-up; this guard is the per-email layer.
+const store = new Map<string, number[]>();
+
+// The widest window any bucket uses; a key whose every hit is older than this is dead and
+// can be dropped so one-off emails can't grow the map unbounded.
+const MAX_WINDOW_MS = 60 * 60_000;
+const SWEEP_MS = 10 * 60_000;
+const sweep = setInterval(() => {
+  const cutoff = Date.now() - MAX_WINDOW_MS;
+  for (const [key, hits] of store) {
+    if (hits.length === 0 || hits[hits.length - 1] <= cutoff) store.delete(key);
+  }
+}, SWEEP_MS);
+// Don't keep the event loop (or test runner / graceful shutdown) alive for the sweep.
+sweep.unref?.();
+
+/**
+ * Per-email OTP rate-limit guard factory. `bucket` separates the request vs verify counters
+ * (so a verify attempt doesn't consume a request's budget). Exceeding `max` hits within
+ * `windowMs` yields a 429 with a Retry-After-style hint. Requests with no email fall through
+ * so the DTO's `@IsEmail` produces the usual 400 instead of a confusing 429.
+ */
+export function OtpRateLimit(bucket: string, max: number, windowMs: number): Type<CanActivate> {
+  @Injectable()
+  class OtpRateLimitGuard implements CanActivate {
+    canActivate(context: ExecutionContext): boolean {
+      const req = context.switchToHttp().getRequest();
+      const email = String(req?.body?.email ?? "")
+        .trim()
+        .toLowerCase();
+      if (!email) return true; // no email → let @IsEmail validation 400 it
+
+      const key = `${bucket}:${email}`;
+      const now = Date.now();
+      const hits = (store.get(key) ?? []).filter(t => t > now - windowMs);
+
+      if (hits.length >= max) {
+        const retryMs = windowMs - (now - hits[0]);
+        store.set(key, hits); // persist the pruned window even when blocking
+        throw new HttpException(
+          {
+            statusCode: HttpStatus.TOO_MANY_REQUESTS,
+            error: "Too Many Requests",
+            message: `Too many OTP ${bucket} attempts. Try again in ${Math.ceil(retryMs / 1000)}s.`,
+          },
+          HttpStatus.TOO_MANY_REQUESTS
+        );
+      }
+
+      hits.push(now);
+      store.set(key, hits);
+      return true;
+    }
+  }
+  return mixin(OtpRateLimitGuard);
+}
+
+// Test-only: reset the shared store between unit tests.
+export function __resetOtpRateLimit(): void {
+  store.clear();
+}

--- a/aastar/src/auth/guards/otp-rate-limit.guard.ts
+++ b/aastar/src/auth/guards/otp-rate-limit.guard.ts
@@ -11,7 +11,8 @@ import {
 // In-memory sliding-window rate limit, keyed per (bucket, email). An OTP is email-bound,
 // so limiting per normalized email throttles BOTH code-spam (otp/request) and code-guessing
 // (otp/verify) without needing the client IP. The store is module-level so it is shared
-// across the singleton guards; a periodic sweep + per-key pruning bound its memory.
+// across the singleton guards; a periodic sweep, a hard key cap, and per-key pruning bound
+// its memory.
 //
 // NOTE: this is per-process memory — correct for YAA's single-instance backend. A multi-
 // replica deployment must move the store to a shared backend (e.g. Redis), or each replica
@@ -24,10 +25,14 @@ import {
 // follow-up; this guard is the per-email layer.
 const store = new Map<string, number[]>();
 
-// The widest window any bucket uses; a key whose every hit is older than this is dead and
-// can be dropped so one-off emails can't grow the map unbounded.
 const MAX_WINDOW_MS = 60 * 60_000;
 const SWEEP_MS = 10 * 60_000;
+// Hard cap on tracked keys. This guard runs BEFORE the DTO ValidationPipe, so a flood of
+// distinct emails (even well-formed) could otherwise grow `store` unbounded within a sweep
+// period (memory DoS, #388). The cap bounds memory; eviction drops oldest-inserted keys —
+// acceptable worst case under a flood (a few limit resets, never OOM).
+const MAX_KEYS = 50_000;
+
 const sweep = setInterval(() => {
   const cutoff = Date.now() - MAX_WINDOW_MS;
   for (const [key, hits] of store) {
@@ -37,34 +42,50 @@ const sweep = setInterval(() => {
 // Don't keep the event loop (or test runner / graceful shutdown) alive for the sweep.
 sweep.unref?.();
 
+function evictIfOverCap(): void {
+  if (store.size <= MAX_KEYS) return;
+  let toDrop = store.size - MAX_KEYS;
+  for (const key of store.keys()) {
+    store.delete(key);
+    if (--toDrop <= 0) break;
+  }
+}
+
+// Cheap pre-validation: only track plausibly-valid emails so a malformed/garbage body can't
+// seed a key. The strict `@IsEmail` still runs later in the pipe (this just bounds garbage).
+function looksLikeEmail(s: string): boolean {
+  return s.length > 0 && s.length <= 254 && /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s);
+}
+
 /**
  * Per-email OTP rate-limit guard factory. `bucket` separates the request vs verify counters
  * (so a verify attempt doesn't consume a request's budget). Exceeding `max` hits within
- * `windowMs` yields a 429 with a Retry-After-style hint. Requests with no email fall through
- * so the DTO's `@IsEmail` produces the usual 400 instead of a confusing 429.
+ * `windowMs` yields a 429 with a `Retry-After` header. Bodies without a plausible email fall
+ * through so the DTO's `@IsEmail` produces the usual 400 instead of a confusing 429.
  */
 export function OtpRateLimit(bucket: string, max: number, windowMs: number): Type<CanActivate> {
   @Injectable()
   class OtpRateLimitGuard implements CanActivate {
     canActivate(context: ExecutionContext): boolean {
-      const req = context.switchToHttp().getRequest();
-      const email = String(req?.body?.email ?? "")
+      const http = context.switchToHttp();
+      const email = String(http.getRequest()?.body?.email ?? "")
         .trim()
         .toLowerCase();
-      if (!email) return true; // no email → let @IsEmail validation 400 it
+      if (!looksLikeEmail(email)) return true; // let @IsEmail 400 it; don't seed a key
 
       const key = `${bucket}:${email}`;
       const now = Date.now();
       const hits = (store.get(key) ?? []).filter(t => t > now - windowMs);
 
       if (hits.length >= max) {
-        const retryMs = windowMs - (now - hits[0]);
         store.set(key, hits); // persist the pruned window even when blocking
+        const retrySec = Math.ceil((windowMs - (now - hits[0])) / 1000);
+        http.getResponse()?.header?.("Retry-After", String(retrySec));
         throw new HttpException(
           {
             statusCode: HttpStatus.TOO_MANY_REQUESTS,
             error: "Too Many Requests",
-            message: `Too many OTP ${bucket} attempts. Try again in ${Math.ceil(retryMs / 1000)}s.`,
+            message: `Too many OTP ${bucket} attempts. Try again in ${retrySec}s.`,
           },
           HttpStatus.TOO_MANY_REQUESTS
         );
@@ -72,13 +93,16 @@ export function OtpRateLimit(bucket: string, max: number, windowMs: number): Typ
 
       hits.push(now);
       store.set(key, hits);
+      evictIfOverCap();
       return true;
     }
   }
   return mixin(OtpRateLimitGuard);
 }
 
-// Test-only: reset the shared store between unit tests.
+// Test-only: reset the shared store between unit tests. No-ops in production so a stray
+// import/call can't clear live rate-limit state.
 export function __resetOtpRateLimit(): void {
+  if (process.env.NODE_ENV === "production") return;
   store.clear();
 }

--- a/aastar/src/operator/operator.service.ts
+++ b/aastar/src/operator/operator.service.ts
@@ -4,7 +4,6 @@ import { createPublicClient, http, formatUnits, parseAbi } from "viem";
 import {
   registryActions,
   stakingActions,
-  superPaymasterActions,
   tokenActions,
   applyConfig,
   CHAIN_SEPOLIA,


### PR DESCRIPTION
Closes #369. In-memory sliding-window guard (OtpRateLimit) per normalized email: /auth/otp/request 5/15min (anti-spam), /auth/otp/verify 10/15min (anti-brute-force; code is also single-use + TTL'd). Separate buckets, no-email falls through to @IsEmail 400, unref'd sweep bounds memory. **6 unit tests** (limit→429, per-email isolation, normalization, bucket separation, no-email, window slide); backend 40/40 green, type-check/build/lint clean.

Self/adversarial review documented in-code: per-process memory (Redis for multi-replica) + per-exact-email scope (sub-address enumeration / per-IP is a separate edge layer). Also drops a pre-existing unused superPaymasterActions import that was failing backend lint.