### PR TITLE
chore(sdk): bump 0.29.2 — passkeyWeight 3->2 unblocks tier config (#227)

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.1",
+    "@aastar/sdk": "^0.29.2",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.1",
+    "@aastar/sdk": "^0.29.2",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.29.1",
+        "@aastar/sdk": "^0.29.2",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.29.1",
+        "@aastar/sdk": "^0.29.2",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.1.tgz",
-      "integrity": "sha512-aeMF2L7tmpTQutp0JldWEFbso5W3QKJ43GL3M1RXmcdkm5zl4SRT5MA4CfFTnCH8AAWP29dP9Hfufb0iOzO2bQ==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.2.tgz",
+      "integrity": "sha512-NORCovbqVGZgq38lUbKKbDyfLHhRmu/KPFrvqDDMYIoA4+fD+zZTp/LA7hyJ6wU/m1O7DPIR0NvoRkKQIwLmEw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
0.29.2 fixes TIER_PROFILES passkeyWeight (3→2). **Verified on-chain**: profileSetupCalls' setTierLimits + setWeightConfig both pass as gasless self-call UserOps on the new factory — #1 persona page now actually arms tiers+weights. Unblocks #1/#3a/#3b. type-check/build green.