### PR TITLE
feat(#1,#3a-B3): SDK V4 gasless onboarding + fix double-deploy (AA10)

### DIFF
--- a/aastar-frontend/app/tier-setup/page.tsx
+++ b/aastar-frontend/app/tier-setup/page.tsx
@@ -85,6 +85,20 @@ export default function TierSetupPage() {
         if (r && r.success === false) {
           throw new Error(r.message || t("tierSetup.failed"));
         }
+        // The first profile call also DEPLOYS the account (initCode). Wait for it to land before
+        // submitting the next call — otherwise that UserOp carries a second deploy for the same
+        // sender and the bundler rejects it (AA10 "deployment already being processed").
+        if (i < calls.length - 1) {
+          const deadline = Date.now() + 120_000;
+          for (;;) {
+            const st = await transferAPI.getStatus(prep.data.transferId);
+            const status = (st.data as { status?: string } | undefined)?.status;
+            if (status === "completed") break;
+            if (status === "failed") throw new Error(t("tierSetup.failed"));
+            if (Date.now() > deadline) throw new Error(t("tierSetup.failed"));
+            await new Promise(resolve => setTimeout(resolve, 3000));
+          }
+        }
       }
       toast.success(t("tierSetup.done"));
       await loadTier();

--- a/aastar-frontend/e2e/helpers/fund.ts
+++ b/aastar-frontend/e2e/helpers/fund.ts
@@ -15,7 +15,9 @@ import {
   GuardClient,
   applyConfig,
   getCanonicalAddresses,
+  xPNTsTokenActions,
 } from "@aastar/sdk/core";
+import { PaymasterClient, PaymasterOperator } from "@aastar/sdk/paymaster";
 
 const ENTRYPOINT_ABI = [
   {
@@ -117,6 +119,57 @@ export async function getTier2Limit(account: Address): Promise<bigint> {
   } catch {
     return 0n; // not deployed / not armed yet
   }
+}
+
+/**
+ * Onboard an account for gasless ops via the SDK's V4 PaymasterClient: refresh the cached price,
+ * then mint aPNTs (env admin = aPNTs communityOwner) and depositFor() into the account's INTERNAL
+ * PaymasterV4 balance (balances[account][aPNTs]) — what validatePaymasterUserOp actually charges.
+ * Without it a fresh account's gasless UserOp reverts AA33 Paymaster__InsufficientBalance.
+ */
+export async function onboardAPNTsGas(account: Address, amount: string): Promise<void> {
+  const key = env("TEST_EOA_PRIVATE_KEY");
+  if (!key) throw new Error("TEST_EOA_PRIVATE_KEY unset");
+  const acct = privateKeyToAccount(key as `0x${string}`);
+  const transport = http(env("ETH_RPC_URL"));
+  const pc = createPublicClient({ chain: sepolia, transport });
+  const wc = createWalletClient({ account: acct, chain: sepolia, transport });
+  applyConfig({ chainId: 11155111 });
+  const C = getCanonicalAddresses(11155111)!;
+  const amt = parseEther(amount);
+  const pm = C.paymasterV4 as Address;
+  const apnts = C.aPNTs as Address;
+  // PaymasterV4 is DEPOSIT-ONLY: validatePaymasterUserOp charges balances[sender][token] (the
+  // account's INTERNAL paymaster balance), NOT the account's own aPNTs token balance, and prices
+  // gas via a cached oracle. This is the V4 flow (distinct from the SuperPaymaster/permit flow),
+  // so use the SDK's V4 PaymasterClient — never hand-rolled contract calls. Onboarding = refresh
+  // the cached price (the updater cron is off in test → a stale price reverts the cost calc, AA33),
+  // mint aPNTs to the admin (the aPNTs communityOwner), approve, then depositFor into the
+  // account's internal balance.
+  try {
+    await confirmTx(
+      pc,
+      (await PaymasterOperator.updatePrice(wc, pm)) as `0x${string}`,
+      "updatePrice"
+    );
+  } catch {
+    /* price already fresh enough */
+  }
+  await confirmTx(
+    pc,
+    await xPNTsTokenActions(apnts)(wc).mint({ token: apnts, to: acct.address, amount: amt }),
+    "aPNTs mint"
+  );
+  await confirmTx(
+    pc,
+    (await PaymasterClient.approveGasToken(wc, apnts, pm, amt)) as `0x${string}`,
+    "approveGasToken"
+  );
+  await confirmTx(
+    pc,
+    (await PaymasterClient.depositFor(wc, pm, account, apnts, amt)) as `0x${string}`,
+    "depositFor"
+  );
 }
 
 const ERC20_TRANSFER_ABI = [

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -1,9 +1,18 @@
 import { test, expect, type Page } from "@playwright/test";
 import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
 import { parseEther, formatEther, type Address } from "viem";
+import { getCanonicalAddresses } from "@aastar/sdk/core";
 import { installVirtualAuthenticator } from "./helpers/webauthn";
 import { installTestWallet } from "./helpers/wallet";
-import { fundWithEth, getEthBalance, getTier2Limit, withRetry } from "./helpers/fund";
+import {
+  fundWithEth,
+  getEthBalance,
+  getTier2Limit,
+  onboardAPNTsGas,
+  withRetry,
+} from "./helpers/fund";
+
+const PAYMASTER_V4 = getCanonicalAddresses(11155111)!.paymasterV4 as `0x${string}`;
 
 // XFER-T3 — #3a B3: a real Tier-3 transfer (passkey + DVT/BLS + guardian co-sign) end to
 // end. Builds a guardian-equipped, tier-configured account from scratch (the only way to
@@ -102,6 +111,12 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   await withRetry(() => fundWithEth(account, "0.08"));
   await expect.poll(() => getEthBalance(account), { timeout: 60_000 }).toBeGreaterThan(0n);
 
+  // 3b) Onboard for gasless: deposit aPNTs into the account's INTERNAL PaymasterV4 balance
+  // (balances[account][aPNTs]) — what validatePaymasterUserOp actually charges — and refresh the
+  // cached price. Without it the gasless config/transfer UserOps revert AA33
+  // Paymaster__InsufficientBalance. 100k aPNTs covers the deploy + transfer ops with headroom.
+  await withRetry(() => onboardAPNTsGas(account, "100000"));
+
   // 4) Arm tiers via the real /tier-setup persona page (#1 verification): the "conservative"
   // profile (tier1 0.005 / tier2 0.05 ETH). This drives the bundled passkey ceremony through the
   // CDP virtual authenticator for both self-call UserOps (setTierLimits + setWeightConfig) — which
@@ -109,7 +124,10 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   // Load the dashboard first so DashboardContext fetches the freshly-created account before
   // /tier-setup reads it from context (a direct deep-link can render before the account loads).
   await page.goto("/dashboard");
-  await page.waitForLoadState("networkidle");
+  // Bounded — the dashboard polls balances/tasks continuously (more so once the account holds
+  // aPNTs), so "networkidle" never settles and would hang to the 300s test cap. A short wait is
+  // enough for DashboardContext to fetch the account before /tier-setup reads it.
+  await page.waitForLoadState("networkidle", { timeout: 12_000 }).catch(() => {});
   await page.goto("/tier-setup");
   await expect(page.getByText(/Conservative|保守型/i)).toBeVisible({ timeout: 30_000 });
   await page.getByText(/Conservative|保守型/i).click();
@@ -126,6 +144,11 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   await page.goto("/transfer");
   await page.locator('input[name="to"]').fill(g2.address); // recipient = g2 (recoverable)
   await page.locator('input[name="amount"]').fill("0.051");
+  // Pay gas via PaymasterV4 (gasless) from the account's deposited aPNTs. The account holds no
+  // spare ETH for an ETH-paid prefund (and zero-ETH transfers are the whole point), so an ETH-paid
+  // path reverts AA21. Check the box, then fill the paymaster address the field reveals.
+  await page.locator("#usePaymaster").check();
+  await page.locator('input[name="paymasterAddress"]').fill(PAYMASTER_V4);
   // Wait for the judging indicator to confirm Tier 3 (the guardian-co-signature line is
   // unambiguous to Tier 3; the "Tier N signing" header's inline {tier} span splits the node).
   await expect(page.getByText(/guardian co-signature/i)).toBeVisible({ timeout: 20_000 });


### PR DESCRIPTION
Drives the Tier-3 e2e (register → create-with-guardians → fund → onboard → arm profile → gasless Tier-3 transfer) through every usage-side blocker. **Real #1 bug fixed**: the persona apply submitted two profile calls that BOTH deploy a fresh account → bundler rejects the 2nd (AA10); now waits for the 1st to land first. onboardAPNTsGas uses the SDK V4 PaymasterClient (updatePrice + depositFor into the account's internal paymaster balance — PaymasterV4 is deposit-only). Tier-3 transfer pays gas via PaymasterV4 (gasless, not an ETH prefund → AA21).

**Remaining (separate)**: the Tier-3 composite signature only carries the single owner sig (no BLS+guardian aggregation) → AA24. That is the device-passkey tiered path not aggregating BLS for Tier-3 (SDK-side). Tracks #382.