### PR TITLE
chore(format): prettier unformatted workspace files (unblock CI Code Quality)

### DIFF
--- a/aastar-frontend/app/transfer/page.tsx
+++ b/aastar-frontend/app/transfer/page.tsx
@@ -1452,9 +1452,9 @@ export default function TransferPage() {
                                 if (preset?.requiresCommunity) {
                                   return (
                                     <div className="p-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 rounded-xl text-xs text-amber-800 dark:text-amber-300">
-                                      ⚠️ {preset.name} pays gas with {preset.gasToken}. You must join
-                                      a community and hold its xPNTs first — otherwise sponsorship
-                                      will be rejected on submit.
+                                      ⚠️ {preset.name} pays gas with {preset.gasToken}. You must
+                                      join a community and hold its xPNTs first — otherwise
+                                      sponsorship will be rejected on submit.
                                     </div>
                                   );
                                 }
@@ -1463,7 +1463,8 @@ export default function TransferPage() {
                                     <div className="p-2 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-300 dark:border-emerald-700 rounded-xl text-xs text-emerald-800 dark:text-emerald-300">
                                       ✅ {preset.name} — pay gas with {preset.gasToken}. PaymasterV4
                                       is a template (this is the AAStar community instance; any
-                                      community can deploy its own). Make sure you hold {preset.gasToken}.
+                                      community can deploy its own). Make sure you hold{" "}
+                                      {preset.gasToken}.
                                     </div>
                                   );
                                 }

--- a/aastar-frontend/e2e/transfer-tier3.spec.ts
+++ b/aastar-frontend/e2e/transfer-tier3.spec.ts
@@ -129,7 +129,10 @@ test("XFER-T3: Tier-3 transfer with guardian co-sign (passkey + BLS + guardian)"
       rpId: o.rpId,
       timeout: o.timeout,
       userVerification: o.userVerification,
-      allowCredentials: (o.allowCredentials || []).map((c: any) => ({ ...c, id: b64urlToBuf(c.id) })),
+      allowCredentials: (o.allowCredentials || []).map((c: any) => ({
+        ...c,
+        id: b64urlToBuf(c.id),
+      })),
     };
     const cred: any = await navigator.credentials.get({ publicKey });
     const r = cred.response;

--- a/aastar-frontend/lib/default-paymaster.ts
+++ b/aastar-frontend/lib/default-paymaster.ts
@@ -44,7 +44,10 @@ export function clearDefaultPaymaster(account?: string | null): void {
   }
 }
 
-export function isDefaultPaymaster(address: string | null | undefined, account?: string | null): boolean {
+export function isDefaultPaymaster(
+  address: string | null | undefined,
+  account?: string | null
+): boolean {
   if (!address) return false;
   return getDefaultPaymaster(account) === address.toLowerCase();
 }


### PR DESCRIPTION
Makes CI **Code Quality** green. `format:check` was failing on three `aastar-frontend` files — `app/transfer/page.tsx`, `lib/default-paymaster.ts` (formatting misses from #399) and `e2e/transfer-tier3.spec.ts` (pre-existing). Ran `prettier --write` with the exact CI scope; both workspaces' `format:check` now pass.

No logic change (whitespace/wrapping only); frontend type-check + lint green. Backend `src` was already clean. Root-level docs formatting debt is intentionally out of scope — CI Code Quality only checks `aastar/src/**/*.ts` + `aastar-frontend/**`, not repo-root docs.