### PR TITLE
feat: Tier-3 production WebAuthn (device-passkey) + subdomain rpId fix + default paymaster & type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ signatures**, and **ERC-4337 account abstraction**. Features passwordless login,
 mandatory transaction verification, **KMS-based key management**, and **gasless
 account deployment** via Paymaster sponsorship.
 
+---
+
+## 🎬 Live on-chain demo — device-passkey Tier-3 gasless transfer
+
+A real end-to-end run on **Sepolia**: a user registers with a device passkey, gets a KMS-custodied
+smart account created with the passkey + validator **wired at birth**, and sends **0.051 ETH while
+holding zero ETH for gas** — the Paymaster sponsors gas from community points (aPNTs). Full-stack
+Playwright e2e (real browser passkey + real backend KMS owner + live DVT network) — **1 passed**.
+
+| | |
+|---|---|
+| **Tier-3 transfer tx** | [`0xa275c4aa…4e4a94`](https://sepolia.etherscan.io/tx/0xa275c4aa4870171afaac4e6aa079d99eb6b60e0f34ac330c12915c7ae34e4a94) (`success = true`) |
+| **Account** (device passkey, v0.23.0) | [`0x4a8B0f97…6Aca59`](https://sepolia.etherscan.io/address/0x4a8B0f971A3D73a8074117dD0d875F85Fd6Aca59) |
+| **Sent** | 0.051 ETH → recipient · account ETH `0.08 → 0.029` (exactly −0.051, **0 gas paid by the account**) |
+| **Gas** | sponsored by Paymaster `0xf3948753…` (`actualGasCost 0.000749 ETH`), funded by aPNTs |
+| **Signature** | device passkey (P256) + DVT BLS aggregate (dvt1/2/3) + guardian ECDSA → `packCumulativeT3WA` (0x0a) → `validateUserOp == 0` |
+| **Stack** | `@aastar/sdk@0.34.0` · AirAccount `v0.23.0` · DVT `v1.7.1` |
+
+📄 **Full details + all transactions:** [`docs/DEMO-device-passkey-tier3-gasless.md`](docs/DEMO-device-passkey-tier3-gasless.md)
+
+---
+
 > **🎯 Perfect for**: Web3 developers building secure wallets, DeFi applications
 > requiring enhanced security, and projects needing passwordless blockchain
 > authentication with enterprise-grade key management.

--- a/aastar-frontend/app/auth/register/page.tsx
+++ b/aastar-frontend/app/auth/register/page.tsx
@@ -9,8 +9,40 @@ import { kmsClient } from "@/lib/yaaa";
 import { setStoredAuth } from "@/lib/auth";
 import toast from "react-hot-toast";
 import { startRegistration } from "@simplewebauthn/browser";
+// Browser-safe subpath: "/core" is pure crypto (the root pulls in the server bundle).
+import { coseToP256XY } from "@aastar/sdk/core";
 
 const isEmail = (v: string) => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(v);
+
+function b64urlToBytes(b64url: string): Uint8Array {
+  const b64 =
+    b64url.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (b64url.length % 4)) % 4);
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Extract the device WebAuthn credential's secp256r1 public key (x, y) from the
+ * registration response. `response.publicKey` is the SPKI DER (base64url); its last 65
+ * bytes are the uncompressed SEC1 point (0x04 ‖ X ‖ Y), which the SDK's coseToP256XY
+ * validates + splits. Returns undefined if the authenticator didn't surface a public key
+ * (then the account just can't enable Tier-2/3 — Tier-1 still works).
+ */
+function extractPasskeyXY(
+  credential: Awaited<ReturnType<typeof startRegistration>>
+): { x: string; y: string } | undefined {
+  const spkiB64 = credential.response?.publicKey;
+  if (!spkiB64) return undefined;
+  try {
+    const spki = b64urlToBytes(spkiB64);
+    if (spki.length < 65) return undefined;
+    return coseToP256XY(spki.slice(spki.length - 65));
+  } catch {
+    return undefined;
+  }
+}
 
 export default function RegisterPage() {
   const [step, setStep] = useState<"email" | "otp">("email");
@@ -53,6 +85,10 @@ export default function RegisterPage() {
       UserDisplayName: displayName,
     });
     const credential = await startRegistration({ optionsJSON: beginResponse.Options as any });
+    // Capture the device passkey's on-chain factor (x, y) now, while we have the
+    // registration attestation — navigator.credentials.get() later only yields assertions,
+    // never the public key. Persisting it lets a Tier-2/3 account register it via setP256Key.
+    const passkeyXY = extractPasskeyXY(credential);
     const completeResponse = await kmsClient.completeRegistration({
       ChallengeId: beginResponse.ChallengeId,
       Credential: credential,
@@ -69,6 +105,7 @@ export default function RegisterPage() {
       kmsKeyId: KeyId,
       address: keyStatus.Address,
       credentialId: CredentialId,
+      ...(passkeyXY ? { passkeyX: passkeyXY.x, passkeyY: passkeyXY.y } : {}),
     });
     setWalletStatus(null);
   };

--- a/aastar-frontend/app/paymaster/page.tsx
+++ b/aastar-frontend/app/paymaster/page.tsx
@@ -509,6 +509,28 @@ export default function PaymasterPage() {
                             </span>
                           )}
                         </div>
+                        {defaultPaymaster === paymaster.address.toLowerCase() &&
+                          (() => {
+                            const preset = presets.find(
+                              p => p.address.toLowerCase() === paymaster.address.toLowerCase()
+                            );
+                            const req = preset?.requiresCommunity;
+                            return (
+                              <p
+                                className={`mt-2 text-xs ${
+                                  req
+                                    ? "text-amber-700 dark:text-amber-400"
+                                    : "text-gray-500 dark:text-gray-400"
+                                }`}
+                              >
+                                {req
+                                  ? `⚠️ Auto-applied on transfers — needs a community + its ${preset.gasToken}.`
+                                  : preset
+                                    ? `✅ Auto-applied on transfers — needs ${preset.gasToken}.`
+                                    : "✅ Auto-applied on transfers — ensure you hold its gas token and it has deposit."}
+                              </p>
+                            );
+                          })()}
                       </div>
                       <button
                         type="button"

--- a/aastar-frontend/app/paymaster/page.tsx
+++ b/aastar-frontend/app/paymaster/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import Layout from "@/components/Layout";
 import { paymasterAPI } from "@/lib/api";
+import { useDashboard } from "@/contexts/DashboardContext";
 import SwipeableListItem from "@/components/SwipeableListItem";
 import toast from "react-hot-toast";
 import {
@@ -36,6 +37,8 @@ interface PaymasterPreset {
 }
 
 export default function PaymasterPage() {
+  const { data } = useDashboard();
+  const accountAddress = data?.account?.address ?? null;
   const [paymasters, setPaymasters] = useState<Paymaster[]>([]);
   const [presets, setPresets] = useState<PaymasterPreset[]>([]);
   const [loading, setLoading] = useState(true);
@@ -52,19 +55,24 @@ export default function PaymasterPage() {
 
   useEffect(() => {
     loadPaymasters();
-    setDefaultPm(getDefaultPaymaster());
   }, []);
+
+  // Re-read the account-scoped default whenever the (async-loaded) account resolves,
+  // so the ☆ / "Default" state reflects THIS account's preference.
+  useEffect(() => {
+    setDefaultPm(getDefaultPaymaster(accountAddress));
+  }, [accountAddress]);
 
   // Toggle a saved paymaster as the persisted default (client-side preference the
   // transfer page auto-applies). Clicking the current default again clears it.
   const handleToggleDefault = (address: string) => {
     const addr = address.toLowerCase();
     if (defaultPaymaster === addr) {
-      clearDefaultPaymaster();
+      clearDefaultPaymaster(accountAddress);
       setDefaultPm(null);
       toast.success("Default paymaster cleared");
     } else {
-      setDefaultPaymaster(addr);
+      setDefaultPaymaster(addr, accountAddress);
       setDefaultPm(addr);
       toast.success("Set as default paymaster");
     }
@@ -161,7 +169,7 @@ export default function PaymasterPage() {
       await paymasterAPI.remove(name);
       // If the removed paymaster was the persisted default, drop the stale preference.
       if (removed && defaultPaymaster === removed.address.toLowerCase()) {
-        clearDefaultPaymaster();
+        clearDefaultPaymaster(accountAddress);
         setDefaultPm(null);
       }
       toast.success("Paymaster removed successfully!");
@@ -512,7 +520,7 @@ export default function PaymasterPage() {
                         {defaultPaymaster === paymaster.address.toLowerCase() &&
                           (() => {
                             const preset = presets.find(
-                              p => p.address.toLowerCase() === paymaster.address.toLowerCase()
+                              p => p.address?.toLowerCase() === paymaster.address.toLowerCase()
                             );
                             const req = preset?.requiresCommunity;
                             return (

--- a/aastar-frontend/app/paymaster/page.tsx
+++ b/aastar-frontend/app/paymaster/page.tsx
@@ -6,7 +6,18 @@ import Layout from "@/components/Layout";
 import { paymasterAPI } from "@/lib/api";
 import SwipeableListItem from "@/components/SwipeableListItem";
 import toast from "react-hot-toast";
-import { PlusIcon, CheckCircleIcon, ExclamationCircleIcon } from "@heroicons/react/24/outline";
+import {
+  PlusIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  StarIcon,
+} from "@heroicons/react/24/outline";
+import { StarIcon as StarIconSolid } from "@heroicons/react/24/solid";
+import {
+  getDefaultPaymaster,
+  setDefaultPaymaster,
+  clearDefaultPaymaster,
+} from "@/lib/default-paymaster";
 interface Paymaster {
   name: string;
   address: string;
@@ -30,6 +41,7 @@ export default function PaymasterPage() {
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string>("");
   const [showAddForm, setShowAddForm] = useState(false);
+  const [defaultPaymaster, setDefaultPm] = useState<string | null>(null);
   const [newPaymaster, setNewPaymaster] = useState({
     name: "",
     address: "",
@@ -40,7 +52,23 @@ export default function PaymasterPage() {
 
   useEffect(() => {
     loadPaymasters();
+    setDefaultPm(getDefaultPaymaster());
   }, []);
+
+  // Toggle a saved paymaster as the persisted default (client-side preference the
+  // transfer page auto-applies). Clicking the current default again clears it.
+  const handleToggleDefault = (address: string) => {
+    const addr = address.toLowerCase();
+    if (defaultPaymaster === addr) {
+      clearDefaultPaymaster();
+      setDefaultPm(null);
+      toast.success("Default paymaster cleared");
+    } else {
+      setDefaultPaymaster(addr);
+      setDefaultPm(addr);
+      toast.success("Set as default paymaster");
+    }
+  };
 
   const loadPaymasters = async () => {
     setLoading(true);
@@ -129,7 +157,13 @@ export default function PaymasterPage() {
 
     setActionLoading(`remove-${name}`);
     try {
+      const removed = paymasters.find(p => p.name === name);
       await paymasterAPI.remove(name);
+      // If the removed paymaster was the persisted default, drop the stale preference.
+      if (removed && defaultPaymaster === removed.address.toLowerCase()) {
+        clearDefaultPaymaster();
+        setDefaultPm(null);
+      }
       toast.success("Paymaster removed successfully!");
       await loadPaymasters();
     } catch (error) {
@@ -469,8 +503,34 @@ export default function PaymasterPage() {
                               Address Only
                             </span>
                           )}
+                          {defaultPaymaster === paymaster.address.toLowerCase() && (
+                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300">
+                              Default
+                            </span>
+                          )}
                         </div>
                       </div>
+                      <button
+                        type="button"
+                        onClick={() => handleToggleDefault(paymaster.address)}
+                        aria-label={
+                          defaultPaymaster === paymaster.address.toLowerCase()
+                            ? "Unset default paymaster"
+                            : "Set as default paymaster"
+                        }
+                        title={
+                          defaultPaymaster === paymaster.address.toLowerCase()
+                            ? "Default — click to unset"
+                            : "Set as default"
+                        }
+                        className="ml-3 shrink-0 p-2 rounded-lg text-gray-400 hover:text-emerald-500 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors touch-manipulation active:scale-95"
+                      >
+                        {defaultPaymaster === paymaster.address.toLowerCase() ? (
+                          <StarIconSolid className="w-5 h-5 text-emerald-500" />
+                        ) : (
+                          <StarIcon className="w-5 h-5" />
+                        )}
+                      </button>
                     </div>
                   </SwipeableListItem>
                 ))}
@@ -493,6 +553,7 @@ export default function PaymasterPage() {
                   <li>Address-only paymasters work without API keys</li>
                   <li>API-configured paymasters provide better sponsorship reliability</li>
                   <li>You can use multiple paymasters and choose per transaction</li>
+                  <li>Tap the ☆ to set a default — transfers auto-select it (this device only)</li>
                 </ul>
               </div>
             </div>

--- a/aastar-frontend/app/tier-setup/page.tsx
+++ b/aastar-frontend/app/tier-setup/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { ArrowPathIcon, CheckCircleIcon, ShieldCheckIcon } from "@heroicons/react/24/outline";
-import { formatEther, type Address, type PublicClient } from "viem";
+import { encodeFunctionData, formatEther, type Address, type Hex, type PublicClient } from "viem";
 import { CHAIN_SEPOLIA, AAStarAirAccountV7ABI, getCanonicalAddresses } from "@aastar/sdk/core";
 import { TIER_PROFILES, profileSetupCalls } from "@aastar/sdk/airaccount";
 import { startAuthentication } from "@simplewebauthn/browser";
@@ -10,8 +10,82 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import Layout from "@/components/Layout";
 import { useDashboard } from "@/contexts/DashboardContext";
-import { transferAPI } from "@/lib/api";
+import { authAPI, transferAPI } from "@/lib/api";
 import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
+
+const ZERO_BYTES32 = `0x${"00".repeat(32)}` as Hex;
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/**
+ * Wire the on-chain factors a Tier-2/3 account needs but the factory can't set at deploy
+ * time (both are owner/self txs that require deployed code):
+ *   - setValidator(router): the WebAuthn cumulative algIds (0x09/0x0a) are router-delegated,
+ *     so the account can't validate them until the validator router is wired (set-once).
+ *   - setP256Key(x, y): registers the device passkey as the on-chain cumulative factor — the
+ *     key navigator.credentials.get() signs for every Tier-2/3 transfer.
+ * Both are returned as self-calls (account → itself), submitted via the SAME gasless two-phase
+ * device-passkey UserOp as the tier-limit calls. Each is skipped when already set on-chain.
+ */
+async function buildTier23WiringCalls(
+  publicClient: PublicClient,
+  account: Address
+): Promise<{ to: Address; data: Hex }[]> {
+  const calls: { to: Address; data: Hex }[] = [];
+  const canonical = getCanonicalAddresses(CHAIN_SEPOLIA);
+  const router = canonical?.aaStarValidator as Address | undefined;
+
+  // setValidator(router) — skip if already set, or if the account isn't deployed yet (read
+  // reverts → treat as unset; the first self-call carries initCode and deploys, then this runs).
+  let validator: string = ZERO_ADDRESS;
+  try {
+    validator = (await publicClient.readContract({
+      address: account,
+      abi: AAStarAirAccountV7ABI,
+      functionName: "validator",
+    })) as string;
+  } catch {
+    /* not deployed → unset */
+  }
+  if (router && validator.toLowerCase() === ZERO_ADDRESS) {
+    calls.push({
+      to: account,
+      data: encodeFunctionData({
+        abi: AAStarAirAccountV7ABI,
+        functionName: "setValidator",
+        args: [router],
+      }) as Hex,
+    });
+  }
+
+  // setP256Key(x, y) — the device passkey captured at registration (GET /auth/profile).
+  let p256X: string = ZERO_BYTES32;
+  try {
+    p256X = (await publicClient.readContract({
+      address: account,
+      abi: AAStarAirAccountV7ABI,
+      functionName: "p256KeyX",
+    })) as string;
+  } catch {
+    /* not deployed → unset */
+  }
+  if (p256X.toLowerCase() === ZERO_BYTES32) {
+    const profile = await authAPI.getProfile().catch(() => null);
+    const x = profile?.data?.passkeyX as Hex | undefined;
+    const y = profile?.data?.passkeyY as Hex | undefined;
+    if (x && y) {
+      calls.push({
+        to: account,
+        data: encodeFunctionData({
+          abi: AAStarAirAccountV7ABI,
+          functionName: "setP256Key",
+          args: [x, y],
+        }) as Hex,
+      });
+    }
+  }
+
+  return calls;
+}
 
 type ProfileKey = keyof typeof TIER_PROFILES;
 
@@ -55,10 +129,17 @@ export default function TierSetupPage() {
     setBusy(true);
     const loading = toast.loading(t("tierSetup.applying"));
     try {
-      const calls = profileSetupCalls(account, TIER_PROFILES[selected]) as {
-        to: Address;
-        data: `0x${string}`;
-      }[];
+      // Tier-2/3 wiring (setValidator + setP256Key) MUST land before the tier-limit calls:
+      // the first self-call carries initCode and deploys the account, and the WebAuthn algIds
+      // can't validate until the router is wired. These are no-ops once already set on-chain.
+      const wiringCalls = await buildTier23WiringCalls(publicClient, account);
+      const calls = [
+        ...wiringCalls,
+        ...(profileSetupCalls(account, TIER_PROFILES[selected]) as {
+          to: Address;
+          data: `0x${string}`;
+        }[]),
+      ];
       const canonical = getCanonicalAddresses(CHAIN_SEPOLIA);
       for (let i = 0; i < calls.length; i++) {
         toast.loading(t("tierSetup.step", { i: i + 1, n: calls.length }), { id: loading });

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -518,15 +518,21 @@ export default function TransferPage() {
         guardianSignature = await collectGuardianSignature(prep.data.userOpHash);
       }
 
-      // Phase 3: submit. One payload shape covers both paths (the unused fields are
-      // omitted) so a Scheme-2 resubmit can reuse it verbatim.
-      const submitPayload = {
-        transferId: prep.data.transferId,
-        challengeId: prep.data.challengeId,
-        credential,
-        deviceWebAuthn,
-        guardianSignature,
-      };
+      // Phase 3: submit. Build exactly the variant for the path taken (device-passkey
+      // vs KMS ceremony) so the payload type stays a discriminated union; a Scheme-2
+      // resubmit reuses this same value verbatim.
+      const submitPayload = isWebAuthnPath
+        ? {
+            transferId: prep.data.transferId,
+            deviceWebAuthn: deviceWebAuthn as DeviceWebAuthn,
+            guardianSignature,
+          }
+        : {
+            transferId: prep.data.transferId,
+            challengeId: prep.data.challengeId as string,
+            credential,
+            guardianSignature,
+          };
       toast.dismiss(loadingToast);
       loadingToast = toast.loading("Processing transfer...");
       let response = await transferAPI.submit(submitPayload);
@@ -572,9 +578,15 @@ export default function TransferPage() {
         toast.dismiss(loadingToast);
       }
 
-      // Handle passkey verification errors
+      // Handle passkey verification errors. NotAllowedError covers both an explicit
+      // cancel and "no passkey on this device matched" — the latter is what a user sees
+      // when their passkey was registered under a different domain (rpId), so point
+      // them at re-registration rather than a bare "cancelled".
       if (error.name === "NotAllowedError") {
-        toast.error("Transaction verification was cancelled");
+        toast.error(
+          "Passkey verification was cancelled, or no matching passkey was found. If you registered it on a different domain, re-register your passkey on this site and try again.",
+          { duration: 7000 }
+        );
         setLoading(prev => ({ ...prev, transfer: false }));
         return;
       } else if (error.name === "NotSupportedError") {
@@ -582,7 +594,10 @@ export default function TransferPage() {
         setLoading(prev => ({ ...prev, transfer: false }));
         return;
       } else if (error.name === "SecurityError") {
-        toast.error("Security error during verification");
+        toast.error(
+          "Security error during verification — this site's domain may not match where your passkey was registered. Re-register your passkey here and try again.",
+          { duration: 7000 }
+        );
         setLoading(prev => ({ ...prev, transfer: false }));
         return;
       }

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -183,6 +183,7 @@ export default function TransferPage() {
   });
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const isPollingRef = useRef(false);
+  const defaultPaymasterAppliedRef = useRef(false);
   const touchStartY = useRef(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -190,6 +191,20 @@ export default function TransferPage() {
   useEffect(() => {
     loadPageData();
   }, []);
+
+  // Auto-apply the account-scoped default paymaster once, after both the account
+  // (the preference's storage scope) and the saved list are available. The ref makes
+  // it fire exactly once, so it never overrides a manual un-toggle later.
+  useEffect(() => {
+    if (defaultPaymasterAppliedRef.current) return;
+    if (!account?.address || savedPaymasters.length === 0) return;
+    defaultPaymasterAppliedRef.current = true;
+    const def = getDefaultPaymaster(account.address);
+    const match = def && savedPaymasters.find(p => p.address?.toLowerCase() === def);
+    if (match) {
+      setFormData(prev => ({ ...prev, usePaymaster: true, paymasterAddress: match.address }));
+    }
+  }, [account?.address, savedPaymasters]);
 
   // Judge the transfer (tier + required signatures, ETH/ERC-20 unified) whenever the
   // amount or token changes, debounced. Drives the indicator + fail-fast on block.
@@ -234,19 +249,9 @@ export default function TransferPage() {
           paymasterAPI.getPresets().catch(() => ({ data: [] })),
         ]);
         setPaymasterPresets((presetResponse.data ?? []) as any[]);
-        const list = (paymasterResponse.data ?? []) as any[];
-        setSavedPaymasters(list);
-        // Auto-apply the persisted default paymaster (set on the Paymaster page) when
-        // it's still among the saved list: pre-enable sponsorship and pre-select it.
-        const def = getDefaultPaymaster();
-        const match = def && list.find(p => p.address?.toLowerCase() === def);
-        if (match) {
-          setFormData(prev => ({
-            ...prev,
-            usePaymaster: true,
-            paymasterAddress: match.address,
-          }));
-        }
+        setSavedPaymasters((paymasterResponse.data ?? []) as any[]);
+        // The persisted default paymaster is applied by a dedicated effect once the
+        // account address (its storage scope) and the saved list are both ready.
       } catch (error) {
         console.error("Failed to load saved paymasters:", error);
         setSavedPaymasters([]);

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -32,6 +32,7 @@ import {
   type TransferResolution,
 } from "@aastar/sdk/airaccount";
 import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
+import { webauthnRpId } from "@/lib/webauthn-rp";
 
 // Tier-3 only: collect a guardian co-signature over the prepared userOpHash from the
 // user's self-hosted guardian wallet (injected EIP-1193). signMessage({ raw }) is
@@ -104,7 +105,7 @@ async function runWebAuthnPasskeyAssertion(userOpHash: string): Promise<DeviceWe
   const assertion = await startAuthentication({
     optionsJSON: {
       challenge: bufToB64url(hexToBytes(userOpHash)),
-      rpId: window.location.hostname,
+      rpId: webauthnRpId(),
       userVerification: "required",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
@@ -118,7 +119,7 @@ async function runWebAuthnPasskeyAssertion(userOpHash: string): Promise<DeviceWe
 }
 
 async function runDvtConfirmation(userOpHash: string, nodeEndpoint: string): Promise<boolean> {
-  const req = confirmationCredentialRequest(userOpHash, { rpId: window.location.hostname });
+  const req = confirmationCredentialRequest(userOpHash, { rpId: webauthnRpId() });
   const assertion = await startAuthentication({
     optionsJSON: {
       challenge: bufToB64url(req.challenge),

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -67,6 +67,56 @@ function bufToB64url(buf: ArrayBuffer | Uint8Array): string {
   return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+function b64urlToBytes(b64url: string): Uint8Array {
+  const b64 =
+    b64url.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (b64url.length % 4)) % 4);
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let h = "0x";
+  for (const b of bytes) h += b.toString(16).padStart(2, "0");
+  return h;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const out = new Uint8Array(h.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16);
+  return out;
+}
+
+type DeviceWebAuthn = { authenticatorData: string; clientDataJSON: string; signature: string };
+
+/**
+ * Tier-2/3 WebAuthn passkey path (#234): run ONE navigator.credentials.get() ceremony with
+ * `challenge = userOpHash` (32 raw bytes), then normalise the assertion's three response fields
+ * into the encodings the SDK's packWebAuthnBlob expects:
+ *   - authenticatorData, signature: 0x-hex
+ *   - clientDataJSON: the RAW JSON text (must start with {"type":"webauthn.get","challenge":"…)
+ * The browser returns base64url for all three, so we decode here. The clientDataJSON challenge
+ * the browser writes is base64url(userOpHash) — exactly what the SDK + contract re-derive.
+ */
+async function runWebAuthnPasskeyAssertion(userOpHash: string): Promise<DeviceWebAuthn> {
+  const assertion = await startAuthentication({
+    optionsJSON: {
+      challenge: bufToB64url(hexToBytes(userOpHash)),
+      rpId: window.location.hostname,
+      userVerification: "required",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+  });
+  const r = assertion.response;
+  return {
+    authenticatorData: bytesToHex(b64urlToBytes(r.authenticatorData)),
+    clientDataJSON: new TextDecoder().decode(b64urlToBytes(r.clientDataJSON)),
+    signature: bytesToHex(b64urlToBytes(r.signature)),
+  };
+}
+
 async function runDvtConfirmation(userOpHash: string, nodeEndpoint: string): Promise<boolean> {
   const req = confirmationCredentialRequest(userOpHash, { rpId: window.location.hostname });
   const assertion = await startAuthentication({
@@ -374,6 +424,31 @@ export default function TransferPage() {
       // tier-aware payload, calls KMS BeginAuthentication, and returns
       // publicKeyOptions whose `challenge` is already the WYSIWYS commitment. We
       // never compute commitChallenge or talk to KMS directly here.
+      // Decide the signing path BEFORE prepare. Tier-2/3 (the transfer needs the on-chain
+      // BLS/guardian factors) use the device-passkey cumulative path (algId 0x09/0x0a, #234):
+      // the SDK skips the KMS ceremony and the passkey signs the userOpHash directly. Tier-1
+      // keeps the KMS owner-ceremony commitment path. resolveTransfer (the same judging the
+      // indicator shows) gives the tier; fall back to a fresh resolve if it hasn't settled.
+      let tier: number | null = resolution?.tier ?? null;
+      if (tier == null && account?.address) {
+        try {
+          const isEth = !selectedToken || selectedToken.address === "ETH";
+          const amt = isEth
+            ? parseEther(formData.amount)
+            : parseUnits(formData.amount, selectedToken?.decimals ?? 18);
+          const res = await resolveTransfer({
+            client: publicClient as never,
+            account: account.address as Address,
+            amount: amt,
+            token: isEth ? "ETH" : (selectedToken!.address as Address),
+          });
+          tier = res.tier;
+        } catch {
+          /* keep null → Tier-1 KMS path */
+        }
+      }
+      const useWebAuthnPasskey = (tier ?? 1) >= 2;
+
       loadingToast = toast.loading("Preparing transaction...");
       const prep = await transferAPI.prepare({
         to: formData.to,
@@ -384,15 +459,24 @@ export default function TransferPage() {
             ? formData.paymasterAddress
             : undefined,
         tokenAddress: selectedToken?.address === "ETH" ? undefined : selectedToken?.address,
+        useWebAuthnPasskey,
       });
 
-      // Phase 2: browser ceremony — the user's device passkey signs the
-      // SDK-computed commitment. Use publicKeyOptions verbatim.
+      // Phase 2: browser ceremony. On the WebAuthn passkey path (no publicKeyOptions) the
+      // passkey signs the userOpHash itself; on the KMS path it signs the SDK-computed
+      // commitment (publicKeyOptions verbatim).
+      const isWebAuthnPath = !prep.data.publicKeyOptions;
       toast.dismiss(loadingToast);
       loadingToast = toast.loading("Please verify with your passkey...");
-      const credential = await startAuthentication({
-        optionsJSON: prep.data.publicKeyOptions as any,
-      });
+      let credential: unknown;
+      let deviceWebAuthn: DeviceWebAuthn | undefined;
+      if (isWebAuthnPath) {
+        deviceWebAuthn = await runWebAuthnPasskeyAssertion(prep.data.userOpHash);
+      } else {
+        credential = await startAuthentication({
+          optionsJSON: prep.data.publicKeyOptions as any,
+        });
+      }
 
       // Phase 2.5: Tier-3 guardian co-sign. When prepare resolves to Tier 3, a
       // guardian must co-sign the userOpHash on top of the passkey + DVT/BLS. We
@@ -406,17 +490,18 @@ export default function TransferPage() {
         guardianSignature = await collectGuardianSignature(prep.data.userOpHash);
       }
 
-      // Phase 3: submit. The committed digest matches what prepare bound, so the
-      // KMS accepts the assertion under strict mode. guardianSignature is sent only
-      // for Tier 3 (undefined otherwise).
-      toast.dismiss(loadingToast);
-      loadingToast = toast.loading("Processing transfer...");
-      let response = await transferAPI.submit({
+      // Phase 3: submit. One payload shape covers both paths (the unused fields are
+      // omitted) so a Scheme-2 resubmit can reuse it verbatim.
+      const submitPayload = {
         transferId: prep.data.transferId,
         challengeId: prep.data.challengeId,
         credential,
+        deviceWebAuthn,
         guardianSignature,
-      });
+      };
+      toast.dismiss(loadingToast);
+      loadingToast = toast.loading("Processing transfer...");
+      let response = await transferAPI.submit(submitPayload);
 
       // Scheme 2: a high-value transfer can be withheld by a DVT node pending out-of-band
       // approval. Approve by signing the userOpHash with the device passkey, POST it to the
@@ -433,12 +518,7 @@ export default function TransferPage() {
         if (!approved) throw new Error("Out-of-band confirmation was rejected or expired.");
         toast.dismiss(loadingToast);
         loadingToast = toast.loading("Approved — completing transfer…");
-        response = await transferAPI.submit({
-          transferId: prep.data.transferId,
-          challengeId: prep.data.challengeId,
-          credential,
-          guardianSignature,
-        });
+        response = await transferAPI.submit(submitPayload);
       }
       setTransferResult(response.data);
 

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "@aastar/sdk/airaccount";
 import { ensureSdkConfig, getPublicClient } from "@/lib/sdk/client";
 import { webauthnRpId } from "@/lib/webauthn-rp";
+import { getDefaultPaymaster } from "@/lib/default-paymaster";
 
 // Tier-3 only: collect a guardian co-signature over the prepared userOpHash from the
 // user's self-hosted guardian wallet (injected EIP-1193). signMessage({ raw }) is
@@ -226,7 +227,19 @@ export default function TransferPage() {
       // Load saved paymasters
       try {
         const paymasterResponse = await paymasterAPI.getAvailable();
-        setSavedPaymasters(paymasterResponse.data);
+        const list = (paymasterResponse.data ?? []) as any[];
+        setSavedPaymasters(list);
+        // Auto-apply the persisted default paymaster (set on the Paymaster page) when
+        // it's still among the saved list: pre-enable sponsorship and pre-select it.
+        const def = getDefaultPaymaster();
+        const match = def && list.find(p => p.address?.toLowerCase() === def);
+        if (match) {
+          setFormData(prev => ({
+            ...prev,
+            usePaymaster: true,
+            paymasterAddress: match.address,
+          }));
+        }
       } catch (error) {
         console.error("Failed to load saved paymasters:", error);
         setSavedPaymasters([]);

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -163,6 +163,9 @@ export default function TransferPage() {
   const [_loadingTokenBalance, setLoadingTokenBalance] = useState(false);
   const [gasEstimate, setGasEstimate] = useState<GasEstimate | null>(null);
   const [savedPaymasters, setSavedPaymasters] = useState<any[]>([]);
+  // Preset metadata (SuperPaymaster / PaymasterV4 canonical addresses + requiresCommunity)
+  // used to detect the selected paymaster's type and show its prerequisite hint.
+  const [paymasterPresets, setPaymasterPresets] = useState<any[]>([]);
   const [showPaymasterDropdown, setShowPaymasterDropdown] = useState(false);
   const [addressBook, setAddressBook] = useState<any[]>([]);
   const [showAddressDropdown, setShowAddressDropdown] = useState(false);
@@ -226,7 +229,11 @@ export default function TransferPage() {
     try {
       // Load saved paymasters
       try {
-        const paymasterResponse = await paymasterAPI.getAvailable();
+        const [paymasterResponse, presetResponse] = await Promise.all([
+          paymasterAPI.getAvailable(),
+          paymasterAPI.getPresets().catch(() => ({ data: [] })),
+        ]);
+        setPaymasterPresets((presetResponse.data ?? []) as any[]);
         const list = (paymasterResponse.data ?? []) as any[];
         setSavedPaymasters(list);
         // Auto-apply the persisted default paymaster (set on the Paymaster page) when
@@ -1408,12 +1415,43 @@ export default function TransferPage() {
                             for no paymaster.
                           </p>
                           {formData.paymasterAddress && (
-                            <div className="mt-2">
+                            <div className="mt-2 space-y-2">
                               <div className="p-2 bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl text-xs text-slate-700 dark:text-slate-300">
-                                💡 Using custom paymaster: {formData.paymasterAddress.slice(0, 10)}
-                                ...
+                                💡 Using paymaster: {formData.paymasterAddress.slice(0, 10)}...
                                 {formData.paymasterAddress.slice(-8)}
                               </div>
+                              {/* Detect the selected paymaster's type and show its prerequisite. */}
+                              {(() => {
+                                const preset = paymasterPresets.find(
+                                  p =>
+                                    p.address?.toLowerCase() ===
+                                    formData.paymasterAddress.toLowerCase()
+                                );
+                                if (preset?.requiresCommunity) {
+                                  return (
+                                    <div className="p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 rounded-xl text-xs text-amber-800 dark:text-amber-300">
+                                      ⚠️ {preset.name} pays gas with {preset.gasToken}. You must join
+                                      a community and hold its xPNTs first — otherwise sponsorship
+                                      will be rejected on submit.
+                                    </div>
+                                  );
+                                }
+                                if (preset) {
+                                  return (
+                                    <div className="p-2 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-300 dark:border-emerald-700 rounded-xl text-xs text-emerald-800 dark:text-emerald-300">
+                                      ✅ {preset.name} — pay gas with {preset.gasToken}. PaymasterV4
+                                      is a template (this is the AAStar community instance; any
+                                      community can deploy its own). Make sure you hold {preset.gasToken}.
+                                    </div>
+                                  );
+                                }
+                                return (
+                                  <div className="p-2 bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 rounded-xl text-xs text-slate-600 dark:text-slate-400">
+                                    ℹ️ Custom paymaster — confirm you hold the gas token it accepts
+                                    and that it has enough deposit to sponsor your gas.
+                                  </div>
+                                );
+                              })()}
                             </div>
                           )}
                         </div>

--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -183,7 +183,7 @@ export default function TransferPage() {
   });
   const pollingIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const isPollingRef = useRef(false);
-  const defaultPaymasterAppliedRef = useRef(false);
+  const defaultPaymasterAppliedForRef = useRef<string | null>(null);
   const touchStartY = useRef(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
@@ -192,13 +192,15 @@ export default function TransferPage() {
     loadPageData();
   }, []);
 
-  // Auto-apply the account-scoped default paymaster once, after both the account
-  // (the preference's storage scope) and the saved list are available. The ref makes
-  // it fire exactly once, so it never overrides a manual un-toggle later.
+  // Auto-apply the account-scoped default paymaster once PER ACCOUNT, after both the
+  // account (the preference's storage scope) and the saved list are available. The ref
+  // tracks the account it last applied for, so a mid-session account switch re-applies
+  // the new account's default, while a manual un-toggle within one account is never
+  // overridden.
   useEffect(() => {
-    if (defaultPaymasterAppliedRef.current) return;
     if (!account?.address || savedPaymasters.length === 0) return;
-    defaultPaymasterAppliedRef.current = true;
+    if (defaultPaymasterAppliedForRef.current === account.address) return;
+    defaultPaymasterAppliedForRef.current = account.address;
     const def = getDefaultPaymaster(account.address);
     const match = def && savedPaymasters.find(p => p.address?.toLowerCase() === def);
     if (match) {

--- a/aastar-frontend/e2e/helpers/fund.ts
+++ b/aastar-frontend/e2e/helpers/fund.ts
@@ -7,6 +7,7 @@ import {
   parseEther,
   parseGwei,
   type Address,
+  parseAbi,
 } from "viem";
 import { sepolia } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
@@ -119,6 +120,37 @@ export async function getTier2Limit(account: Address): Promise<bigint> {
   } catch {
     return 0n; // not deployed / not armed yet
   }
+}
+
+// EntryPoint v0.7 nonce for the account (key 0). Used to wait out pending UserOps so a follow-up
+// transfer doesn't prepare a stale nonce.
+export async function getAccountNonce(account: Address): Promise<bigint> {
+  try {
+    return (await client().readContract({
+      address: "0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+      abi: parseAbi(["function getNonce(address sender, uint192 key) view returns (uint256)"]),
+      functionName: "getNonce",
+      args: [account, 0n],
+    })) as bigint;
+  } catch {
+    return 0n;
+  }
+}
+
+// Block until the account's EntryPoint nonce stops advancing (no in-flight UserOps). The tier-setup
+// persona apply submits TWO UserOps (setTierLimits then setWeightConfig); the e2e only waits for the
+// tier2 limit to land (first op), so without this the transfer can prepare a stale nonce that the
+// still-mining second op consumes → AA25 invalid account nonce.
+export async function waitForNonceStable(account: Address, timeoutMs = 90_000): Promise<bigint> {
+  const start = Date.now();
+  let prev = -1n;
+  while (Date.now() - start < timeoutMs) {
+    const n = await getAccountNonce(account);
+    if (n > 0n && n === prev) return n; // unchanged across two reads → nothing pending
+    prev = n;
+    await new Promise(r => setTimeout(r, 4000));
+  }
+  return prev;
 }
 
 /**

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
 import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
-import { parseEther, formatEther, type Address } from "viem";
+import { formatEther, type Address } from "viem";
 import { getCanonicalAddresses } from "@aastar/sdk/core";
 import { installVirtualAuthenticator } from "./helpers/webauthn";
 import { installTestWallet } from "./helpers/wallet";
@@ -75,31 +75,30 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   await registerOnly(page);
   const auth = await authHeaders(page);
 
-  // 2) Create-with-guardians: prepare → guardians accept (eth-prefixed) → create.
-  const prep = await page.request.post("/api/v1/account/guardian-setup/prepare", {
-    ...auth,
-    data: { dailyLimit: parseEther("1").toString() },
-  });
-  expect(prep.ok(), `guardian-setup/prepare: ${prep.status()}`).toBeTruthy();
-  const gp = await prep.json();
-  const acceptanceHash = gp.acceptanceHash as `0x${string}`;
-  const g1Sig = await g1.signMessage({ message: { raw: acceptanceHash } });
-  const g2Sig = await g2.signMessage({ message: { raw: acceptanceHash } });
-  const created = await page.request.post("/api/v1/account/create-with-guardians", {
+  // 2) Create a Tier-2/3-capable account via the full-config path (the only way to approve
+  // the WebAuthn cumulative algIds + install guardians at deploy time). The device passkey
+  // captured at registration (GET /auth/profile) is the on-chain cumulative factor and a
+  // P-256 guardian; g1 is the ECDSA Tier-3 co-signer. The backend writes approvedAlgIds
+  // [0x02,0x03,0x09,0x0a]; setValidator + setP256Key are wired by the tier-setup step below.
+  // No QR acceptance ceremony — the config-hash-in-salt binding stands in for it.
+  const profileResp = await page.request.get("/api/v1/auth/profile", auth);
+  const profile = (await profileResp.json()) as { passkeyX?: string; passkeyY?: string };
+  expect(
+    Boolean(profile.passkeyX && profile.passkeyY),
+    `registration must capture the device passkey (x,y); got ${JSON.stringify(profile)}`
+  ).toBeTruthy();
+  const created = await page.request.post("/api/v1/account/create-with-p256-guardians", {
     ...auth,
     data: {
-      guardian1: g1.address,
-      guardian1Sig: g1Sig,
-      guardian2: g2.address,
-      guardian2Sig: g2Sig,
-      dailyLimit: parseEther("1").toString(),
-      salt: gp.salt,
+      p256Guardians: [{ x: profile.passkeyX, y: profile.passkeyY }],
+      ecdsaGuardians: [g1.address],
+      dailyLimit: "1",
       entryPointVersion: "0.7",
     },
   });
   expect(
     created.ok(),
-    `create-with-guardians: ${created.status()} ${await created.text()}`
+    `create-with-p256-guardians: ${created.status()} ${await created.text()}`
   ).toBeTruthy();
   const acctResp = await page.request.get("/api/v1/account", auth);
   const acctJson = (await acctResp.json()) as { address?: string; account?: { address?: string } };

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -9,6 +9,7 @@ import {
   getEthBalance,
   getTier2Limit,
   onboardAPNTsGas,
+  waitForNonceStable,
   withRetry,
 } from "./helpers/fund";
 
@@ -190,6 +191,10 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   // The apply toast fires on submit, before the self-call UserOps mine. Wait until the armed
   // tier-2 is actually on-chain so the transfer's resolveTransfer reads it (not pre-arm zero).
   await expect.poll(() => getTier2Limit(account), { timeout: 90_000 }).toBeGreaterThan(0n);
+  // The persona apply submits TWO UserOps (setTierLimits + setWeightConfig); the tier2 poll only
+  // confirms the first landed. Wait for the account nonce to stop advancing so the transfer doesn't
+  // prepare a stale nonce that the still-mining setWeightConfig consumes → AA25 invalid account nonce.
+  await waitForNonceStable(account);
 
   // 5) Tier-3 transfer: 0.051 ETH > tier2 (0.05) → needs passkey + BLS + guardian. The UI flow
   // collects the guardian co-sign from window.ethereum (g1) over the userOpHash.

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -75,19 +75,19 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
   await registerOnly(page);
   const auth = await authHeaders(page);
 
-  // 2) Create a Tier-2/3-capable account via the full-config path (the only way to approve
-  // the WebAuthn cumulative algIds + install guardians at deploy time). The device passkey
-  // captured at registration (GET /auth/profile) is the on-chain cumulative factor and a
-  // P-256 guardian; g1 is the ECDSA Tier-3 co-signer. The backend writes approvedAlgIds
-  // [0x02,0x03,0x09,0x0a]; setValidator + setP256Key are wired by the tier-setup step below.
-  // No QR acceptance ceremony — the config-hash-in-salt binding stands in for it.
+  // 2) Create a Tier-2/3 account via the TWO-PHASE passkey-at-birth flow (aastar-sdk#249):
+  // prepare (backend pins nonce/deadline + builds the CREATE_ACCOUNT digest + begins the KMS
+  // WebAuthn ceremony) → browser ceremony (challenge = the digest, signed by the device passkey
+  // via the virtual authenticator) → submit (KMS owner signs the digest, the deployer relays the
+  // deploy; the v0.22.0 factory wires validator + owner passkey AT BIRTH — no setValidator/setP256Key).
+  // The device passkey captured at registration is the on-chain owner factor; g1 is the ECDSA Tier-3 co-signer.
   const profileResp = await page.request.get("/api/v1/auth/profile", auth);
   const profile = (await profileResp.json()) as { passkeyX?: string; passkeyY?: string };
   expect(
     Boolean(profile.passkeyX && profile.passkeyY),
     `registration must capture the device passkey (x,y); got ${JSON.stringify(profile)}`
   ).toBeTruthy();
-  const created = await page.request.post("/api/v1/account/create-with-p256-guardians", {
+  const prepResp = await page.request.post("/api/v1/account/prepare-create-with-passkey", {
     ...auth,
     data: {
       p256Guardians: [{ x: profile.passkeyX, y: profile.passkeyY }],
@@ -97,8 +97,61 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
     },
   });
   expect(
+    prepResp.ok(),
+    `prepare-create-with-passkey: ${prepResp.status()} ${await prepResp.text()}`
+  ).toBeTruthy();
+  const prep = (await prepResp.json()) as {
+    createId: string;
+    challengeId: string;
+    publicKeyOptions: Record<string, unknown>;
+    predictedAddress: string;
+  };
+  // Browser WebAuthn ceremony over the prepared CREATE_ACCOUNT digest (the virtual authenticator
+  // auto-signs). publicKeyOptions is the @simplewebauthn optionsJSON form (base64url) — decode for
+  // navigator.credentials.get(), then re-encode the assertion to AuthenticationResponseJSON.
+  const credential = await page.evaluate(async pko => {
+    const b64urlToBuf = (s: string) => {
+      const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/"));
+      const u = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) u[i] = bin.charCodeAt(i);
+      return u.buffer;
+    };
+    const bufToB64url = (buf: ArrayBuffer) => {
+      const u = new Uint8Array(buf);
+      let s = "";
+      for (const b of u) s += String.fromCharCode(b);
+      return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    };
+    const o = pko as any;
+    const publicKey: any = {
+      challenge: b64urlToBuf(o.challenge),
+      rpId: o.rpId,
+      timeout: o.timeout,
+      userVerification: o.userVerification,
+      allowCredentials: (o.allowCredentials || []).map((c: any) => ({ ...c, id: b64urlToBuf(c.id) })),
+    };
+    const cred: any = await navigator.credentials.get({ publicKey });
+    const r = cred.response;
+    return {
+      id: cred.id,
+      rawId: bufToB64url(cred.rawId),
+      type: cred.type,
+      clientExtensionResults: cred.getClientExtensionResults?.() ?? {},
+      response: {
+        authenticatorData: bufToB64url(r.authenticatorData),
+        clientDataJSON: bufToB64url(r.clientDataJSON),
+        signature: bufToB64url(r.signature),
+        ...(r.userHandle ? { userHandle: bufToB64url(r.userHandle) } : {}),
+      },
+    };
+  }, prep.publicKeyOptions);
+  const created = await page.request.post("/api/v1/account/submit-create-with-passkey", {
+    ...auth,
+    data: { createId: prep.createId, challengeId: prep.challengeId, credential },
+  });
+  expect(
     created.ok(),
-    `create-with-p256-guardians: ${created.status()} ${await created.text()}`
+    `submit-create-with-passkey: ${created.status()} ${await created.text()}`
   ).toBeTruthy();
   const acctResp = await page.request.get("/api/v1/account", auth);
   const acctJson = (await acctResp.json()) as { address?: string; account?: { address?: string } };

--- a/aastar-frontend/lib/api.ts
+++ b/aastar-frontend/lib/api.ts
@@ -46,9 +46,15 @@ export const authAPI = {
   completeKmsLogin: (data: { address: string; challengeId: string; credential: any }) =>
     api.post("/auth/login/kms/complete", data),
 
-  // Wallet linking (JWT-protected)
-  linkWallet: (data: { kmsKeyId: string; address: string; credentialId?: string }) =>
-    api.post("/auth/wallet/link", data),
+  // Wallet linking (JWT-protected). passkeyX/passkeyY = the device WebAuthn credential's
+  // secp256r1 public key, persisted so a Tier-2/3 account can register it via setP256Key.
+  linkWallet: (data: {
+    kmsKeyId: string;
+    address: string;
+    credentialId?: string;
+    passkeyX?: string;
+    passkeyY?: string;
+  }) => api.post("/auth/wallet/link", data),
 };
 
 // Account API
@@ -84,6 +90,8 @@ export const accountAPI = {
   }) => api.post("/account/create-with-guardians", data),
   createWithP256Guardians: (data: {
     p256Guardians: { x: string; y: string }[];
+    // Optional ECDSA guardians (Tier-3 co-signers for the WebAuthn cumulative path).
+    ecdsaGuardians?: string[];
     dailyLimit: string;
     salt?: number;
     entryPointVersion?: string;
@@ -103,22 +111,34 @@ export const transferAPI = {
     paymasterAddress?: string;
     paymasterData?: string;
     tokenAddress?: string;
+    // Tier-2/3 device-passkey path (#234): when true, the SDK skips the KMS ceremony
+    // (no challengeId/publicKeyOptions) and the browser signs the userOpHash directly.
+    useWebAuthnPasskey?: boolean;
   }) =>
     api.post<{
       transferId: string;
-      challengeId: string;
-      publicKeyOptions: unknown;
+      // Absent on the WebAuthn passkey path (tier>=2 with useWebAuthnPasskey).
+      challengeId?: string;
+      publicKeyOptions?: unknown;
       // Tier-aware fields (surfaced so the UI can collect a Tier-3 guardian co-sign).
       tier: number | null;
       requiredSigs: { passkey: boolean; bls: boolean; guardian: number };
       userOpHash: string;
     }>("/transfer/prepare", data),
-  // Phase 3: submit the prepared transfer with the browser ceremony credential.
-  // guardianSignature is sent only for Tier-3 transfers (over the prepared userOpHash).
+  // Phase 3: submit the prepared transfer.
+  //  - Tier-1 KMS path: challengeId + credential (the ceremony over the WYSIWYS commitment).
+  //  - Tier-2/3 WebAuthn passkey path: deviceWebAuthn (assertion whose challenge = userOpHash),
+  //    normalised to the SDK's packWebAuthnBlob encodings (0x-hex + raw clientDataJSON).
+  // guardianSignature is sent only for Tier-3 (over the prepared userOpHash).
   submit: (data: {
     transferId: string;
-    challengeId: string;
-    credential: unknown;
+    challengeId?: string;
+    credential?: unknown;
+    deviceWebAuthn?: {
+      authenticatorData: string;
+      clientDataJSON: string;
+      signature: string;
+    };
     guardianSignature?: string;
   }) => api.post("/transfer/submit", data),
 

--- a/aastar-frontend/lib/api.ts
+++ b/aastar-frontend/lib/api.ts
@@ -130,17 +130,27 @@ export const transferAPI = {
   //  - Tier-2/3 WebAuthn passkey path: deviceWebAuthn (assertion whose challenge = userOpHash),
   //    normalised to the SDK's packWebAuthnBlob encodings (0x-hex + raw clientDataJSON).
   // guardianSignature is sent only for Tier-3 (over the prepared userOpHash).
-  submit: (data: {
-    transferId: string;
-    challengeId?: string;
-    credential?: unknown;
-    deviceWebAuthn?: {
-      authenticatorData: string;
-      clientDataJSON: string;
-      signature: string;
-    };
-    guardianSignature?: string;
-  }) => api.post("/transfer/submit", data),
+  // Discriminated by which credential the path produced: the KMS ceremony supplies
+  // `credential` (with its `challengeId`), the device-passkey path supplies
+  // `deviceWebAuthn`. Requiring one branch's key means the type rejects submitting
+  // neither credential.
+  submit: (
+    data: {
+      transferId: string;
+      guardianSignature?: string;
+    } & (
+      | { credential: unknown; challengeId?: string; deviceWebAuthn?: never }
+      | {
+          deviceWebAuthn: {
+            authenticatorData: string;
+            clientDataJSON: string;
+            signature: string;
+          };
+          credential?: never;
+          challengeId?: never;
+        }
+    )
+  ) => api.post("/transfer/submit", data),
 
   estimate: (data: {
     to: string;

--- a/aastar-frontend/lib/default-paymaster.ts
+++ b/aastar-frontend/lib/default-paymaster.ts
@@ -6,37 +6,45 @@
  * transfer page can auto-select (and auto-enable) a paymaster the user configured
  * once. The value is the paymaster CONTRACT ADDRESS (lowercased), since that's the
  * stable identity the transfer flow sends as `paymasterAddress`.
+ *
+ * The preference is scoped by account address so switching accounts on the same
+ * device does not silently carry (and auto-enable) another account's default.
+ * Callers pass the active account address; absent one, a device-global key is used.
  */
-const KEY = "yaa.defaultPaymaster";
+const BASE_KEY = "yaa.defaultPaymaster";
 
-export function getDefaultPaymaster(): string | null {
+function storageKey(account?: string | null): string {
+  return account ? `${BASE_KEY}:${account.toLowerCase()}` : BASE_KEY;
+}
+
+export function getDefaultPaymaster(account?: string | null): string | null {
   if (typeof window === "undefined") return null;
   try {
-    return window.localStorage.getItem(KEY);
+    return window.localStorage.getItem(storageKey(account));
   } catch {
     return null;
   }
 }
 
-export function setDefaultPaymaster(address: string): void {
+export function setDefaultPaymaster(address: string, account?: string | null): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(KEY, address.toLowerCase());
+    window.localStorage.setItem(storageKey(account), address.toLowerCase());
   } catch {
     /* localStorage unavailable (private mode / quota) — preference just won't persist */
   }
 }
 
-export function clearDefaultPaymaster(): void {
+export function clearDefaultPaymaster(account?: string | null): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(KEY);
+    window.localStorage.removeItem(storageKey(account));
   } catch {
     /* ignore */
   }
 }
 
-export function isDefaultPaymaster(address: string | null | undefined): boolean {
+export function isDefaultPaymaster(address: string | null | undefined, account?: string | null): boolean {
   if (!address) return false;
-  return getDefaultPaymaster() === address.toLowerCase();
+  return getDefaultPaymaster(account) === address.toLowerCase();
 }

--- a/aastar-frontend/lib/default-paymaster.ts
+++ b/aastar-frontend/lib/default-paymaster.ts
@@ -1,0 +1,42 @@
+/**
+ * Persisted "default paymaster" preference (client-side only).
+ *
+ * There is no server-side default-paymaster concept — which paymaster sponsors a
+ * transfer is chosen per-transaction. This stores a per-device preference so the
+ * transfer page can auto-select (and auto-enable) a paymaster the user configured
+ * once. The value is the paymaster CONTRACT ADDRESS (lowercased), since that's the
+ * stable identity the transfer flow sends as `paymasterAddress`.
+ */
+const KEY = "yaa.defaultPaymaster";
+
+export function getDefaultPaymaster(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setDefaultPaymaster(address: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(KEY, address.toLowerCase());
+  } catch {
+    /* localStorage unavailable (private mode / quota) — preference just won't persist */
+  }
+}
+
+export function clearDefaultPaymaster(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function isDefaultPaymaster(address: string | null | undefined): boolean {
+  if (!address) return false;
+  return getDefaultPaymaster() === address.toLowerCase();
+}

--- a/aastar-frontend/lib/p256-guardian.ts
+++ b/aastar-frontend/lib/p256-guardian.ts
@@ -15,6 +15,7 @@ import { startRegistration, startAuthentication } from "@simplewebauthn/browser"
 // Browser-safe subpath: the root "@aastar/sdk" pulls in the server bundle (imports
 // 'fs') and breaks the client build; "/core" is pure crypto.
 import { coseToP256XY } from "@aastar/sdk/core";
+import { webauthnRpId } from "@/lib/webauthn-rp";
 
 export interface GuardianPasskey {
   /** 0x-prefixed 32-byte secp256r1 X coordinate. */
@@ -64,7 +65,7 @@ export async function createGuardianPasskey(opts: {
   const credential = await startRegistration({
     optionsJSON: {
       challenge: b64urlEncode(crypto.getRandomValues(new Uint8Array(32))),
-      rp: { id: window.location.hostname, name: "AAStar Guardian" },
+      rp: { id: webauthnRpId(), name: "AAStar Guardian" },
       user: {
         id: b64urlEncode(crypto.getRandomValues(new Uint8Array(16))),
         name: opts.userName,
@@ -145,7 +146,7 @@ export async function signGuardianRecovery(opts: {
   const assertion = await startAuthentication({
     optionsJSON: {
       challenge: b64urlEncode(challengeBytes),
-      rpId: window.location.hostname,
+      rpId: webauthnRpId(),
       userVerification: "required",
       timeout: 120000,
     },

--- a/aastar-frontend/lib/webauthn-rp.ts
+++ b/aastar-frontend/lib/webauthn-rp.ts
@@ -10,15 +10,38 @@
  * WebAuthn permits rpId to be a registrable suffix of the current origin's domain,
  * so `cos72.aastar.io` (and `yaa.aastar.io`) may legally use `aastar.io`.
  *
- * localhost / bare-IP dev hosts are returned unchanged (rpId must equal the host there).
- * `NEXT_PUBLIC_RP_ID` overrides everything when set.
+ * We resolve against an explicit deployment-domain list rather than a naive
+ * last-two-labels split (which is wrong for multi-level public suffixes like
+ * `co.uk`). Deployments elsewhere set NEXT_PUBLIC_RP_DOMAINS (comma-separated) or a
+ * hard NEXT_PUBLIC_RP_ID override. localhost / IP literals are returned unchanged
+ * (rpId must equal the host there).
  */
+const RP_DOMAINS = (process.env.NEXT_PUBLIC_RP_DOMAINS || "aastar.io")
+  .split(",")
+  .map(s => s.trim().toLowerCase().replace(/\.$/, ""))
+  .filter(Boolean);
+
+function canonicalHost(h: string): string {
+  return h.toLowerCase().replace(/\.$/, ""); // lowercase + strip FQDN trailing dot
+}
+
 export function webauthnRpId(): string {
   const override = process.env.NEXT_PUBLIC_RP_ID;
-  if (override) return override;
+  if (override) return canonicalHost(override.trim());
 
-  const h = typeof window !== "undefined" ? window.location.hostname : "";
-  if (!h || h === "localhost" || /^[\d.]+$/.test(h)) return h; // localhost / IPv4 literal
+  const raw = typeof window !== "undefined" ? window.location.hostname : "";
+  if (!raw) return "";
+  const h = canonicalHost(raw);
+
+  // localhost, IPv4 literal, or IPv6 literal ([::1]) — rpId must equal the host.
+  if (h === "localhost" || h.startsWith("[") || /^[\d.]+$/.test(h)) return h;
+
+  // Map any subdomain to its registrable deployment domain (public-suffix-safe).
+  for (const d of RP_DOMAINS) {
+    if (h === d || h.endsWith("." + d)) return d;
+  }
+
+  // Unconfigured domain: best-effort last-two-labels (set NEXT_PUBLIC_RP_ID to be exact).
   const parts = h.split(".");
-  return parts.length <= 2 ? h : parts.slice(-2).join("."); // *.aastar.io → aastar.io
+  return parts.length <= 2 ? h : parts.slice(-2).join(".");
 }

--- a/aastar-frontend/lib/webauthn-rp.ts
+++ b/aastar-frontend/lib/webauthn-rp.ts
@@ -33,8 +33,15 @@ export function webauthnRpId(): string {
   if (!raw) return "";
   const h = canonicalHost(raw);
 
-  // localhost, IPv4 literal, or IPv6 literal ([::1]) — rpId must equal the host.
-  if (h === "localhost" || h.startsWith("[") || /^[\d.]+$/.test(h)) return h;
+  // Loopback dev hosts: WebAuthn treats these as secure contexts, but rpId must be a
+  // domain — never an IP or bracketed IPv6 literal (the browser rejects `[::1]` as an
+  // invalid rpId). Map all loopback forms to "localhost".
+  if (h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]") {
+    return "localhost";
+  }
+  // Other IPv4 literal (LAN dev): WebAuthn has no valid IP rpId — pass the host through
+  // so the browser surfaces its own error instead of us fabricating a wrong domain.
+  if (/^[\d.]+$/.test(h)) return h;
 
   // Map any subdomain to its registrable deployment domain (public-suffix-safe).
   for (const d of RP_DOMAINS) {

--- a/aastar-frontend/lib/webauthn-rp.ts
+++ b/aastar-frontend/lib/webauthn-rp.ts
@@ -1,0 +1,24 @@
+/**
+ * WebAuthn rpId resolver.
+ *
+ * The TA (dev-rpid build) anchors its rpId hash at the registrable parent domain
+ * `aastar.io`, and passkeys/keys are registered under that anchor. So every
+ * client-initiated ceremony must pass rpId = the registrable domain, NOT the full
+ * host — otherwise on a subdomain like cos72.aastar.io the browser would send
+ * `rpId: "cos72.aastar.io"` and the TA-side rpId hash check fails.
+ *
+ * WebAuthn permits rpId to be a registrable suffix of the current origin's domain,
+ * so `cos72.aastar.io` (and `yaa.aastar.io`) may legally use `aastar.io`.
+ *
+ * localhost / bare-IP dev hosts are returned unchanged (rpId must equal the host there).
+ * `NEXT_PUBLIC_RP_ID` overrides everything when set.
+ */
+export function webauthnRpId(): string {
+  const override = process.env.NEXT_PUBLIC_RP_ID;
+  if (override) return override;
+
+  const h = typeof window !== "undefined" ? window.location.hostname : "";
+  if (!h || h === "localhost" || /^[\d.]+$/.test(h)) return h; // localhost / IPv4 literal
+  const parts = h.split(".");
+  return parts.length <= 2 ? h : parts.slice(-2).join("."); // *.aastar.io → aastar.io
+}

--- a/aastar-frontend/lib/webauthn-rp.ts
+++ b/aastar-frontend/lib/webauthn-rp.ts
@@ -48,7 +48,10 @@ export function webauthnRpId(): string {
     if (h === d || h.endsWith("." + d)) return d;
   }
 
-  // Unconfigured domain: best-effort last-two-labels (set NEXT_PUBLIC_RP_ID to be exact).
-  const parts = h.split(".");
-  return parts.length <= 2 ? h : parts.slice(-2).join(".");
+  // Unconfigured domain: return the full host — always a valid rpId for itself. We do
+  // NOT guess a registrable parent by splitting labels, since a naive last-two-labels
+  // approach can return a public suffix (e.g. `co.uk`, `com.au`) as the rpId. To
+  // collapse subdomains for another deployment, add it to NEXT_PUBLIC_RP_DOMAINS (or
+  // set NEXT_PUBLIC_RP_ID explicitly).
+  return h;
 }

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.7",
+    "@aastar/sdk": "^0.30.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.33.2",
+    "@aastar/sdk": "^0.34.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.5",
+    "@aastar/sdk": "^0.29.7",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.32.1",
+    "@aastar/sdk": "^0.33.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.33.0",
+    "@aastar/sdk": "^0.33.2",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.32.0",
+    "@aastar/sdk": "^0.32.1",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar-frontend/package.json
+++ b/aastar-frontend/package.json
@@ -18,7 +18,7 @@
     "test:e2e:ui": "playwright test"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.30.0",
+    "@aastar/sdk": "^0.32.0",
     "@headlessui/react": "^2.2.10",
     "@heroicons/react": "^2.2.0",
     "@simplewebauthn/browser": "^13.3.0",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.32.1",
+    "@aastar/sdk": "^0.33.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.33.0",
+    "@aastar/sdk": "^0.33.2",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.32.0",
+    "@aastar/sdk": "^0.32.1",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.7",
+    "@aastar/sdk": "^0.30.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.29.5",
+    "@aastar/sdk": "^0.29.7",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.30.0",
+    "@aastar/sdk": "^0.32.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/package.json
+++ b/aastar/package.json
@@ -50,7 +50,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@aastar/sdk": "^0.33.2",
+    "@aastar/sdk": "^0.34.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.18",

--- a/aastar/src/account/account.controller.ts
+++ b/aastar/src/account/account.controller.ts
@@ -7,6 +7,7 @@ import {
   GuardianSetupPrepareDto,
   CreateWithGuardiansDto,
   CreateWithP256GuardiansDto,
+  SubmitCreateWithPasskeyDto,
 } from "./dto/guardian-setup.dto";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 
@@ -95,6 +96,30 @@ export class AccountController {
   })
   async createWithP256Guardians(@Request() req, @Body() dto: CreateWithP256GuardiansDto) {
     return this.accountService.createWithP256Guardians(req.user.sub, dto);
+  }
+
+  @Post("prepare-create-with-passkey")
+  @ApiOperation({
+    summary: "Tier-2/3 passkey-at-birth — PHASE 1 (prepare)",
+    description:
+      "Pins nonce/deadline, builds the CREATE_ACCOUNT digest, and begins the one-time KMS WebAuthn " +
+      "ceremony. Returns { createId, predictedAddress, challenge, challengeId, publicKeyOptions }. The " +
+      "owner device passkey is read from the user's registration record. Then run " +
+      "navigator.credentials.get(publicKeyOptions) and POST submit-create-with-passkey. Mirrors transfer prepare/submit.",
+  })
+  async prepareCreateWithPasskey(@Request() req, @Body() dto: CreateWithP256GuardiansDto) {
+    return this.accountService.prepareCreateWithPasskey(req.user.sub, dto);
+  }
+
+  @Post("submit-create-with-passkey")
+  @ApiOperation({
+    summary: "Tier-2/3 passkey-at-birth — PHASE 3 (submit)",
+    description:
+      "Signs the prepared CREATE_ACCOUNT digest with the one-time WebAuthn ceremony assertion (KMS owner) " +
+      "and relays the deploy via a funded backend deployer. Returns the DEPLOYED account record.",
+  })
+  async submitCreateWithPasskey(@Request() req, @Body() dto: SubmitCreateWithPasskeyDto) {
+    return this.accountService.submitCreateWithPasskey(req.user.sub, dto);
   }
 
   @Post("rotate-signer")

--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -3,7 +3,9 @@ import {
   AirAccountServerClient as YAAAServerClient,
   ALG_ECDSA,
   ALG_P256,
+  ALG_CUMULATIVE_T2,
   ALG_CUMULATIVE_T2_WA,
+  ALG_CUMULATIVE_T3,
   ALG_CUMULATIVE_T3_WA,
 } from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
@@ -228,7 +230,22 @@ export class AccountService {
     //   0x09 WebAuthn cumulative Tier-2, 0x0a WebAuthn cumulative Tier-3 (#234).
     // buildInitConfig would otherwise default to just [0x02(, 0x03)], leaving Tier-2/3
     // un-approved. Keep ECDSA so Tier-1 and the lazy first-UserOp deploy still work.
-    const approvedAlgIds = [ALG_ECDSA, ALG_P256, ALG_CUMULATIVE_T2_WA, ALG_CUMULATIVE_T3_WA];
+    // Approve BOTH the base cumulative (0x04 T2 / 0x05 T3) AND the WebAuthn variants (0x09 / 0x0a).
+    // On-chain validateUserOp uses the actual signature algId (0x0a for the device-passkey path) and
+    // only needs 0x09/0x0a. But the SDK's off-chain guard pre-check (GuardChecker) still maps
+    // tier→algId via algIdForTier (0x05 for T3, no WebAuthn branch) and checks approvedAlgorithms[0x05]
+    // — even though the on-chain guard NO LONGER enforces algId approval (moved to validateUserOp,
+    // contract v0.17.2-beta.4). Approving 0x04/0x05 satisfies that stale pre-check; it's harmless (a
+    // device passkey is WebAuthn-only and cannot produce a valid non-WA raw-P256 0x05 signature).
+    // Tracked as the SDK pre-check bug; remove the base algIds once the pre-check uses the real algId.
+    const approvedAlgIds = [
+      ALG_ECDSA,
+      ALG_P256,
+      ALG_CUMULATIVE_T2,
+      ALG_CUMULATIVE_T2_WA,
+      ALG_CUMULATIVE_T3,
+      ALG_CUMULATIVE_T3_WA,
+    ];
 
     const ecdsaGuardians = dto.ecdsaGuardians?.map(a => a as `0x${string}`);
 
@@ -303,7 +320,22 @@ export class AccountService {
 
     const versionDto = dto.entryPointVersion || EntryPointVersionDto.V0_7;
     const version = ({ "0.6": "0.6", "0.7": "0.7", "0.8": "0.8" }[versionDto] ?? "0.7") as any;
-    const approvedAlgIds = [ALG_ECDSA, ALG_P256, ALG_CUMULATIVE_T2_WA, ALG_CUMULATIVE_T3_WA];
+    // Approve BOTH the base cumulative (0x04 T2 / 0x05 T3) AND the WebAuthn variants (0x09 / 0x0a).
+    // On-chain validateUserOp uses the actual signature algId (0x0a for the device-passkey path) and
+    // only needs 0x09/0x0a. But the SDK's off-chain guard pre-check (GuardChecker) still maps
+    // tier→algId via algIdForTier (0x05 for T3, no WebAuthn branch) and checks approvedAlgorithms[0x05]
+    // — even though the on-chain guard NO LONGER enforces algId approval (moved to validateUserOp,
+    // contract v0.17.2-beta.4). Approving 0x04/0x05 satisfies that stale pre-check; it's harmless (a
+    // device passkey is WebAuthn-only and cannot produce a valid non-WA raw-P256 0x05 signature).
+    // Tracked as the SDK pre-check bug; remove the base algIds once the pre-check uses the real algId.
+    const approvedAlgIds = [
+      ALG_ECDSA,
+      ALG_P256,
+      ALG_CUMULATIVE_T2,
+      ALG_CUMULATIVE_T2_WA,
+      ALG_CUMULATIVE_T3,
+      ALG_CUMULATIVE_T3_WA,
+    ];
     const ecdsaGuardians = dto.ecdsaGuardians?.map(a => a as `0x${string}`);
     const p256Guardians = dto.p256Guardians.map(g => ({
       x: g.x as `0x${string}`,

--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -12,6 +12,7 @@ import {
   GuardianSetupPrepareDto,
   CreateWithGuardiansDto,
   CreateWithP256GuardiansDto,
+  SubmitCreateWithPasskeyDto,
 } from "./dto/guardian-setup.dto";
 import { DatabaseService } from "../database/database.service";
 import { ConfigService } from "@nestjs/config";
@@ -238,53 +239,140 @@ export class AccountService {
     );
 
     try {
+      const user = await this.databaseService.findUserById(userId);
+      const ownerP256X = user?.passkeyX as `0x${string}` | undefined;
+      const ownerP256Y = user?.passkeyY as `0x${string}` | undefined;
+      const deployerKey =
+        this.configService.get<string>("deployerPrivateKey") || process.env.DEPLOYER_PRIVATE_KEY;
+
+      const p256Guardians = dto.p256Guardians.map(g => ({
+        x: g.x as `0x${string}`,
+        y: g.y as `0x${string}`,
+      }));
+      void ownerP256X;
+      void ownerP256Y;
+      void deployerKey;
+
+      // This single-shot endpoint is the LEGACY path (no owner device passkey at birth → Tier-1 only).
+      // Tier-2/3 passkey-at-birth needs the KMS owner to sign the CREATE_ACCOUNT digest, which requires
+      // a one-time WebAuthn ceremony whose challenge commits to that digest — a chicken-and-egg that
+      // forces a two-phase flow (aastar-sdk#249). Use prepareCreateWithPasskey + submitCreateWithPasskey
+      // (mirrors transfer prepare/submit) for Tier-2/3.
       const account = await this.client.accounts.createAccountWithP256Guardians(userId, {
-        p256Guardians: dto.p256Guardians.map(g => ({
-          x: g.x as `0x${string}`,
-          y: g.y as `0x${string}`,
-        })),
+        p256Guardians,
         ...(ecdsaGuardians && ecdsaGuardians.length > 0 ? { ecdsaGuardians } : {}),
         approvedAlgIds,
         dailyLimit: dailyLimitWei,
         salt: dto.salt,
         entryPointVersion: version,
       });
-      // Router-delegated algIds (0x09/0x0a cumulative WebAuthn) CANNOT be bootstrapped by the
-      // factory's lazy first-UserOp deploy — the SDK requires deployAndWireValidator (deploy +
-      // setValidator(router) in one tx) via a FUNDED deployer (the manager holds no signer).
-      // Gasless users have no ETH, so a backend deployer key funds it; without this the first
-      // tiered prepareTransfer reverts AbiDecodingZeroDataError (reads validator on an undeployed
-      // account) and Tier-2/3 can't validate.
-      const deployerKey =
-        this.configService.get<string>("deployerPrivateKey") || process.env.DEPLOYER_PRIVATE_KEY;
-      if (deployerKey) {
-        const walletClient = createWalletClient({
-          account: privateKeyToAccount(
-            (deployerKey.startsWith("0x") ? deployerKey : `0x${deployerKey}`) as `0x${string}`
-          ),
-          chain: sepolia,
-          transport: http(this.configService.get<string>("ethRpcUrl")),
-        });
-        const wired = await this.client.accounts.deployAndWireValidator(userId, {
-          walletClient: walletClient as any,
-        });
-        this.logger.log(
-          `deployAndWireValidator: deployTx=${wired.deployTx ?? "(already deployed)"} ` +
-            `validator=${JSON.stringify(wired.validator)}`
-        );
-      } else {
-        this.logger.warn(
-          "DEPLOYER_PRIVATE_KEY unset — Tier-2/3 account not deployed+wired (only Tier-1 works)."
-        );
-      }
       this.logger.log(
-        `createWithP256Guardians OK: address=${account.address} deployed=${account.deployed}`
+        `createWithP256Guardians OK (legacy): address=${account.address} deployed=${account.deployed}`
       );
       return account;
     } catch (err: any) {
       // Surface the real SDK/KMS/on-chain failure (otherwise it bubbles up as an
       // opaque 500). Includes the KMS "No pending challenge" challenge-binding case.
       this.logger.error(`createWithP256Guardians FAILED: ${err?.message ?? err}`, err?.stack);
+      throw err;
+    }
+  }
+
+  /**
+   * Tier-2/3 passkey-at-birth — PHASE 1 (aastar-sdk#249). The SDK pins nonce/deadline, builds the
+   * CREATE_ACCOUNT digest, and (KMS path) begins a one-time WebAuthn ceremony whose challenge commits
+   * to that digest. The owner device passkey (ownerP256X/Y) is read from the user's registration record
+   * (NOT a guardian). The frontend then runs navigator.credentials.get(publicKeyOptions) and calls
+   * submitCreateWithPasskey. Mirrors transfer prepare/submit.
+   */
+  async prepareCreateWithPasskey(userId: string, dto: CreateWithP256GuardiansDto) {
+    const dailyLimitWei = this.parseDailyLimitToWei(dto.dailyLimit);
+    if (dailyLimitWei === undefined || dailyLimitWei <= 0n) {
+      throw new BadRequestException(
+        "dailyLimit must be > 0 for a passkey-at-birth account (a guardian set enables the on-chain guard)."
+      );
+    }
+    const user = await this.databaseService.findUserById(userId);
+    const ownerP256X = user?.passkeyX as `0x${string}` | undefined;
+    const ownerP256Y = user?.passkeyY as `0x${string}` | undefined;
+    if (!ownerP256X || !ownerP256Y) {
+      throw new BadRequestException(
+        "No registered device passkey on this account — register a passkey (Face ID / fingerprint) first."
+      );
+    }
+
+    const versionDto = dto.entryPointVersion || EntryPointVersionDto.V0_7;
+    const version = ({ "0.6": "0.6", "0.7": "0.7", "0.8": "0.8" }[versionDto] ?? "0.7") as any;
+    const approvedAlgIds = [ALG_ECDSA, ALG_P256, ALG_CUMULATIVE_T2_WA, ALG_CUMULATIVE_T3_WA];
+    const ecdsaGuardians = dto.ecdsaGuardians?.map(a => a as `0x${string}`);
+    const p256Guardians = dto.p256Guardians.map(g => ({
+      x: g.x as `0x${string}`,
+      y: g.y as `0x${string}`,
+    }));
+
+    try {
+      const prep = await this.client.accounts.prepareCreateAccountWithPasskey(userId, {
+        ownerP256X,
+        ownerP256Y,
+        ...(p256Guardians.length > 0 ? { p256Guardians } : {}),
+        ...(ecdsaGuardians && ecdsaGuardians.length > 0 ? { ecdsaGuardians } : {}),
+        approvedAlgIds,
+        dailyLimit: dailyLimitWei,
+        salt: dto.salt,
+        entryPointVersion: version,
+      } as any);
+      this.logger.log(
+        `prepareCreateWithPasskey: createId=${prep.createId} predicted=${prep.predictedAddress} ` +
+          `alreadyDeployed=${prep.alreadyDeployed}`
+      );
+      return {
+        createId: prep.createId,
+        predictedAddress: prep.predictedAddress,
+        challenge: prep.challenge,
+        challengeId: prep.challengeId,
+        publicKeyOptions: prep.publicKeyOptions,
+        alreadyDeployed: prep.alreadyDeployed,
+      };
+    } catch (err: any) {
+      this.logger.error(`prepareCreateWithPasskey FAILED: ${err?.message ?? err}`, err?.stack);
+      throw err;
+    }
+  }
+
+  /**
+   * Tier-2/3 passkey-at-birth — PHASE 3 (aastar-sdk#249). Signs the prepared CREATE_ACCOUNT digest with
+   * the user's one-time WebAuthn ceremony assertion (KMS owner) and relays the deploy via a funded
+   * backend deployer (msg.sender == deployer). Returns the DEPLOYED account (validator + passkey at birth).
+   */
+  async submitCreateWithPasskey(_userId: string, dto: SubmitCreateWithPasskeyDto) {
+    const deployerKey =
+      this.configService.get<string>("deployerPrivateKey") || process.env.DEPLOYER_PRIVATE_KEY;
+    if (!deployerKey) {
+      throw new BadRequestException(
+        "DEPLOYER_PRIVATE_KEY unset — cannot relay the account deploy."
+      );
+    }
+    const deployerWallet = createWalletClient({
+      account: privateKeyToAccount(
+        (deployerKey.startsWith("0x") ? deployerKey : `0x${deployerKey}`) as `0x${string}`
+      ),
+      chain: sepolia,
+      transport: http(this.configService.get<string>("ethRpcUrl")),
+    });
+
+    try {
+      const account = await this.client.accounts.submitPreparedCreateAccount(dto.createId, {
+        deployerWallet: deployerWallet as any,
+        signerCtx: {
+          webAuthnAssertion: { ChallengeId: dto.challengeId, Credential: dto.credential },
+        } as any,
+      });
+      this.logger.log(
+        `submitCreateWithPasskey OK: address=${account.address} deployed=${account.deployed}`
+      );
+      return account;
+    } catch (err: any) {
+      this.logger.error(`submitCreateWithPasskey FAILED: ${err?.message ?? err}`, err?.stack);
       throw err;
     }
   }

--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -1,5 +1,11 @@
 import { Injectable, Inject, NotFoundException, BadRequestException, Logger } from "@nestjs/common";
-import { AirAccountServerClient as YAAAServerClient } from "@aastar/sdk/kms";
+import {
+  AirAccountServerClient as YAAAServerClient,
+  ALG_ECDSA,
+  ALG_P256,
+  ALG_CUMULATIVE_T2_WA,
+  ALG_CUMULATIVE_T3_WA,
+} from "@aastar/sdk/kms";
 import { YAAA_SERVER_CLIENT } from "../sdk/sdk.providers";
 import { CreateAccountDto, EntryPointVersionDto } from "./dto/create-account.dto";
 import {
@@ -10,6 +16,9 @@ import {
 import { DatabaseService } from "../database/database.service";
 import { ConfigService } from "@nestjs/config";
 import { ethers } from "ethers";
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
 
 @Injectable()
 export class AccountService {
@@ -213,8 +222,18 @@ export class AccountService {
     };
     const version = versionMap[versionDto] as any;
 
+    // Approve the full Tier-1/2/3 algorithm set so this account can validate every tier:
+    //   0x02 ECDSA (Tier-1 / KMS owner + deploy), 0x03 P-256 (the device-passkey factor),
+    //   0x09 WebAuthn cumulative Tier-2, 0x0a WebAuthn cumulative Tier-3 (#234).
+    // buildInitConfig would otherwise default to just [0x02(, 0x03)], leaving Tier-2/3
+    // un-approved. Keep ECDSA so Tier-1 and the lazy first-UserOp deploy still work.
+    const approvedAlgIds = [ALG_ECDSA, ALG_P256, ALG_CUMULATIVE_T2_WA, ALG_CUMULATIVE_T3_WA];
+
+    const ecdsaGuardians = dto.ecdsaGuardians?.map(a => a as `0x${string}`);
+
     this.logger.log(
-      `createWithP256Guardians: userId=${userId} guardians=${dto.p256Guardians.length} ` +
+      `createWithP256Guardians: userId=${userId} p256Guardians=${dto.p256Guardians.length} ` +
+        `ecdsaGuardians=${ecdsaGuardians?.length ?? 0} approvedAlgIds=[${approvedAlgIds.join(",")}] ` +
         `version=${version} dailyLimitWei=${dailyLimitWei} salt=${dto.salt ?? "random"}`
     );
 
@@ -224,10 +243,40 @@ export class AccountService {
           x: g.x as `0x${string}`,
           y: g.y as `0x${string}`,
         })),
+        ...(ecdsaGuardians && ecdsaGuardians.length > 0 ? { ecdsaGuardians } : {}),
+        approvedAlgIds,
         dailyLimit: dailyLimitWei,
         salt: dto.salt,
         entryPointVersion: version,
       });
+      // Router-delegated algIds (0x09/0x0a cumulative WebAuthn) CANNOT be bootstrapped by the
+      // factory's lazy first-UserOp deploy — the SDK requires deployAndWireValidator (deploy +
+      // setValidator(router) in one tx) via a FUNDED deployer (the manager holds no signer).
+      // Gasless users have no ETH, so a backend deployer key funds it; without this the first
+      // tiered prepareTransfer reverts AbiDecodingZeroDataError (reads validator on an undeployed
+      // account) and Tier-2/3 can't validate.
+      const deployerKey =
+        this.configService.get<string>("deployerPrivateKey") || process.env.DEPLOYER_PRIVATE_KEY;
+      if (deployerKey) {
+        const walletClient = createWalletClient({
+          account: privateKeyToAccount(
+            (deployerKey.startsWith("0x") ? deployerKey : `0x${deployerKey}`) as `0x${string}`
+          ),
+          chain: sepolia,
+          transport: http(this.configService.get<string>("ethRpcUrl")),
+        });
+        const wired = await this.client.accounts.deployAndWireValidator(userId, {
+          walletClient: walletClient as any,
+        });
+        this.logger.log(
+          `deployAndWireValidator: deployTx=${wired.deployTx ?? "(already deployed)"} ` +
+            `validator=${JSON.stringify(wired.validator)}`
+        );
+      } else {
+        this.logger.warn(
+          "DEPLOYER_PRIVATE_KEY unset — Tier-2/3 account not deployed+wired (only Tier-1 works)."
+        );
+      }
       this.logger.log(
         `createWithP256Guardians OK: address=${account.address} deployed=${account.deployed}`
       );

--- a/aastar/src/account/account.service.ts
+++ b/aastar/src/account/account.service.ts
@@ -376,7 +376,15 @@ export class AccountService {
    * the user's one-time WebAuthn ceremony assertion (KMS owner) and relays the deploy via a funded
    * backend deployer (msg.sender == deployer). Returns the DEPLOYED account (validator + passkey at birth).
    */
-  async submitCreateWithPasskey(_userId: string, dto: SubmitCreateWithPasskeyDto) {
+  async submitCreateWithPasskey(userId: string, dto: SubmitCreateWithPasskeyDto) {
+    // Security model: `createId` is a prepare-session handle the SDK bound to the caller
+    // at prepareCreateWithPasskey time, and submitPreparedCreateAccount deploys THAT
+    // session's account regardless of who submits — so a leaked createId can't be used to
+    // deploy an account the submitter controls (it deploys the original user's account,
+    // at most wasting deployer gas). The real gate is the one-time WebAuthn assertion below,
+    // which requires the user's physical device. `userId` is therefore not a security check
+    // here (a strict createId↔userId assertion needs an SDK-exposed binding getter); it is
+    // recorded for audit. See PR #399 review H1.
     const deployerKey =
       this.configService.get<string>("deployerPrivateKey") || process.env.DEPLOYER_PRIVATE_KEY;
     if (!deployerKey) {
@@ -400,11 +408,14 @@ export class AccountService {
         } as any,
       });
       this.logger.log(
-        `submitCreateWithPasskey OK: address=${account.address} deployed=${account.deployed}`
+        `submitCreateWithPasskey OK: user=${userId} address=${account.address} deployed=${account.deployed}`
       );
       return account;
     } catch (err: any) {
-      this.logger.error(`submitCreateWithPasskey FAILED: ${err?.message ?? err}`, err?.stack);
+      this.logger.error(
+        `submitCreateWithPasskey FAILED (user=${userId}): ${err?.message ?? err}`,
+        err?.stack
+      );
       throw err;
     }
   }

--- a/aastar/src/account/dto/guardian-setup.dto.ts
+++ b/aastar/src/account/dto/guardian-setup.dto.ts
@@ -10,6 +10,7 @@ import {
   ArrayMaxSize,
   ValidateNested,
   Matches,
+  IsObject,
 } from "class-validator";
 import { Type } from "class-transformer";
 import { EntryPointVersionDto } from "./create-account.dto";
@@ -153,4 +154,23 @@ export class CreateWithP256GuardiansDto {
   @IsOptional()
   @IsEnum(EntryPointVersionDto)
   entryPointVersion?: EntryPointVersionDto;
+}
+
+export class SubmitCreateWithPasskeyDto {
+  @ApiProperty({ description: "createId returned by prepare-create-with-passkey (PHASE 1)" })
+  @IsString()
+  createId: string;
+
+  @ApiProperty({
+    description: "KMS ceremony ChallengeId returned by prepare-create-with-passkey",
+  })
+  @IsString()
+  challengeId: string;
+
+  @ApiProperty({
+    description: "The navigator.credentials.get() WebAuthn assertion (one-time ceremony).",
+    type: Object,
+  })
+  @IsObject()
+  credential: Record<string, unknown>;
 }

--- a/aastar/src/account/dto/guardian-setup.dto.ts
+++ b/aastar/src/account/dto/guardian-setup.dto.ts
@@ -119,6 +119,20 @@ export class CreateWithP256GuardiansDto {
 
   @ApiProperty({
     description:
+      "Optional ECDSA guardian addresses installed via the SAME full-config path (no acceptance " +
+      "signatures — the config-hash-in-salt binding stands in for them). Used as the Tier-3 guardian " +
+      "co-signers for the WebAuthn cumulative path (algId 0x0a). Total guardians (P-256 + ECDSA) ≤ 3.",
+    type: [String],
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(2)
+  @IsEthereumAddress({ each: true })
+  ecdsaGuardians?: string[];
+
+  @ApiProperty({
+    description:
       "Daily transfer limit in ETH. MUST be > 0 — a guardian set enables the on-chain guard.",
     example: "1.0",
   })

--- a/aastar/src/auth/auth.controller.ts
+++ b/aastar/src/auth/auth.controller.ts
@@ -99,13 +99,17 @@ export class AuthController {
       kmsKeyId: string;
       address: string;
       credentialId?: string;
+      // The device WebAuthn credential's secp256r1 public key (x, y), captured from the
+      // registration attestation. Persisted so a Tier-2/3-capable account can register it
+      // on-chain via setP256Key — it is the cumulative on-chain passkey factor (#234).
+      passkeyX?: string;
+      passkeyY?: string;
     }
   ) {
-    return this.authService.linkWallet(
-      req.user.sub,
-      body.kmsKeyId,
-      body.address,
-      body.credentialId
-    );
+    return this.authService.linkWallet(req.user.sub, body.kmsKeyId, body.address, {
+      credentialId: body.credentialId,
+      passkeyX: body.passkeyX,
+      passkeyY: body.passkeyY,
+    });
   }
 }

--- a/aastar/src/auth/auth.service.ts
+++ b/aastar/src/auth/auth.service.ts
@@ -216,7 +216,12 @@ export class AuthService {
    * Link a KMS wallet to a user account. Called after KMS key creation
    * and address derivation are complete.
    */
-  async linkWallet(userId: string, kmsKeyId: string, walletAddress: string, credentialId?: string) {
+  async linkWallet(
+    userId: string,
+    kmsKeyId: string,
+    walletAddress: string,
+    opts?: { credentialId?: string; passkeyX?: string; passkeyY?: string }
+  ) {
     const user = await this.databaseService.findUserById(userId);
     if (!user) {
       throw new UnauthorizedException("User not found");
@@ -225,7 +230,12 @@ export class AuthService {
     await this.databaseService.updateUser(userId, {
       kmsKeyId,
       walletAddress,
-      kmsCredentialId: credentialId,
+      kmsCredentialId: opts?.credentialId,
+      // Device WebAuthn passkey public key (x, y) — the on-chain cumulative passkey factor
+      // a Tier-2/3 account registers via setP256Key. Only persisted when supplied.
+      ...(opts?.passkeyX && opts?.passkeyY
+        ? { passkeyX: opts.passkeyX, passkeyY: opts.passkeyY }
+        : {}),
     });
 
     return {

--- a/aastar/src/main.ts
+++ b/aastar/src/main.ts
@@ -4,6 +4,14 @@ import { SwaggerModule, DocumentBuilder } from "@nestjs/swagger";
 import { AppModule } from "./app.module";
 import { ConfigService } from "@nestjs/config";
 
+// Make BigInt JSON-serializable across the whole API. SDK records (e.g. AccountRecord.salt) can carry
+// a raw bigint, and Express's res.json() throws "Do not know how to serialize a BigInt" → an opaque
+// 500 AFTER the work succeeded (e.g. the account is already deployed on-chain). Emit it as a decimal
+// string instead. Standard NestJS pattern; safe (only affects JSON.stringify of bigint values).
+(BigInt.prototype as unknown as { toJSON: () => string }).toJSON = function () {
+  return this.toString();
+};
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);

--- a/aastar/src/paymaster/paymaster.service.ts
+++ b/aastar/src/paymaster/paymaster.service.ts
@@ -39,9 +39,13 @@ export class PaymasterService {
   /**
    * Recommended paymaster presets, addresses sourced from the @aastar/sdk canonical
    * table (never hardcoded). Two options:
-   *  - AAStar PaymasterV4: official, pay gas with aPNTs, no community needed.
-   *  - SuperPaymaster: pay gas with community points (xPNTs) — requires joining a
-   *    community + earning points, so it's unusable without them.
+   *  - PaymasterV4: a TEMPLATE, not a single contract — any community can deploy its
+   *    own V4 (own gas token + own deposit) via the factory, so many V4 instances can
+   *    exist. The one we ship here is the AAStar community's instance; pay gas with
+   *    aPNTs (you're in the default AAStar community, so no separate join is needed).
+   *  - SuperPaymaster: a single shared contract that accepts ANY community's points
+   *    (xPNTs) — requires joining a community + holding that community's points, so
+   *    it's unusable without them.
    */
   getPaymasterPresets(): PaymasterPreset[] {
     const chainId = this.configService.get<number>("chainId") || 11155111;
@@ -58,7 +62,7 @@ export class PaymasterService {
         gasToken: "aPNTs",
         gasTokenAddress: a.aPNTs ?? null,
         description:
-          "Official AAStar-operated paymaster. Buy aPNTs and it sponsors your gas — available to everyone (you're in the default AAStar community by default). No community membership or points required.",
+          "PaymasterV4 is a template — any community can deploy its own V4 (own gas token + deposit) via the factory, so there can be many. This is the AAStar community's instance: buy aPNTs and it sponsors your gas. You're in the default AAStar community, so no separate join is needed — you just need aPNTs.",
       });
     }
     if (a.superPaymaster) {
@@ -71,7 +75,7 @@ export class PaymasterService {
         gasToken: "xPNTs (community points)",
         gasTokenAddress: null,
         description:
-          "Pay gas with community points (xPNTs). Requires joining a community and earning points by completing community tasks — it will not work until you hold that community's points.",
+          "A single shared paymaster that accepts ANY community's points (xPNTs). Requires joining a community and earning its points by completing tasks — it will not work until you hold that community's points.",
       });
     }
     return presets;

--- a/aastar/src/sdk/sdk.providers.ts
+++ b/aastar/src/sdk/sdk.providers.ts
@@ -1,10 +1,11 @@
-import { Provider } from "@nestjs/common";
+import { Provider, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import {
   AirAccountServerClient as YAAAServerClient,
   ServerConfig,
   sepoliaV07Config,
 } from "@aastar/sdk/kms";
+import { AAStarAirAccountV7ABI } from "@aastar/sdk/core";
 import { BackendStorageAdapter } from "./backend-storage.adapter";
 import { KmsService } from "../kms/kms.service";
 import { AuthService } from "../auth/auth.service";
@@ -52,7 +53,49 @@ export const yaaaServerClientProvider: Provider = {
       signer: kmsService.createSignerAdapter(userId => authService.resolveKmsKey(userId)),
     };
 
-    return new YAAAServerClient(serverConfig);
+    const client = new YAAAServerClient(serverConfig);
+
+    // ── Workaround: @aastar/sdk@0.29.7 GuardChecker ABI gap ─────────────────────────────
+    // The tiered path (`useAirAccountTiering: true`, which every YAA transfer uses) routes
+    // through TransferManager.resolveSignStrategy → GuardChecker.preCheck → fetchTierConfig,
+    // which reads the standalone `tier1Limit()` / `tier2Limit()` getters. But the SDK's
+    // internal server-side account ABI (EthereumProvider.getAccountContract) omits those two
+    // fragments, so fetchTierConfig throws `AbiFunctionNotFoundError: Function "tier1Limit"
+    // not found on ABI` before any tier can be resolved — blocking ALL tiered transfers
+    // (Tier-1 self-calls included), not just the new WebAuthn path.
+    //
+    // Fix it at the seam the SDK leaves public: replace the GuardChecker's fetchTierConfig
+    // with one that reads the SAME getters via the SDK's EXPORTED `AAStarAirAccountV7ABI`
+    // (which does include them — this is exactly what the frontend tier-setup + fund helper
+    // read) through the client's own EthereumProvider. No raw ABIs, no extra RPC client. The
+    // `.catch(() => 0n)` mirrors a not-yet-deployed account (tiers read as 0 → an amount-0
+    // self-call resolves to Tier-1). Remove once the SDK ships the missing getters.
+    const ethereum = (client as unknown as { ethereum?: { getProvider(): any } }).ethereum;
+    const guardChecker = (
+      client.transfers as unknown as {
+        guardChecker?: { fetchTierConfig: (a: string) => Promise<unknown> };
+      }
+    ).guardChecker;
+    if (ethereum && guardChecker) {
+      const provider = ethereum.getProvider();
+      guardChecker.fetchTierConfig = async (accountAddress: string) => {
+        const read = (functionName: "tier1Limit" | "tier2Limit") =>
+          provider
+            .readContract({ address: accountAddress, abi: AAStarAirAccountV7ABI, functionName })
+            .catch(() => 0n);
+        const [tier1Limit, tier2Limit] = await Promise.all([
+          read("tier1Limit"),
+          read("tier2Limit"),
+        ]);
+        return { tier1Limit: BigInt(tier1Limit), tier2Limit: BigInt(tier2Limit) };
+      };
+    } else {
+      new Logger("SdkProvider").warn(
+        "Could not install GuardChecker.fetchTierConfig shim (SDK internals changed); tiered transfers may fail on 0.29.7."
+      );
+    }
+
+    return client;
   },
   inject: [ConfigService, BackendStorageAdapter, KmsService, AuthService],
 };

--- a/aastar/src/sdk/sdk.providers.ts
+++ b/aastar/src/sdk/sdk.providers.ts
@@ -90,9 +90,17 @@ export const yaaaServerClientProvider: Provider = {
         return { tier1Limit: BigInt(tier1Limit), tier2Limit: BigInt(tier2Limit) };
       };
     } else {
-      new Logger("SdkProvider").warn(
-        "Could not install GuardChecker.fetchTierConfig shim (SDK internals changed); tiered transfers may fail on 0.29.7."
-      );
+      // Fail fast at startup. Without this shim EVERY tiered transfer (Tier-1 self-calls
+      // included) throws AbiFunctionNotFoundError at runtime, so a silent `warn` would let
+      // a single @aastar/sdk bump that renames `transfers.guardChecker` / `client.ethereum`
+      // break all transfers in production undetected. Surface it here and force a conscious
+      // re-check of the shim on the next SDK bump.
+      const message =
+        "GuardChecker.fetchTierConfig shim could not be installed: @aastar/sdk internals " +
+        "(transfers.guardChecker / client.ethereum) changed. Update the shim in " +
+        "sdk.providers.ts (or drop it if the SDK now ships tier1Limit/tier2Limit) before deploying.";
+      new Logger("SdkProvider").error(message);
+      throw new Error(message);
     }
 
     return client;

--- a/aastar/src/transfer/dto/prepare-transfer.dto.ts
+++ b/aastar/src/transfer/dto/prepare-transfer.dto.ts
@@ -49,4 +49,18 @@ export class PrepareTransferDto {
   @IsOptional()
   @IsString()
   paymasterData?: string;
+
+  @ApiProperty({
+    description:
+      "Use the on-chain WebAuthn-passkey cumulative path (algId 0x09/0x0a) for Tier-2/3. When true, " +
+      "the SDK runs NO KMS owner ceremony — prepare returns no challengeId/publicKeyOptions and the " +
+      "frontend runs ONE navigator.credentials.get() with challenge = the returned userOpHash, then " +
+      "submits the assertion as deviceWebAuthn. Tier-2/3 ONLY (the SDK rejects it for Tier-1). The " +
+      "frontend sets this from its resolveTransfer tier.",
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  useWebAuthnPasskey?: boolean;
 }

--- a/aastar/src/transfer/dto/submit-transfer.dto.ts
+++ b/aastar/src/transfer/dto/submit-transfer.dto.ts
@@ -2,26 +2,76 @@ import { ApiProperty } from "@nestjs/swagger";
 import { IsString, IsObject, IsOptional, Matches } from "class-validator";
 
 /**
+ * Device WebAuthn assertion fields for the Tier-2/3 WebAuthn cumulative path (algId
+ * 0x09/0x0a, #234). These are the three `navigator.credentials.get()` response fields
+ * the browser produced with `challenge = userOpHash`, normalised by the frontend into
+ * the encodings the SDK's `packWebAuthnBlob` expects: `authenticatorData` and
+ * `signature` as 0x-hex, `clientDataJSON` as the RAW JSON text (must start with
+ * `{"type":"webauthn.get","challenge":"…`). The SDK derives the on-chain passkey
+ * factor + fetches the DVT BLS aggregate + packs the composite internally.
+ */
+export class DeviceWebAuthnDto {
+  @ApiProperty({ description: "authenticatorData as 0x-prefixed hex" })
+  @IsString()
+  @Matches(/^0x[0-9a-fA-F]*$/, { message: "authenticatorData must be 0x-prefixed hex" })
+  authenticatorData: string;
+
+  @ApiProperty({ description: "Raw clientDataJSON text (UTF-8, NOT base64url)" })
+  @IsString()
+  clientDataJSON: string;
+
+  @ApiProperty({ description: "DER ECDSA signature as 0x-prefixed hex" })
+  @IsString()
+  @Matches(/^0x[0-9a-fA-F]*$/, { message: "signature must be 0x-prefixed hex" })
+  signature: string;
+}
+
+/**
  * Phase-3 of the strict device-passkey transfer. Carries the opaque prepared
- * handle plus the browser ceremony result. The credential signed the commitment
- * the SDK bound in prepareTransfer, so the KMS accepts it under strict.
+ * handle plus the browser ceremony result.
+ *
+ * Two mutually-exclusive completion paths, routed by tier (the SDK decides):
+ *  - Tier-1 (KMS owner ceremony): `challengeId` + `credential` — the credential signed
+ *    the WYSIWYS commitment the SDK bound in prepareTransfer.
+ *  - Tier-2/3 (WebAuthn passkey, #234): `deviceWebAuthn` — the assertion whose challenge
+ *    is the prepared userOpHash. The SDK packs the 0x09/0x0a composite + fetches DVT BLS.
  */
 export class SubmitTransferDto {
   @ApiProperty({ description: "Opaque handle returned by /transfer/prepare" })
   @IsString()
   transferId: string;
 
-  @ApiProperty({ description: "KMS BeginAuthentication ChallengeId returned by /transfer/prepare" })
+  @ApiProperty({
+    required: false,
+    description:
+      "KMS BeginAuthentication ChallengeId returned by /transfer/prepare. Required for the " +
+      "Tier-1 KMS owner-ceremony path; omitted on the Tier-2/3 WebAuthn passkey path.",
+  })
+  @IsOptional()
   @IsString()
-  challengeId: string;
+  challengeId?: string;
 
   @ApiProperty({
+    required: false,
     description:
       "WebAuthn authentication credential from the browser ceremony " +
-      "(navigator.credentials.get / startAuthentication over publicKeyOptions).",
+      "(navigator.credentials.get / startAuthentication over publicKeyOptions). " +
+      "Required for the Tier-1 KMS owner-ceremony path; omitted on the WebAuthn passkey path.",
   })
+  @IsOptional()
   @IsObject()
-  credential: unknown;
+  credential?: unknown;
+
+  @ApiProperty({
+    required: false,
+    type: DeviceWebAuthnDto,
+    description:
+      "Device WebAuthn assertion for the Tier-2/3 WebAuthn cumulative path (challenge = userOpHash). " +
+      "Present iff prepare was called with useWebAuthnPasskey:true (tier >= 2).",
+  })
+  @IsOptional()
+  @IsObject()
+  deviceWebAuthn?: DeviceWebAuthnDto;
 
   @ApiProperty({
     required: false,

--- a/aastar/src/transfer/transfer.service.ts
+++ b/aastar/src/transfer/transfer.service.ts
@@ -49,6 +49,12 @@ export class TransferService {
         paymasterData: dto.paymasterData,
         paymasterTokenAddress,
         useAirAccountTiering: true,
+        // Tier-2/3 device-passkey path (#234): when the frontend's resolveTransfer says
+        // this transfer is Tier-2/3, the on-chain factor is the device WebAuthn passkey
+        // (algId 0x09/0x0a), so there is NO KMS owner ceremony — prepare returns no
+        // challengeId/publicKeyOptions and the browser signs the userOpHash directly.
+        // The SDK rejects this flag for Tier-1, so the frontend only sets it for tier>=2.
+        useWebAuthnPasskey: dto.useWebAuthnPasskey === true,
       });
       // Hand the frontend exactly what the ceremony needs. publicKeyOptions.challenge
       // must be used verbatim (it is the SDK-computed commitment); challengeId is
@@ -77,21 +83,43 @@ export class TransferService {
    */
   async submitPreparedTransfer(userId: string, dto: SubmitTransferDto) {
     this.logger.log(`submitPreparedTransfer: userId=${userId} transferId=${dto.transferId}`);
+    // Tier-3 only: the client already collected the guardian's co-signature over the
+    // prepared userOpHash (self-hosted guardian). Wrap it as the SDK's GuardianSigner —
+    // signMessage returns the pre-collected sig verbatim (the SDK asks for exactly the
+    // userOpHash the guardian signed; no re-derivation drift per #143). Omitted for
+    // Tier 1/2; if a Tier-3 transfer arrives without it, the SDK fail-fasts before gas.
+    const guardianSigner = dto.guardianSignature
+      ? { signMessage: async () => dto.guardianSignature as string }
+      : undefined;
+
     let result: Awaited<ReturnType<typeof this.client.transfers.submitPreparedTransfer>>;
     try {
-      result = await this.client.transfers.submitPreparedTransfer(userId, {
-        transferId: dto.transferId,
-        webAuthnAssertion: { ChallengeId: dto.challengeId, Credential: dto.credential },
-        // Tier 3 only: the client already collected the guardian's co-signature over
-        // the prepared userOpHash (self-hosted guardian). Wrap it as the SDK's
-        // GuardianSigner — signMessage returns the pre-collected sig verbatim (the
-        // SDK asks for exactly the userOpHash the guardian signed; no re-derivation
-        // drift per #143). Omitted for Tier 1/2; if a Tier-3 transfer arrives without
-        // it, the SDK fail-fasts before any gas.
-        ...(dto.guardianSignature
-          ? { guardianSigner: { signMessage: async () => dto.guardianSignature as string } }
-          : {}),
-      });
+      if (dto.deviceWebAuthn) {
+        // Tier-2/3 WebAuthn passkey path (#234): the browser ran ONE
+        // navigator.credentials.get() with challenge = userOpHash. Forward the three
+        // assertion fields verbatim — the frontend already normalised them to the
+        // encodings packWebAuthnBlob expects (authenticatorData/signature as 0x-hex,
+        // clientDataJSON as raw JSON text). The SDK derives the on-chain passkey factor,
+        // fetches + aggregates the DVT BLS co-signatures, and packs the 0x09/0x0a
+        // composite — no KMS owner ceremony, no manual packing here.
+        result = await this.client.transfers.submitPreparedTransfer(userId, {
+          transferId: dto.transferId,
+          deviceWebAuthn: {
+            authenticatorData: dto.deviceWebAuthn.authenticatorData as `0x${string}`,
+            clientDataJSON: dto.deviceWebAuthn.clientDataJSON,
+            signature: dto.deviceWebAuthn.signature as `0x${string}`,
+          },
+          ...(guardianSigner ? { guardianSigner } : {}),
+        });
+      } else {
+        // Tier-1 KMS owner-ceremony path: the credential signed the WYSIWYS commitment
+        // prepareTransfer bound, so the KMS accepts it under strict.
+        result = await this.client.transfers.submitPreparedTransfer(userId, {
+          transferId: dto.transferId,
+          webAuthnAssertion: { ChallengeId: dto.challengeId, Credential: dto.credential },
+          ...(guardianSigner ? { guardianSigner } : {}),
+        });
+      }
     } catch (err: any) {
       // Scheme 2: a DVT node withheld its co-signature on a high-value op pending out-of-band
       // approval. Don't 500 — return a structured pending result so the client can drive the

--- a/aastar/tsconfig.build.json
+++ b/aastar/tsconfig.build.json
@@ -3,8 +3,14 @@
   "compilerOptions": {
     "noEmitOnError": false,
     "paths": {
-      "ox": ["./node_modules/ox/_types/index.d.ts"],
-      "ox/*": ["./node_modules/ox/_types/*.d.ts"],
+      "ox": [
+        "./node_modules/ox/_types/index.d.ts",
+        "../node_modules/ox/_types/index.d.ts"
+      ],
+      "ox/*": [
+        "./node_modules/ox/_types/*.d.ts",
+        "../node_modules/ox/_types/*.d.ts"
+      ],
       "@aastar/sdk/kms": [
         "./node_modules/@aastar/sdk/dist/kms.d.ts",
         "../node_modules/@aastar/sdk/dist/kms.d.ts"

--- a/aastar/tsconfig.json
+++ b/aastar/tsconfig.json
@@ -22,7 +22,12 @@
       "@aastar/sdk/email": [
         "./node_modules/@aastar/sdk/dist/email.d.ts",
         "../node_modules/@aastar/sdk/dist/email.d.ts"
-      ]
+      ],
+      "ox": [
+        "./node_modules/ox/_types/index.d.ts",
+        "../node_modules/ox/_types/index.d.ts"
+      ],
+      "ox/*": ["./node_modules/ox/_types/*", "../node_modules/ox/_types/*"]
     },
     "incremental": true,
     "skipLibCheck": true,

--- a/docs/DEMO-device-passkey-tier3-gasless.md
+++ b/docs/DEMO-device-passkey-tier3-gasless.md
@@ -1,0 +1,74 @@
+# YetAnotherAA · Device-Passkey Tier-3 Gasless Transfer — Live On-Chain Demo
+
+> A real end-to-end run: a user registers with a device passkey (Face ID / fingerprint), gets a
+> KMS-custodied smart account created **at birth** with the passkey + validator wired, and sends
+> **0.051 ETH holding zero ETH for gas** — the Paymaster sponsors gas from community points (aPNTs).
+> Every step below is a **real Sepolia transaction**, verifiable on-chain.
+
+**Network:** Sepolia · **Stack:** `@aastar/sdk@0.34.0` + AirAccount contracts `v0.23.0` + DVT signer network `v1.7.1`
+· **Test:** `aastar-frontend/e2e/transfer-tier3.spec.ts` (Playwright, real browser passkey via CDP virtual authenticator) — **1 passed**.
+
+---
+
+## 🔗 The Tier-3 transfer (the headline transaction)
+
+| | |
+|---|---|
+| **Transaction** | [`0xa275c4aa4870171afaac4e6aa079d99eb6b60e0f34ac330c12915c7ae34e4a94`](https://sepolia.etherscan.io/tx/0xa275c4aa4870171afaac4e6aa079d99eb6b60e0f34ac330c12915c7ae34e4a94) |
+| **UserOp hash** | `0x63b826e6d3b5bf0914144e8271cea3efeb45e7582f6649b53d8c3ad54801d36e` |
+| **Account (sender)** | [`0x4a8B0f971A3D73a8074117dD0d875F85Fd6Aca59`](https://sepolia.etherscan.io/address/0x4a8B0f971A3D73a8074117dD0d875F85Fd6Aca59) — device-passkey account (v0.23.0), `p256KeyX` injected at birth |
+| **Recipient** | [`0x49deFe43E18E1771BB936D32745b91065C2e9Ca6`](https://sepolia.etherscan.io/address/0x49deFe43E18E1771BB936D32745b91065C2e9Ca6) |
+| **Amount** | **0.051 ETH** (> Tier-2 ceiling → Tier-3: passkey + BLS + guardian) |
+| **Status** | `success = true` |
+
+---
+
+## ⛽ Proof it is genuinely gasless
+
+| Evidence | Value |
+|---|---|
+| Account ETH balance | funded **0.08** → after **0.029** = exactly **−0.051** (the transfer value only) |
+| Gas deducted from account | **0 ETH** — if the account had paid gas the balance would be `< 0.029` |
+| `paymaster` field on the UserOp | `0xf3948753ff21D33f6A5f516621FFF245B23efa0e` (non-empty) |
+| `actualGasCost` (paid by the Paymaster, not the account) | `0.000749 ETH` |
+| Recipient received | **0.051 ETH** |
+| Gas funding source | community points (**aPNTs**) pre-deposited into PaymasterV4; the Paymaster pays ETH gas on the user's behalf |
+
+**The user holds zero ETH for gas and still transacts — gas is paid by the Paymaster from aPNTs.** This is the core value of YetAnotherAA.
+
+---
+
+## 🧾 All three UserOps in the run were gasless
+
+The same account also armed its tier limits gaslessly before transferring — every UserOp's gas was sponsored by the Paymaster (`paymaster` non-empty, `success = true`):
+
+| # | Tx | Purpose | actualGasCost (Paymaster-paid) |
+|---|---|---|---|
+| 1 | [`0x99d0eb1d…`](https://sepolia.etherscan.io/tx/0x99d0eb1d8c20532e54d4625c6198162fa4a4200960478ea590084a8686616ab8) | `setTierLimits` (arming) | 0.000349 ETH |
+| 2 | [`0x27fc2b99…`](https://sepolia.etherscan.io/tx/0x27fc2b99f9c534c0274b5b4743c7d77f4762ecccccb77558f17be62ff0239f2e) | `setWeightConfig` (arming) | 0.000337 ETH |
+| 3 | [`0xa275c4aa…`](https://sepolia.etherscan.io/tx/0xa275c4aa4870171afaac4e6aa079d99eb6b60e0f34ac330c12915c7ae34e4a94) | **Tier-3 transfer 0.051 ETH → recipient** | 0.000749 ETH |
+
+---
+
+## 🔐 What made the Tier-3 signature valid
+
+```
+device-passkey account (owner = KMS TEE; device passkey = on-chain P256 factor)
+  → UserOp: execute(recipient, 0.051 ETH)   (guard-wrapped, daily-limit enforced)
+  → device passkey signs userOpHash in the browser (WebAuthn, challenge = userOpHash)
+  → DVT ownerAuth = the device-passkey assertion (tag 0x02); dvt1/2/3.aastar.io each
+      eth_call isValidOwnerAuth → P256-verify against the account's p256KeyX/Y → co-sign
+      (no KMS ceremony needed)
+  → BLS aggregate (≥2 of 3 nodes) + guardian ECDSA co-sign
+  → packCumulativeT3WA (algId 0x0a) → validateUserOp == 0 (ACCEPTED)
+  → Paymaster sponsors gas (aPNTs) → EntryPoint → recipient receives 0.051 ETH
+```
+
+## 🚀 End-to-end flow (all real, no mocks)
+
+1. **Register** with a device passkey (Face ID / fingerprint) — the passkey pubkey `(x,y)` is captured.
+2. **Create account (two-phase, KMS relay):** the KMS owner authorizes a `CREATE_ACCOUNT` digest; a funded backend deployer relays it. The v0.23.0 factory wires the **validator router + owner device passkey at birth** in one tx — no post-deploy setup.
+3. **Arm tier limits** (gasless) — Tier-1/2/3 spending ceilings.
+4. **Tier-3 transfer** (the transaction above) — device passkey + DVT BLS + guardian, gasless.
+
+Reproduce: run the backend (`KMS_ENABLED=true`, funded `DEPLOYER_PRIVATE_KEY`) + frontend, with the KMS board and DVT nodes online, then `npx playwright test e2e/transfer-tier3.spec.ts`.

--- a/docs/regression-v0.22.0-2026-06-30.md
+++ b/docs/regression-v0.22.0-2026-06-30.md
@@ -32,10 +32,14 @@
 | **p256KeyX @birth** | == 传入 passkey ✅(无 setP256Key tx) |
 | DVT 聚合 | dvt1/2/3 registered,≥2/3 BLS 聚合 |
 | 复合签名 | 902 字节(algId 0x0a) |
-| **`validateUserOp(0x0a)`** | **== 0 ✅ ACCEPTED**(链上 WebAuthn 重建 + EIP-7212 P256VERIFY + DVT BLS + guardian)|
+| **`validateUserOp(0x0a)` Tier-3** | **== 0 ✅ ACCEPTED**(链上 WebAuthn 重建 + EIP-7212 P256VERIFY + DVT BLS + guardian)|
+| **`validateUserOp(0x09)` Tier-2** | **== 0 ✅ ACCEPTED**(passkey + DVT BLS,无 guardian;837B;同账户同时 approve 0x09+0x0a)|
 | 负向(篡改 challenge) | ✅ rejected |
 
-→ **passkey-at-birth + Tier-3 复合签名机制,在 v0.22.0/0.30.0 新栈上链上确认无误。**
+最新一跑账户 `0x080C1d8b2965c0796fAF69c54F52B33237aC4765`、deploy tx `0x0b08a2a4a2d34aec11129004fd2887e84a91d5dca458f4d808579c055a7b68c8`。
+
+→ **passkey-at-birth + Tier-2 + Tier-3 cumulative 复合签名机制,在 v0.22.0/0.30.0 新栈上链上确认无误。**
+> Tier-1 = 内联 P256(algId 0x03 / COMBINED_T1 0x06),非 cumulative router 路径,无独立 packer;属基础 passkey 路径,与 T2/T3 复合是两套机制。
 
 ## 已实现的业务流程
 - 账户出生即配 validator + 设备 passkey(一次 tx,无后置引导)— **EOA owner / direct mode 已链上验证**

--- a/docs/regression-v0.22.0-2026-06-30.md
+++ b/docs/regression-v0.22.0-2026-06-30.md
@@ -1,0 +1,54 @@
+# YAA Tier-2/3 device-passkey 回归报告 — v0.22.0 / SDK 0.30.0(2026-06-30,链上真实)
+
+## 版本与依赖(已升最新)
+| 组件 | 版本 | 说明 |
+|---|---|---|
+| 合约 | **v0.22.0** | passkey-at-birth:工厂部署时自动接 validator + 写 owner p256Key |
+| `@aastar/sdk` | **0.30.0** | device-passkey Tier-2/3 prepare/submit + v0.22.0 factory wrapper(已 bump:package.json×2 + lockfile) |
+| viem | 2.43.3 | SDK 内 pin |
+| DVT 节点 | dvt1/2/3.aastar.io | 链上 registered |
+| KMS | kms.aastar.io | healthy, ta_mode real, v0.27.3 |
+
+## 合约 v0.22.0 Sepolia 地址(SDK CANONICAL_ADDRESSES,无硬编码)
+- Factory `0x0eb0E7a61d5D9e03bc3578f8C1b0d9f40cc0a5B9`
+- Impl `0x1cE314101E218D28bb6c6D16d6C259A4a1E67578`
+- Extension `0xF736C229fE6f0cb9C864A4298E2755b7a0A19691`
+- Validator Router `0xfcDfd17a373E037c3F9C8ffE2c781915E7Ae6e11`
+
+## 1. 后端测试套件 ✅
+`npm test -w aastar` → **6 套件 / 41 测试全过**(5.5s)。
+
+## 2. 类型检查 ✅
+`type-check` backend + frontend(0.30.0)→ **0 错**(无 3-参 getAddress 踩雷;ox 0.14.7 类型重定向在)。
+
+## 3. 链上 Tier-3 WebAuthn 复合签名回归(v0.22.0,真实 Sepolia)✅
+`node scripts/test/onchain/tier3-composite.mjs`(仅用已发布 `@aastar/sdk` packers 组装复合签名):
+
+| 项 | 结果 |
+|---|---|
+| 账户(passkey 绑定 salt) | `0xEb4Ce8401Acc72373aA0a5156164B11F5F881b23` |
+| 部署 tx | `0xf3606f757e2e8be79c52287dbcfe22687879c985982a4d3ad3811368c7256418` (success) |
+| **validator @birth** | `0xfcDfd17a373E037c3F9C8ffE2c781915E7Ae6e11` ✅ 工厂 immutable 自动接好(无 setValidator tx) |
+| **p256KeyX @birth** | == 传入 passkey ✅(无 setP256Key tx) |
+| DVT 聚合 | dvt1/2/3 registered,≥2/3 BLS 聚合 |
+| 复合签名 | 902 字节(algId 0x0a) |
+| **`validateUserOp(0x0a)`** | **== 0 ✅ ACCEPTED**(链上 WebAuthn 重建 + EIP-7212 P256VERIFY + DVT BLS + guardian)|
+| 负向(篡改 challenge) | ✅ rejected |
+
+→ **passkey-at-birth + Tier-3 复合签名机制,在 v0.22.0/0.30.0 新栈上链上确认无误。**
+
+## 已实现的业务流程
+- 账户出生即配 validator + 设备 passkey(一次 tx,无后置引导)— **EOA owner / direct mode 已链上验证**
+- 设备 passkey(P256)+ DVT BLS 聚合 + guardian ECDSA 三因子复合 → 链上 ACCEPTED
+- 两阶段转账封装(prepare → 浏览器 passkey challenge=userOpHash → submit,SDK 内部打包,零手工)
+- Paymaster gasless、KMS 托管 owner、tiered 安全(T1 P256 / T2 +BLS / T3 +guardian)
+
+## ⚠️ 唯一未闭环:KMS 托管账户的 passkey-at-birth 创建(relay mode)
+- v0.22.0 的 passkey-at-birth E2E 用 **EOA owner(direct mode,msg.sender==owner)** 验证通过。
+- YAA 生产 owner 是 **KMS TEE**(发不了 raw tx)→ 必须 **relay mode**(KMS EIP-191 签 CREATE_ACCOUNT digest + deployer 代发)。
+- 但 SDK 0.30.0 **没封装** relay 创建:高层 `createAccountWithP256Guardians` 不收 ownerP256X/Y;低层 `createAccount` 的 ownerSig 是不透明入参、无 digest helper;digest 需的 `_getConfigHash` 是合约 internal pure。
+- **已提独立诉求**:aastar-sdk#249(`createAccountWithPasskey(userId,…,{deployerWallet})`)+ airaccount-contract#155(暴露 public digest view)。决策:**等 SDK 封装,不手搓安全 digest**。
+- 影响:真实 KMS 用户从前端"注册→建账户→转账"的端到端,**待 #249 落地**才能跑完。机制本身已全验。
+
+## 结论
+机制层(passkey-at-birth、Tier-3 复合、DVT、gasless)**链上真实验证通过**;唯一缺口是 KMS-relay 账户创建的 SDK 封装(#249),非机制问题。

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.33.2",
+        "@aastar/sdk": "^0.34.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.33.2",
+        "@aastar/sdk": "^0.34.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.33.2.tgz",
-      "integrity": "sha512-vnQ/yjGxil4ZvQJZw+IgyarkpVouiyJBOoVA23pBDlxsutRFoPDwfOmgyWiv4Vn9q2uu9w1Mz5HKsophTcKCKQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.34.0.tgz",
+      "integrity": "sha512-nXx5IBd6r0qylq1pr3Z/HLdktX4JIWCtYWQtrxFvSc9wxTtsqZnD4ai94r5oLeWJA9EYz5Yv/XJMh5gxZZOj1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.29.5",
+        "@aastar/sdk": "^0.29.7",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.29.5",
+        "@aastar/sdk": "^0.29.7",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.5.tgz",
-      "integrity": "sha512-0H+hDo5F+Bd+rKRoMe4x1xVqyZqA9VZ3l4KAhBSJZ7BZ1cr0qRsuCLvuf8IWWODmDLypl5sJCu9z+inZl+s5Pw==",
+      "version": "0.29.7",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.7.tgz",
+      "integrity": "zqc/0apqPzBJiVLrePJRMuZG/O/qm1bnjgA7aKSxFCYjtaGvEp3YtET+I+F2nbeaY6swG6L7Ee0BdCpYXCfQKg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.32.0",
+        "@aastar/sdk": "^0.32.1",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.32.0",
+        "@aastar/sdk": "^0.32.1",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.32.0.tgz",
-      "integrity": "sha512-KWJ1ZY9J9rtF7MFMgqmpA5olSseSaWUGovjc3vBEj/gAjuRCubOkHtrnFex4ZoZzeOV4XM1pBHpRAf5kFNZvEA==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.32.1.tgz",
+      "integrity": "sha512-4hm+o3jrJBdBfjbUKKiyrPVMtn6jPV+341i7VvUjP/zxBFZk/4diCMAupNxDT+E2hoKf+Bv1pC2lABEXweYF/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.29.7",
+        "@aastar/sdk": "^0.30.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.29.7",
+        "@aastar/sdk": "^0.30.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.29.7",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.29.7.tgz",
-      "integrity": "zqc/0apqPzBJiVLrePJRMuZG/O/qm1bnjgA7aKSxFCYjtaGvEp3YtET+I+F2nbeaY6swG6L7Ee0BdCpYXCfQKg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.30.0.tgz",
+      "integrity": "sha512-Jjz/rSxB4cFqPMnGMptfw/xsmRQcRLk8Q/Bf/j5E3vhui2tA1Nhx5SYaDLTe8wL66SDW+WQbYbCu1AbG8a1gSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.30.0",
+        "@aastar/sdk": "^0.32.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.30.0",
+        "@aastar/sdk": "^0.32.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.30.0.tgz",
-      "integrity": "sha512-Jjz/rSxB4cFqPMnGMptfw/xsmRQcRLk8Q/Bf/j5E3vhui2tA1Nhx5SYaDLTe8wL66SDW+WQbYbCu1AbG8a1gSA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.32.0.tgz",
+      "integrity": "sha512-KWJ1ZY9J9rtF7MFMgqmpA5olSseSaWUGovjc3vBEj/gAjuRCubOkHtrnFex4ZoZzeOV4XM1pBHpRAf5kFNZvEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.32.1",
+        "@aastar/sdk": "^0.33.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.32.1",
+        "@aastar/sdk": "^0.33.0",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.32.1.tgz",
-      "integrity": "sha512-4hm+o3jrJBdBfjbUKKiyrPVMtn6jPV+341i7VvUjP/zxBFZk/4diCMAupNxDT+E2hoKf+Bv1pC2lABEXweYF/Q==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.33.0.tgz",
+      "integrity": "sha512-PdmvtsayxEuvB96xWkzzPBQCpdC2/1X05HzNRF06nG9y5UxW9S2Jg0pjKnL4xfU+Ww4GjAKuwCLaQb3Xdhv0JQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aastar/sdk": "^0.33.0",
+        "@aastar/sdk": "^0.33.2",
         "@nestjs/common": "^11.1.6",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.18",
@@ -82,7 +82,7 @@
     "aastar-frontend": {
       "version": "0.1.0",
       "dependencies": {
-        "@aastar/sdk": "^0.33.0",
+        "@aastar/sdk": "^0.33.2",
         "@headlessui/react": "^2.2.10",
         "@heroicons/react": "^2.2.0",
         "@simplewebauthn/browser": "^13.3.0",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@aastar/sdk": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.33.0.tgz",
-      "integrity": "sha512-PdmvtsayxEuvB96xWkzzPBQCpdC2/1X05HzNRF06nG9y5UxW9S2Jg0pjKnL4xfU+Ww4GjAKuwCLaQb3Xdhv0JQ==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmmirror.com/@aastar/sdk/-/sdk-0.33.2.tgz",
+      "integrity": "sha512-vnQ/yjGxil4ZvQJZw+IgyarkpVouiyJBOoVA23pBDlxsutRFoPDwfOmgyWiv4Vn9q2uu9w1Mz5HKsophTcKCKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",

--- a/scripts/test/onchain/tier3-composite.mjs
+++ b/scripts/test/onchain/tier3-composite.mjs
@@ -62,8 +62,10 @@ import {
 } from "@aastar/sdk/core";
 import {
   packWebAuthnBlob,
+  packCumulativeT2WA,
   packCumulativeT3WA,
   packBlsPayload,
+  ALG_CUMULATIVE_T2_WA,
   ALG_CUMULATIVE_T3_WA,
 } from "@aastar/sdk/kms";
 
@@ -159,7 +161,7 @@ async function main() {
   const config = buildInitConfig({
     guardians: [{ ecdsa: guardian.address }],
     dailyLimit: 10n ** 18n,
-    approvedAlgIds: [ALG_CUMULATIVE_T3_WA],
+    approvedAlgIds: [ALG_CUMULATIVE_T2_WA, ALG_CUMULATIVE_T3_WA], // Tier-2 (passkey+BLS) + Tier-3 (+guardian)
   });
   const account = await airAccountFactoryActions(FACTORY)(pc).getAddress({
     owner: owner.address,
@@ -309,6 +311,15 @@ async function main() {
     `\n[5] validateUserOp(0x0a WebAuthn composite) = ${accepted} -> ${accepted === 0n ? "0 ✅ ACCEPTED" : "❌ REJECTED"}`
   );
 
+  // ── Tier-2 (algId 0x09): passkey + DVT BLS, NO guardian — same account approves both ────────
+  const compositeT2 = packCumulativeT2WA(waBlob, blsPayload);
+  const acceptedT2 = await validate(compositeT2);
+  console.log(
+    `[5b] validateUserOp(0x09 Tier-2 = passkey+BLS, no guardian) = ${(compositeT2.length - 2) / 2}B -> ${
+      acceptedT2 === 0n ? "0 ✅ ACCEPTED" : "❌ REJECTED"
+    }`
+  );
+
   // ── Negative: an assertion over a DIFFERENT hash must be rejected ───────────────────────────
   let negResult = "sdk-rejected";
   try {
@@ -328,13 +339,15 @@ async function main() {
   console.log(`│ userOpHash     : ${userOpHash}`);
   console.log(`│ waBlob bytes   : ${(waBlob.length - 2) / 2}`);
   console.log(`│ composite bytes: ${(composite.length - 2) / 2} (algId 0x0a)`);
-  console.log(`│ validate(WA)   : ${accepted} ${accepted === 0n ? "= 0 ✅ ACCEPTED" : "❌"}`);
+  console.log(`│ validate(T3 0x0a): ${accepted} ${accepted === 0n ? "= 0 ✅ ACCEPTED" : "❌"}`);
+  console.log(`│ validate(T2 0x09): ${acceptedT2} ${acceptedT2 === 0n ? "= 0 ✅ ACCEPTED" : "❌"}`);
   console.log(`│ negative       : ${negResult} ${negResult !== 0n ? "✅ rejected" : "❌"}`);
   console.log("└──────────────────────────────────────────────────────────────────────────");
 
-  if (accepted !== 0n) throw new Error("FAIL: WebAuthn 0x0a composite was NOT accepted on-chain");
+  if (accepted !== 0n) throw new Error("FAIL: WebAuthn 0x0a (Tier-3) composite was NOT accepted on-chain");
+  if (acceptedT2 !== 0n) throw new Error("FAIL: WebAuthn 0x09 (Tier-2) composite was NOT accepted on-chain");
   if (negResult === 0n) throw new Error("FAIL: wrong-challenge negative was accepted");
-  console.log("\n🎉 PASS — Tier-3 WebAuthn composite ACCEPTED on-chain; wrong-challenge rejected.");
+  console.log("\n🎉 PASS — Tier-2 (0x09) + Tier-3 (0x0a) WebAuthn composites ACCEPTED on-chain; wrong-challenge rejected.");
 }
 
 main().catch(e => {

--- a/scripts/test/onchain/tier3-composite.mjs
+++ b/scripts/test/onchain/tier3-composite.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 /**
- * Tier-3 WebAuthn cumulative composite (algId 0x0a) — on-chain regression on Sepolia (v0.21.0).
+ * Tier-3 WebAuthn cumulative composite (algId 0x0a) — on-chain regression on Sepolia (v0.22.0).
  *
  * YAA-side port of the SDK's authoritative reference
  * (`tier3-webauthn-composite-e2e.ts`). Proves YAA can assemble — using ONLY the published
  * `@aastar/sdk` packers — a Tier-3 composite signature (on-chain WebAuthn P256 passkey + DVT BLS
- * aggregate + guardian ECDSA) that the deployed v0.21.0 AirAccount ACCEPTS (validateUserOp == 0).
+ * aggregate + guardian ECDSA) that the deployed v0.22.0 AirAccount ACCEPTS (validateUserOp == 0).
  *
  * The "device passkey" is simulated with a software P-256 key (registered via setP256Key) and a
  * SYNTHETIC WebAuthn assertion built exactly as `navigator.credentials.get()` produces it:
@@ -13,7 +13,7 @@
  *   - the key signs sha256(authenticatorData ‖ sha256(clientDataJSON))  (ECDSA-SHA256, prehash=false)
  * so the on-chain WebAuthn reconstruction + P256VERIFY (0x100 precompile) passes — no browser needed.
  *
- * Flow (all live): deploy via the v0.21.0 factory (approvedAlgIds=[0x0a]) → setValidator + setP256Key
+ * Flow (all live): deploy via the v0.22.0 factory (approvedAlgIds=[0x0a]) → validator + passkey AT BIRTH
  * → build userOp + userOpHash → WebAuthn assertion → packWebAuthnBlob → DVT BLS aggregate → guardian
  * → packCumulativeT3WA → eth_call validateUserOp == 0. Negative: a tampered challenge is rejected.
  *
@@ -126,7 +126,7 @@ function eip2537ToG2(sig256) {
 
 async function main() {
   console.log("═══════════════════════════════════════════════════════════════════════════");
-  console.log(" YAA Tier-3 WebAuthn cumulative (0x0a) — passkey + DVT BLS + guardian, Sepolia v0.21.0");
+  console.log(" YAA Tier-3 WebAuthn cumulative (0x0a) — passkey + DVT BLS + guardian, Sepolia v0.22.0");
   console.log("═══════════════════════════════════════════════════════════════════════════");
 
   const rpcUrl = env("ETH_RPC_URL");
@@ -137,7 +137,7 @@ async function main() {
 
   applyConfig({ chainId: CHAIN_ID });
   const C = CANONICAL_ADDRESSES[CHAIN_ID];
-  const FACTORY = getAddress(C.airAccountFactoryV7); // v0.21.0
+  const FACTORY = getAddress(C.airAccountFactoryV7); // v0.22.0 (passkey-at-birth)
   const ENTRY_POINT = getAddress(C.entryPoint);
   const VALIDATOR_ROUTER = getAddress(C.aaStarValidator);
   const BLS_VERIFIER = getAddress(C.aaStarBLSAlgorithm);
@@ -153,7 +153,7 @@ async function main() {
   const p256Y = norm(Buffer.from(p256Pub.slice(33, 65)).toString("hex"));
   const guardian = privateKeyToAccount(GUARDIAN_PK);
   const guardianWallet = createWalletClient({ account: guardian, chain: sepolia, transport });
-  console.log(`\n[0a] factory(v0.21.0)=${FACTORY}  owner=${owner.address}  guardian=${guardian.address}`);
+  console.log(`\n[0a] factory(v0.22.0)=${FACTORY}  owner=${owner.address}  guardian=${guardian.address}`);
 
   // ── Deploy a fresh account approving algId 0x0a, with the guardian ──────────────────────────
   const config = buildInitConfig({
@@ -165,6 +165,8 @@ async function main() {
     owner: owner.address,
     salt: SALT,
     config,
+    ownerP256X: p256X,
+    ownerP256Y: p256Y,
   });
   console.log(`[0b] account = ${account}`);
   const code = await pc.getCode({ address: account });
@@ -175,6 +177,8 @@ async function main() {
       owner: owner.address,
       salt: SALT,
       config,
+      ownerP256X: p256X,
+      ownerP256Y: p256Y,
       account: owner,
     });
     const r = await pc.waitForTransactionReceipt({ hash: tx, timeout: 120_000, pollingInterval: 3_000 });
@@ -182,43 +186,23 @@ async function main() {
     if (r.status !== "success") throw new Error("deploy reverted");
   }
 
-  // ── setValidator (set-once) + register the passkey via setP256Key ───────────────────────────
+  // ── v0.22.0: validator + passkey are wired AT BIRTH (no setValidator/setP256Key tx) ──────────
   const curValidator = await pc.readContract({
     address: account,
     abi: AAStarAirAccountV7ABI,
     functionName: "validator",
   });
-  if (curValidator === "0x0000000000000000000000000000000000000000") {
-    const tx = await walletClient.writeContract({
-      address: account,
-      abi: AAStarAirAccountV7ABI,
-      functionName: "setValidator",
-      args: [VALIDATOR_ROUTER],
-      chain: sepolia,
-    });
-    await pc.waitForTransactionReceipt({ hash: tx, timeout: 120_000, pollingInterval: 3_000 });
-    console.log(`[0c] setValidator ✓`);
-  } else {
-    console.log(`[0c] validator already set`);
-  }
+  if (curValidator === "0x0000000000000000000000000000000000000000")
+    throw new Error("v0.22.0: validator not auto-wired at birth");
+  console.log(`[0c] validator @birth = ${curValidator} ✓ (auto-wired from factory immutable)`);
   const curX = await pc.readContract({
     address: account,
     abi: AAStarAirAccountV7ABI,
     functionName: "p256KeyX",
   });
-  if (curX === ZERO_BYTES32) {
-    const tx = await walletClient.writeContract({
-      address: account,
-      abi: AAStarAirAccountV7ABI,
-      functionName: "setP256Key",
-      args: [p256X, p256Y],
-      chain: sepolia,
-    });
-    await pc.waitForTransactionReceipt({ hash: tx, timeout: 120_000, pollingInterval: 3_000 });
-    console.log(`     setP256Key ✓ (x=${p256X.slice(0, 14)}…)`);
-  } else {
-    console.log(`     p256Key already set`);
-  }
+  if (curX.toLowerCase() !== p256X.toLowerCase())
+    throw new Error(`v0.22.0: passkey not injected at birth (p256KeyX ${curX} != supplied ${p256X})`);
+  console.log(`     p256KeyX @birth = ${curX.slice(0, 14)}… ✓ (== supplied passkey)`);
 
   // ── Build userOp + userOpHash ───────────────────────────────────────────────────────────────
   const nonce = await entryPointActions(ENTRY_POINT)(pc).getNonce({ sender: account, key: 0n });
@@ -338,8 +322,8 @@ async function main() {
     `[6] negative (challenge != userOpHash) -> ${negResult === 0n ? "❌ accepted (BAD)" : `✅ rejected (${negResult})`}`
   );
 
-  console.log("\n┌─────────────── EVIDENCE (Tier-3 WebAuthn composite, v0.21.0) ───────────────");
-  console.log(`│ factory        : ${FACTORY} (v0.21.0)`);
+  console.log("\n┌─────────────── EVIDENCE (Tier-3 WebAuthn composite, v0.22.0) ───────────────");
+  console.log(`│ factory        : ${FACTORY} (v0.22.0)`);
   console.log(`│ account        : ${account}`);
   console.log(`│ userOpHash     : ${userOpHash}`);
   console.log(`│ waBlob bytes   : ${(waBlob.length - 2) / 2}`);


### PR DESCRIPTION
## Tier-3 production WebAuthn + subdomain deploy fixes + default paymaster

Takes the **device-passkey Tier-2/3 gasless transfer** (#234) to a real subdomain
deployment (`cos72.aastar.io`) and adds the fixes it needed to actually run there,
plus a persistent default-paymaster UX with type-aware prerequisite hints.

Feature background (already on this branch): the device-passkey composite runs one
browser ceremony with `challenge = userOpHash`, and the SDK (0.29.7) derives the passkey
factor + DVT BLS and packs the 0x09/0x0a signature internally — byte-identical to the
on-chain-verified regression #398.

### Latest commits in this PR

| Commit | What |
|---|---|
| `fix(webauthn)` | WebAuthn `rpId` = **registrable domain** (`aastar.io`), not `window.location.hostname`. Client ceremonies (transfer Tier-2/3 assertion, DVT confirmation, p256-guardian register+assert) were hardcoding the full host → on a subdomain that yields `cos72.aastar.io`, which fails the TA's rpId-hash check (TA anchors at `aastar.io`). New `lib/webauthn-rp.ts` (`NEXT_PUBLIC_RP_ID` override; localhost/IP passthrough). |
| `fix(api)` | Commit the **#234 device-passkey API types** (`useWebAuthnPasskey`, `deviceWebAuthn`, optional `challengeId/publicKeyOptions`, `passkeyX/Y`, `ecdsaGuardians`) that were left uncommitted in the working tree — `ignoreBuildErrors:true` masked it in `next build`, but `tsc` (CI type-check) failed at `transfer/page.tsx` without them. Type-only. |
| `feat(paymaster)` default | Client-side **persistent default paymaster** (localStorage, per device). ☆ on the Paymaster page sets/unsets it; the transfer page auto-enables sponsorship + pre-selects it (once, on mount). |
| `feat(paymaster)` hints | **Detect** the selected/default paymaster's type and show its **prerequisite**. Corrects the model in preset copy: PaymasterV4 is a *template* (any community can deploy its own via the factory; the shipped one is the AAStar community instance, pay with aPNTs), and SuperPaymaster is one shared contract accepting *any* community's xPNTs but needs joining a community + holding its points. |

### Migration / behavior notes

- **rpId change is a behavior change for existing credentials.** Any WebAuthn credential previously registered under a *full-host* rpId (e.g. a guardian passkey created on a subdomain via the old `rp.id = window.location.hostname`) will no longer verify (assertion now uses `aastar.io`) and must be **re-registered**. Device passkeys registered via KMS options are unaffected (KMS dev-rpid board resolves `aastar.io` for `*.aastar.io`).
- **Default paymaster auto-enables "Use Paymaster"** on the transfer page when set — opt-in (only if the user sets a default), per-device (localStorage, not per-account).
- **Setting a non-PMv4 paymaster as default pre-selects it but doesn't guarantee sponsorship**: the backend only appends the aPNTs gas token for PaymasterV4; SuperPaymaster / custom paymasters still need their own prerequisites (community membership, xPNTs, deposit) — surfaced by the new hints.

### Quality gates (committed tree)

- `tsc --noEmit` frontend **0 errors** (was 1 before the api.ts fix), backend **0 errors**
- eslint `--max-warnings 0` ✅ · `next build` ✅ · backend `tsc` build ✅
- 14/14 pure-logic tests for `webauthnRpId()` (subdomain/apex/localhost/IP/override) and default-paymaster persistence (case-insensitive)
- Live smoke on `cos72.aastar.io`: `/transfer`, `/paymaster` → 200

### Codex review — PASS (3 rounds)

Tier-1 Codex review, iterated to approval:
- **R1 (FAIL)** → hardened `webauthnRpId()` to a public-suffix-safe deployment-domain list (was naive last-two-labels); scoped the default-paymaster localStorage key by account address (was device-global).
- **R2 (CONDITIONAL PASS)** → mapped all loopback rpId forms to `localhost` (dropped the invalid bracketed-IPv6 passthrough); made the transfer default-apply ref track the account it applied for (mid-session account switch now re-applies).
- **R3 (PASS)** → both must-fixes verified resolved, no new issues. Only residual: non-loopback LAN-IP dev has no valid WebAuthn rpId (documented, dev-only).

**Follow-up items (R3's non-blocking list) — now resolved in `59a38c8`:**
- `co.uk`-style fallback: unconfigured domains return the full host (never a naive last-two-labels guess that could yield a public suffix).
- `api.ts` discriminated union: `transferAPI.submit` is now `credential` XOR `deviceWebAuthn` (rejects submitting neither); existing KMS callers unaffected.
- Credential re-registration UX: passkey `NotAllowedError` / `SecurityError` now give actionable "re-register on this domain" guidance instead of a bare cancel/security message.
