### PR TITLE
chore(ops): service liveness monitor (Telegram) + warn-log getV4PaymasterStatus

### DIFF
--- a/aastar/src/operator/operator.service.ts
+++ b/aastar/src/operator/operator.service.ts
@@ -156,9 +156,13 @@ export class OperatorService implements OnModuleInit {
         balance: formatUnits(balance, 18),
         hasRole,
       };
-    } catch {
+    } catch (err) {
       // Bad/undefined address or RPC/contract revert → treat as "not a V4 operator"
-      // rather than propagating a 500 (mirrors getSPOStatus's null-on-error).
+      // rather than propagating a 500 (mirrors getSPOStatus's null-on-error). Warn so a
+      // real RPC/config problem is still visible (not silently swallowed). PR #403 review.
+      this.logger.warn(
+        `getV4PaymasterStatus failed for ${address}: ${(err as Error)?.message ?? err}`
+      );
       return { paymasterAddress: null, balance: "0", hasRole: false };
     }
   }

--- a/scripts/ops/io.aastar.yaa-monitor.plist
+++ b/scripts/ops/io.aastar.yaa-monitor.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- YAA liveness monitor. Install:
+       cp scripts/ops/io.aastar.yaa-monitor.plist ~/Library/LaunchAgents/
+       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/io.aastar.yaa-monitor.plist
+     Runs yaa-liveness.sh every 60s; alerts on state change via Telegram (creds from aastar/.env). -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.aastar.yaa-monitor</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/jason/Dev/aastar/YetAnotherAA/scripts/ops/yaa-liveness.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>60</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/jason/Library/Logs/yaa-monitor.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/jason/Library/Logs/yaa-monitor.launchd.log</string>
+</dict>
+</plist>

--- a/scripts/ops/yaa-liveness.sh
+++ b/scripts/ops/yaa-liveness.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# YAA liveness monitor — checks the cos72 stack (frontend/backend/tunnel) + KMS and alerts
+# on STATE CHANGE (up→down / down→up) via Telegram, so a beta running on one laptop +
+# launchd isn't silently down. Run periodically via launchd (io.aastar.yaa-monitor.plist).
+#
+# Telegram creds are read from aastar/.env at runtime (TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID)
+# — never hardcoded/committed. If absent, it logs only. Alerts fire only on transitions
+# (state files) so a persistent outage doesn't spam every interval.
+set -uo pipefail
+
+REPO="${YAA_REPO:-/Users/jason/Dev/aastar/YetAnotherAA}"
+ENV_FILE="$REPO/aastar/.env"
+STATE_DIR="${YAA_MONITOR_STATE:-$HOME/.yaa-monitor}"
+LOG="${YAA_MONITOR_LOG:-$HOME/Library/Logs/yaa-monitor.log}"
+mkdir -p "$STATE_DIR" "$(dirname "$LOG")"
+
+BOT="" CHAT=""
+if [ -f "$ENV_FILE" ]; then
+  BOT=$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d "\"' \r")
+  CHAT=$(grep -E '^TELEGRAM_CHAT_ID=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d "\"' \r")
+fi
+
+ts() { date "+%Y-%m-%d %H:%M:%S"; }
+
+alert() { # $1 = message
+  echo "$(ts) ALERT: $1" >>"$LOG"
+  if [ -n "$BOT" ] && [ -n "$CHAT" ]; then
+    curl -s --max-time 10 "https://api.telegram.org/bot${BOT}/sendMessage" \
+      --data-urlencode "chat_id=${CHAT}" \
+      --data-urlencode "text=🖥️ YAA monitor: $1" >/dev/null 2>&1 || true
+  fi
+}
+
+check() { # $1 name, $2 url
+  local name="$1" url="$2" code now prev sf
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 12 "$url" 2>/dev/null)
+  now="ok"; [ "$code" = "200" ] || now="fail"
+  sf="$STATE_DIR/${name}.state"
+  prev=$(cat "$sf" 2>/dev/null || echo "unknown")
+  echo "$(ts) ${name} -> ${code} (${now})" >>"$LOG"
+  if [ "$now" != "$prev" ]; then
+    if [ "$now" = "fail" ]; then
+      alert "${name} DOWN (http=${code}) ${url}"
+    elif [ "$prev" = "fail" ]; then
+      alert "${name} recovered (http=${code})"
+    fi
+    echo "$now" >"$sf"
+  fi
+}
+
+check "frontend-5173" "http://localhost:5173"
+check "backend-health" "http://localhost:3000/api/v1/health"
+check "cos72-external" "https://cos72.aastar.io"
+check "kms-health" "https://kms.aastar.io/health"


### PR DESCRIPTION
**beta-pre #6 (monitoring)** + the **#403** non-blocking follow-up.

- `scripts/ops/yaa-liveness.sh`: checks frontend :5173, backend `/api/v1/health`, **cos72 external** (tunnel+edge), and **KMS /health**; alerts **only on state change** (up↔down) via **Telegram** (creds read from `aastar/.env` at runtime — never committed; per-check state files prevent spam). Logs to `~/Library/Logs/yaa-monitor.log`.
- `scripts/ops/io.aastar.yaa-monitor.plist`: launchd agent, `StartInterval` 60s (install notes in the plist comment).
- `operator.service.getV4PaymasterStatus`: catch now `logger.warn`s the error (was silent) — #403 review suggestion.

Verified: first run all 4 → 200, no false alert; tsc/lint/build green; operator/status e2e regression still passes. Done in a git worktree. After merge I'll install the launchd monitor on the cos72 host.