### PR TITLE
chore+fix: bump @aastar/sdk 0.29.4 (Tier-2/3 composite) + narrow updatePrice catch (#396 Low)

### DIFF
--- a/aastar-frontend/e2e/helpers/fund.ts
+++ b/aastar-frontend/e2e/helpers/fund.ts
@@ -152,8 +152,11 @@ export async function onboardAPNTsGas(account: Address, amount: string): Promise
       (await PaymasterOperator.updatePrice(wc, pm)) as `0x${string}`,
       "updatePrice"
     );
-  } catch {
-    /* price already fresh enough */
+  } catch (e) {
+    // updatePrice reverts when the cached price is still within the staleness window — expected,
+    // skip. But log anything else (RPC down, wrong PM, not the price updater) so a real failure
+    // isn't silently swallowed — the same lesson as the SDK's #229 silent-catch.
+    console.warn(`onboardAPNTsGas: updatePrice skipped (${(e as Error)?.message ?? String(e)})`);
   }
   await confirmTx(
     pc,

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.3",
+    "@aastar/sdk": "^0.29.4",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.3",
+    "@aastar/sdk": "^0.29.4",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.29.3",
+        "@aastar/sdk": "^0.29.4",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.29.3",
+        "@aastar/sdk": "^0.29.4",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.3.tgz",
-      "integrity": "sha512-uAgwaS/xi8RIJ2a0fDHVKLQGCPItoFfH9kj5kSv+VFuSvT5fxY8ugd80eV88f92RqnNrYu9Wz1pYm0R4Pw9/0A==",
+      "version": "0.29.4",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.4.tgz",
+      "integrity": "sha512-WYTO3DZJ+bHIARKfhyhFIHRRljPb90V+XQeoPnAbvNZx7u1CwGlh/gCHKm26KJBDtoIgU7sJBhFMfc7/R+Irgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",


### PR DESCRIPTION
**0.29.4 bump** (surgical): wires Tier-2/3 BLS+guardian aggregation into submitPreparedTransfer (p256Signature param + fail-fast) — addresses aastar-sdk#234. **Integration of the p256Signature path is pending** confirmation of YAA's Tier-2/3 P256 key source: YAA's P256 is **KMS/TEE-hosted** (AirAccount — the private key never leaves the enclave, WebAuthn is only the auth), so YAA cannot produce a client-side raw-P256-over-userOpHash. Posted the full architecture + 2 questions to aastar-sdk#234 (which KMS method yields the raw r‖s; and — since we wrap all KMS access via the SDK — whether submitPreparedTransfer should source p256Signature internally for KMS-hosted accounts). Also fixes #396's Low: the updatePrice catch no longer silently swallows non-stale errors. type-check/build green.