### PR TITLE
fix(tier-setup,tier-raise): surface gasless submit failure instead of false success

### DIFF
--- a/aastar-frontend/app/tier-raise/page.tsx
+++ b/aastar-frontend/app/tier-raise/page.tsx
@@ -175,11 +175,14 @@ export default function TierRaisePage() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         optionsJSON: prep.data.publicKeyOptions as any,
       });
-      await transferAPI.submit({
+      const res = await transferAPI.submit({
         transferId: prep.data.transferId,
         challengeId: prep.data.challengeId,
         credential,
       });
+      // success:false (not a throw) when the bundler/paymaster rejects the UserOp — surface it.
+      const r = res.data as { success?: boolean; message?: string } | undefined;
+      if (r && r.success === false) throw new Error(r.message || t("tierRaise.failed"));
       toast.success(t("tierRaise.done"), { id });
       setPending(null);
       setSigs([]);

--- a/aastar-frontend/app/tier-setup/page.tsx
+++ b/aastar-frontend/app/tier-setup/page.tsx
@@ -73,11 +73,18 @@ export default function TierSetupPage() {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           optionsJSON: prep.data.publicKeyOptions as any,
         });
-        await transferAPI.submit({
+        const res = await transferAPI.submit({
           transferId: prep.data.transferId,
           challengeId: prep.data.challengeId,
           credential,
         });
+        // The SDK returns success:false (not a throw) when the bundler/paymaster rejects the
+        // UserOp (e.g. AA33 — no aPNTs for PaymasterV4), so a missing check would falsely report
+        // the tiers as applied. Surface the real failure instead.
+        const r = res.data as { success?: boolean; message?: string } | undefined;
+        if (r && r.success === false) {
+          throw new Error(r.message || t("tierSetup.failed"));
+        }
       }
       toast.success(t("tierSetup.done"));
       await loadTier();


### PR DESCRIPTION
The persona apply and the raise page submit via gasless UserOps; the SDK returns { success:false } (not a throw) when the bundler/paymaster rejects (e.g. AA33 — fresh account has no aPNTs for PaymasterV4), so the pages showed a success toast even though nothing landed. Both now check res.data.success and surface the real error. Found via the B3 live run.