### PR TITLE
fix(operator): operator/status no longer 500s on missing/invalid address

### DIFF
--- a/aastar/src/operator/operator.controller.ts
+++ b/aastar/src/operator/operator.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Query, UseGuards, Request } from "@nestjs/common";
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 import { OperatorService } from "./operator.service";
+import { isAddress } from "viem";
 import type { Address } from "viem";
 
 @ApiTags("operator")
@@ -31,13 +32,20 @@ export class OperatorController {
 
   @Get("status")
   @ApiOperation({ summary: "Get operator status for a given address" })
-  @ApiQuery({ name: "address", required: true })
-  async getStatus(@Query("address") address: string) {
+  @ApiQuery({ name: "address", required: false })
+  async getStatus(@Query("address") address?: string) {
+    // Missing / malformed address is a valid "not an operator" query, not a 500:
+    // passing undefined to the contract's hasRole(user) reverts. Return an empty,
+    // unregistered status instead.
+    if (!address || !isAddress(address)) {
+      return { address: address ?? null, registered: false, spoStatus: null, v4Status: null };
+    }
     const [spoStatus, v4Status] = await Promise.all([
       this.operatorService.getSPOStatus(address as Address),
       this.operatorService.getV4PaymasterStatus(address as Address),
     ]);
-    return { address, spoStatus, v4Status };
+    const registered = !!(spoStatus?.hasRole || v4Status?.hasRole);
+    return { address, registered, spoStatus, v4Status };
   }
 
   // ── JWT-Protected Endpoints ──────────────────────────────────────────────────

--- a/aastar/src/operator/operator.service.ts
+++ b/aastar/src/operator/operator.service.ts
@@ -127,34 +127,40 @@ export class OperatorService implements OnModuleInit {
     balance: string;
     hasRole: boolean;
   }> {
-    const factoryAbi = parseAbi([
-      "function getPaymasterByOperator(address) view returns (address)",
-    ]);
+    try {
+      const factoryAbi = parseAbi([
+        "function getPaymasterByOperator(address) view returns (address)",
+      ]);
 
-    const r = registryActions(this.registryAddress)(this.publicClient);
-    const [hasRole, pmAddr] = await Promise.all([
-      r.hasRole({ roleId: ROLE_PAYMASTER_SUPER, user: address }),
-      this.publicClient
-        .readContract({
-          address: this.paymasterFactoryAddress,
-          abi: factoryAbi,
-          functionName: "getPaymasterByOperator",
-          args: [address],
-        })
-        .catch(() => null),
-    ]);
+      const r = registryActions(this.registryAddress)(this.publicClient);
+      const [hasRole, pmAddr] = await Promise.all([
+        r.hasRole({ roleId: ROLE_PAYMASTER_SUPER, user: address }),
+        this.publicClient
+          .readContract({
+            address: this.paymasterFactoryAddress,
+            abi: factoryAbi,
+            functionName: "getPaymasterByOperator",
+            args: [address],
+          })
+          .catch(() => null),
+      ]);
 
-    const zeroAddr = "0x0000000000000000000000000000000000000000";
-    if (!pmAddr || pmAddr === zeroAddr) {
-      return { paymasterAddress: null, balance: "0", hasRole };
+      const zeroAddr = "0x0000000000000000000000000000000000000000";
+      if (!pmAddr || pmAddr === zeroAddr) {
+        return { paymasterAddress: null, balance: "0", hasRole };
+      }
+
+      const balance = await this.publicClient.getBalance({ address: pmAddr });
+      return {
+        paymasterAddress: pmAddr as Address,
+        balance: formatUnits(balance, 18),
+        hasRole,
+      };
+    } catch {
+      // Bad/undefined address or RPC/contract revert → treat as "not a V4 operator"
+      // rather than propagating a 500 (mirrors getSPOStatus's null-on-error).
+      return { paymasterAddress: null, balance: "0", hasRole: false };
     }
-
-    const balance = await this.publicClient.getBalance({ address: pmAddr });
-    return {
-      paymasterAddress: pmAddr as Address,
-      balance: formatUnits(balance, 18),
-      hasRole,
-    };
   }
 
   // ── GToken Balance ───────────────────────────────────────────────────────────

--- a/aastar/test/api.e2e-spec.ts
+++ b/aastar/test/api.e2e-spec.ts
@@ -50,11 +50,25 @@ describe("API e2e (guards + public reads)", () => {
     });
   });
 
-  // NOTE: the public read endpoints (community/list, operator/status, admin/*,
-  // registry/info) all do live on-chain reads via the SDK, which makes them
+  // NOTE: the public read endpoints (community/list, operator/status w/ address,
+  // admin/*, registry/info) all do live on-chain reads via the SDK, which makes them
   // RPC-dependent and flaky under e2e load (Infura rate-limit / transient
-  // "fetch failed"). They are NOT asserted here — covered by L1 (direct viem)
-  // or against a warm running server. Findings recorded in docs/TEST_RESULTS.md
-  // (S2), including a real bug: GET /operator/status → 500 because the public
-  // endpoint calls hasRole(user) with no authenticated caller (user=undefined).
+  // "fetch failed"). Those are NOT asserted here — covered by L1 (direct viem) or a
+  // warm running server. See docs/TEST_RESULTS.md (S2).
+
+  // Regression (deterministic, no RPC): GET /operator/status with a missing/invalid
+  // address used to 500 (it called hasRole(user=undefined)). The controller now guards
+  // and returns 200 + an unregistered status BEFORE any chain read.
+  describe("GET /operator/status tolerates a missing/invalid address (was 500)", () => {
+    it("returns 200 + unregistered when address is absent", async () => {
+      const res = await get("/operator/status");
+      expect(res.status).toBe(200);
+      expect((await res.json()).registered).toBe(false);
+    });
+    it("returns 200 + unregistered for a malformed address", async () => {
+      const res = await get("/operator/status?address=notanaddress");
+      expect(res.status).toBe(200);
+      expect((await res.json()).registered).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
**beta-pre #2.** `GET /operator/status` called `hasRole(user=undefined)` when no address was supplied → contract revert → **500**. Now the controller validates the address (viem `isAddress`) and returns **200 + unregistered status** before any chain read; `getV4PaymasterStatus` gets a try/catch (like `getSPOStatus`) so a valid-but-reverting address degrades to `{hasRole:false}` instead of 500.

Deterministic e2e regression added (no RPC): missing + malformed address → 200 + `registered:false` (2 passed). tsc/lint/build green. Fixes `LAUNCH_READINESS_PLAN.md` step 3.