### PR TITLE
chore(deps): bump @aastar/sdk to 0.29.3 (#229 non-silent gas fallback)

### DIFF
--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.2",
+    "@aastar/sdk": "^0.29.3",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.2",
+    "@aastar/sdk": "^0.29.3",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.29.2",
+        "@aastar/sdk": "^0.29.3",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.29.2",
+        "@aastar/sdk": "^0.29.3",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.2.tgz",
-      "integrity": "sha512-NORCovbqVGZgq38lUbKKbDyfLHhRmu/KPFrvqDDMYIoA4+fD+zZTp/LA7hyJ6wU/m1O7DPIR0NvoRkKQIwLmEw==",
+      "version": "0.29.3",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.3.tgz",
+      "integrity": "sha512-uAgwaS/xi8RIJ2a0fDHVKLQGCPItoFfH9kj5kSv+VFuSvT5fxY8ugd80eV88f92RqnNrYu9Wz1pYm0R4Pw9/0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
Surgical bump 0.29.2 → 0.29.3 (aastar-sdk#229). The SDK's KMS gas-estimation path no longer silently swallows bundler estimation failures behind a flat 4M verificationGasLimit — it now logger.warns the real error and adds a 10% buffer on the success path. **Verified YAA-side**: backend logs the real '[EthereumProvider] eth_estimateUserOperationGas failed (...); falling back to static gas limits...' warning. type-check/build green.