### PR TITLE
test(#3a-B3): wait for arming to mine + diagnose AA33 aPNTs gap

### DIFF
--- a/aastar-frontend/e2e/helpers/fund.ts
+++ b/aastar-frontend/e2e/helpers/fund.ts
@@ -104,6 +104,21 @@ export async function getEthBalance(addr: Address): Promise<bigint> {
   return client().getBalance({ address: addr });
 }
 
+// On-chain tier-2 limit — used to poll until a profile-arming UserOp has actually mined
+// (the apply toast fires on submit, before the self-call lands), so a follow-on transfer's
+// resolveTransfer reads the armed tiers rather than the still-zero pre-arm state.
+export async function getTier2Limit(account: Address): Promise<bigint> {
+  try {
+    return (await client().readContract({
+      address: account,
+      abi: AAStarAirAccountV7ABI,
+      functionName: "tier2Limit",
+    })) as bigint;
+  } catch {
+    return 0n; // not deployed / not armed yet
+  }
+}
+
 const ERC20_TRANSFER_ABI = [
   {
     type: "function",

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -3,7 +3,7 @@ import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
 import { parseEther, formatEther, type Address } from "viem";
 import { installVirtualAuthenticator } from "./helpers/webauthn";
 import { installTestWallet } from "./helpers/wallet";
-import { fundWithEth, getEthBalance, withRetry } from "./helpers/fund";
+import { fundWithEth, getEthBalance, getTier2Limit, withRetry } from "./helpers/fund";
 
 // XFER-T3 — #3a B3: a real Tier-3 transfer (passkey + DVT/BLS + guardian co-sign) end to
 // end. Builds a guardian-equipped, tier-configured account from scratch (the only way to
@@ -117,6 +117,9 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   await expect(page.getByText(/Tier config applied|分层配置已应用/i)).toBeVisible({
     timeout: 120_000,
   });
+  // The apply toast fires on submit, before the self-call UserOps mine. Wait until the armed
+  // tier-2 is actually on-chain so the transfer's resolveTransfer reads it (not pre-arm zero).
+  await expect.poll(() => getTier2Limit(account), { timeout: 90_000 }).toBeGreaterThan(0n);
 
   // 5) Tier-3 transfer: 0.051 ETH > tier2 (0.05) → needs passkey + BLS + guardian. The UI flow
   // collects the guardian co-sign from window.ethereum (g1) over the userOpHash.


### PR DESCRIPTION
Live B3 rounds 4–5 confirmed **register + create-with-guardians + fund + the #1 /tier-setup apply UI all run end to end** against the real KMS/bundler. Adds getTier2Limit() + an expect.poll so the run waits for arming to actually mine.

**Root cause found** for why armed tier-2 stays 0: the gasless config self-call UserOps revert **AA33 (0xa18ee550)** — PaymasterV4 rejects because the FRESH account holds no aPNTs (its gas token). This is the SuperPaymaster model (gas paid in community xPNTs/aPNTs), **not a #1 bug** — the contract self-call is verified (simulate passes). B3 goes green once it funds aPNTs + approves the paymaster (the real onboarding) before gasless ops. Also surfaced: the persona page shows a success toast even when submit's UserOp reverts — should check the result.