### PR TITLE
feat(config): config center on master — self-hostable endpoints (decentralization)

### DIFF
--- a/aastar-frontend/app/settings/page.tsx
+++ b/aastar-frontend/app/settings/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Layout from "@/components/Layout";
+import toast from "react-hot-toast";
+import {
+  getApiKey,
+  setApiKey,
+  clearApiKey,
+  getKmsUrl,
+  setKmsUrl,
+  getBundlerUrl,
+  setBundlerUrl,
+  getRpcUrl,
+  setRpcUrl,
+  getRelayUrl,
+  setRelayUrl,
+} from "@/lib/api-key-store";
+import { kmsBaseUrl, isDirectKmsReady, pingKms } from "@/lib/kms-client";
+
+export default function SettingsPage() {
+  const [apiKey, setApiKeyInput] = useState("");
+  const [kmsUrl, setKmsUrlInput] = useState("");
+  const [bundlerUrl, setBundlerUrlInput] = useState("");
+  const [rpcUrl, setRpcUrlInput] = useState("");
+  const [relayUrl, setRelayUrlInput] = useState("");
+  const [ready, setReady] = useState(false);
+  const [resolvedKms, setResolvedKms] = useState("");
+  const [pinging, setPinging] = useState(false);
+  const [pingResult, setPingResult] = useState<string | null>(null);
+
+  useEffect(() => {
+    setApiKeyInput(getApiKey() ?? "");
+    setKmsUrlInput(getKmsUrl() ?? "");
+    setBundlerUrlInput(getBundlerUrl() ?? "");
+    setRpcUrlInput(getRpcUrl() ?? "");
+    setRelayUrlInput(getRelayUrl() ?? "");
+    setReady(isDirectKmsReady());
+    setResolvedKms(kmsBaseUrl());
+  }, []);
+
+  const handleSave = () => {
+    if (apiKey.trim()) setApiKey(apiKey);
+    else clearApiKey();
+    setKmsUrl(kmsUrl);
+    setBundlerUrl(bundlerUrl);
+    setRpcUrl(rpcUrl);
+    setRelayUrl(relayUrl);
+    setReady(isDirectKmsReady());
+    setResolvedKms(kmsBaseUrl());
+    toast.success("Settings saved (this device)");
+  };
+
+  const handleClear = () => {
+    clearApiKey();
+    setKmsUrl("");
+    setBundlerUrl("");
+    setRpcUrl("");
+    setRelayUrl("");
+    setApiKeyInput("");
+    setKmsUrlInput("");
+    setBundlerUrlInput("");
+    setRpcUrlInput("");
+    setRelayUrlInput("");
+    setReady(false);
+    setResolvedKms(kmsBaseUrl());
+    setPingResult(null);
+    toast.success("Cleared");
+  };
+
+  const handlePing = async () => {
+    setPinging(true);
+    setPingResult(null);
+    const r = await pingKms();
+    setPingResult(r.ok ? `OK (${r.status})` : `Failed: ${r.error ?? r.status}`);
+    setPinging(false);
+  };
+
+  const inputClass =
+    "block w-full px-4 py-3 border-2 border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white rounded-xl shadow-sm focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-sm placeholder-gray-400 dark:placeholder-gray-500 transition-all";
+
+  return (
+    <Layout requireAuth={true}>
+      <div className="max-w-2xl px-3 py-4 sm:px-4 sm:py-6 mx-auto lg:px-8">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white mb-1">
+          Settings
+        </h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+          Endpoints &amp; credentials for this device. Leave a field{" "}
+          <strong>blank to use the AAStar default</strong>; fill it to point at{" "}
+          <strong>your own</strong> node/service — YAA doesn&apos;t lock you into AAStar infra. The
+          AAStar API key (free tier; more via aPoints) authorizes the default KMS + bundler;
+          self-hosted endpoints use your own auth. Nothing here leaves this device.
+        </p>
+
+        <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 sm:p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              AAStar API Key
+            </label>
+            <input
+              type="password"
+              value={apiKey}
+              onChange={e => setApiKeyInput(e.target.value)}
+              placeholder="Paste your API key"
+              autoComplete="off"
+              className={inputClass}
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Authorizes both KMS and the bundler. Leave blank to keep using the hosted proxy.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              KMS Endpoint (optional override)
+            </label>
+            <input
+              type="text"
+              value={kmsUrl}
+              onChange={e => setKmsUrlInput(e.target.value)}
+              placeholder={kmsBaseUrl()}
+              autoComplete="off"
+              spellCheck={false}
+              className={`${inputClass} font-mono`}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Bundler Endpoint (optional override)
+            </label>
+            <input
+              type="text"
+              value={bundlerUrl}
+              onChange={e => setBundlerUrlInput(e.target.value)}
+              placeholder="Default bundler"
+              autoComplete="off"
+              spellCheck={false}
+              className={`${inputClass} font-mono`}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              RPC Endpoint (optional override)
+            </label>
+            <input
+              type="text"
+              value={rpcUrl}
+              onChange={e => setRpcUrlInput(e.target.value)}
+              placeholder="Default RPC (viem public)"
+              autoComplete="off"
+              spellCheck={false}
+              className={`${inputClass} font-mono`}
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Used for on-chain reads (balances, nonce). Point at your own node to decentralize
+              reads.
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Relay Endpoint (optional override)
+            </label>
+            <input
+              type="text"
+              value={relayUrl}
+              onChange={e => setRelayUrlInput(e.target.value)}
+              placeholder="Default account-deploy relay"
+              autoComplete="off"
+              spellCheck={false}
+              className={`${inputClass} font-mono`}
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Sponsors passkey account creation (see relay proposal). Blank = AAStar relay.
+            </p>
+          </div>
+
+          <div className="flex flex-col sm:flex-row gap-3 pt-2">
+            <button
+              onClick={handleSave}
+              className="inline-flex items-center justify-center px-4 py-3 sm:py-2 text-sm font-medium text-white bg-slate-900 hover:bg-slate-800 dark:bg-emerald-600 dark:hover:bg-emerald-500 rounded-xl shadow transition active:scale-95"
+            >
+              Save
+            </button>
+            <button
+              onClick={handlePing}
+              disabled={pinging}
+              className="inline-flex items-center justify-center px-4 py-3 sm:py-2 text-sm font-medium text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-xl transition active:scale-95 disabled:opacity-60"
+            >
+              {pinging ? "Testing…" : "Test KMS connection"}
+            </button>
+            <button
+              onClick={handleClear}
+              className="inline-flex items-center justify-center px-4 py-3 sm:py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-xl transition active:scale-95"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        {/* Status */}
+        <div className="mt-6 rounded-xl bg-slate-50 dark:bg-slate-800/50 border border-slate-200 dark:border-slate-700 p-4 text-sm">
+          <div className="flex items-center justify-between py-1">
+            <span className="text-slate-600 dark:text-slate-400">Direct-KMS ready</span>
+            <span className={ready ? "text-emerald-600 dark:text-emerald-400" : "text-gray-500"}>
+              {ready ? "Yes (API key set)" : "No (using hosted proxy)"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between py-1">
+            <span className="text-slate-600 dark:text-slate-400">Resolved KMS endpoint</span>
+            <span className="font-mono text-xs text-slate-700 dark:text-slate-300 break-all">
+              {resolvedKms}
+            </span>
+          </div>
+          {pingResult && (
+            <div className="flex items-center justify-between py-1">
+              <span className="text-slate-600 dark:text-slate-400">Last test</span>
+              <span className="text-xs text-slate-700 dark:text-slate-300">{pingResult}</span>
+            </div>
+          )}
+        </div>
+
+        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+          Note: transfer signing still runs through the hosted service today. Direct browser→KMS +
+          direct bundler (using this key) turn on once the KMS Origin/API-key path is live — this
+          screen configures it ahead of that switch.
+        </p>
+      </div>
+    </Layout>
+  );
+}

--- a/aastar-frontend/components/Layout.tsx
+++ b/aastar-frontend/components/Layout.tsx
@@ -199,6 +199,7 @@ export default function Layout({ children, requireAuth = false }: LayoutProps) {
                         {
                           title: "Settings",
                           items: [
+                            { label: "Settings", path: "/settings", Icon: Cog6ToothIcon },
                             { label: "Tokens", path: "/tokens", Icon: WalletIcon },
                             { label: "NFTs", path: "/nfts", Icon: BookOpenIcon },
                             { label: "Address Book", path: "/address-book", Icon: BookOpenIcon },

--- a/aastar-frontend/lib/api-key-store.ts
+++ b/aastar-frontend/lib/api-key-store.ts
@@ -1,0 +1,97 @@
+/**
+ * Client-side AAStar API-key store (zero-backend migration — foundation prep).
+ *
+ * The zero-backend model authorizes the browser's KMS + bundler calls with the user's
+ * OWN API key (a free-tier or provided key, scoped to their wallet / community identity)
+ * instead of a shared server secret. This holds that key (and optional endpoint overrides)
+ * in localStorage so the direct-KMS / direct-bundler paths can read it once the flows are
+ * switched over. Nothing load-bearing yet — the transfer/auth flows still use the backend
+ * until the KMS Origin+API-key infra is live.
+ *
+ * Per-device (not per-account): the key is the user's credential for this install.
+ */
+const API_KEY = "yaa.apiKey";
+const KMS_URL_KEY = "yaa.kmsUrl";
+const BUNDLER_URL_KEY = "yaa.bundlerUrl";
+const RPC_URL_KEY = "yaa.rpcUrl";
+const RELAY_URL_KEY = "yaa.relayUrl";
+
+function get(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function set(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    /* private mode / quota — best effort */
+  }
+}
+
+function remove(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getApiKey(): string | null {
+  return get(API_KEY);
+}
+export function setApiKey(key: string): void {
+  set(API_KEY, key.trim());
+}
+export function clearApiKey(): void {
+  remove(API_KEY);
+}
+export function hasApiKey(): boolean {
+  return !!getApiKey();
+}
+
+/** Optional KMS endpoint override (blank → default). */
+export function getKmsUrl(): string | null {
+  return get(KMS_URL_KEY);
+}
+export function setKmsUrl(url: string): void {
+  const u = url.trim();
+  if (u) set(KMS_URL_KEY, u);
+  else remove(KMS_URL_KEY);
+}
+
+/** Optional bundler endpoint override (blank → default). */
+export function getBundlerUrl(): string | null {
+  return get(BUNDLER_URL_KEY);
+}
+export function setBundlerUrl(url: string): void {
+  const u = url.trim();
+  if (u) set(BUNDLER_URL_KEY, u);
+  else remove(BUNDLER_URL_KEY);
+}
+
+/** Optional RPC endpoint override (blank → default). Consumed by getPublicClient(). */
+export function getRpcUrl(): string | null {
+  return get(RPC_URL_KEY);
+}
+export function setRpcUrl(url: string): void {
+  const u = url.trim();
+  if (u) set(RPC_URL_KEY, u);
+  else remove(RPC_URL_KEY);
+}
+
+/** Optional account-deploy relay endpoint override (blank → default; see RELAY_SERVICE_PROPOSAL). */
+export function getRelayUrl(): string | null {
+  return get(RELAY_URL_KEY);
+}
+export function setRelayUrl(url: string): void {
+  const u = url.trim();
+  if (u) set(RELAY_URL_KEY, u);
+  else remove(RELAY_URL_KEY);
+}

--- a/aastar-frontend/lib/kms-client.ts
+++ b/aastar-frontend/lib/kms-client.ts
@@ -5,6 +5,7 @@
  * Signing operations go through the backend (which calls KMS internally),
  * but WebAuthn ceremonies must happen in the browser.
  */
+import { getApiKey, getKmsUrl } from "./api-key-store";
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -206,5 +207,44 @@ export class KmsClient {
       ClientDataHash: bytesToHex(clientDataHash),
       Signature: bytesToHex(signatureBytes),
     };
+  }
+}
+
+// ── Direct-KMS seam (zero-backend migration — foundation prep) ────────────────
+//
+// Today the app reaches KMS through the server-side `/kms-api` proxy (which injects the
+// shared KMS_API_KEY). The zero-backend target is to call KMS DIRECTLY from the browser,
+// authorized by the user's OWN API key (from api-key-store) + the browser Origin. These
+// helpers wire the existing KmsClient to that model. NOT yet used by the transfer/auth
+// flows — they keep using `/kms-api` until the KMS Origin+API-key path is live (revised
+// plan step 2). The Settings page uses them to configure + test the key.
+
+export const DEFAULT_KMS_URL = "https://kms.aastar.io";
+
+/** The KMS base URL: a user override (Settings), else the build-time default. */
+export function kmsBaseUrl(): string {
+  return getKmsUrl() || process.env.NEXT_PUBLIC_KMS_URL || DEFAULT_KMS_URL;
+}
+
+/** True once the user has supplied an API key (the direct-KMS path is configured). */
+export function isDirectKmsReady(): boolean {
+  return !!getApiKey();
+}
+
+/** A KmsClient wired for DIRECT browser→KMS access with the user's API key. */
+export function directKmsClient(): KmsClient {
+  return new KmsClient(kmsBaseUrl(), getApiKey() ?? undefined);
+}
+
+/**
+ * Best-effort KMS health probe — no infra assumption. Settings uses it to sanity-check the
+ * endpoint (and, once Origin-auth is live, whether the browser is allowed). Never throws.
+ */
+export async function pingKms(): Promise<{ ok: boolean; status?: number; error?: string }> {
+  try {
+    const res = await fetch(`${kmsBaseUrl().replace(/\/$/, "")}/health`, { method: "GET" });
+    return { ok: res.ok, status: res.status };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 }

--- a/aastar-frontend/lib/sdk/client.ts
+++ b/aastar-frontend/lib/sdk/client.ts
@@ -14,6 +14,7 @@ import { sepolia } from "viem/chains";
 import { applyConfig, CHAIN_SEPOLIA } from "@aastar/sdk/core";
 import { TokenSaleClient } from "@aastar/sdk/tokens";
 import { GuardClient } from "@aastar/sdk/core";
+import { getRpcUrl } from "@/lib/api-key-store";
 
 let sdkConfigured = false;
 
@@ -36,7 +37,10 @@ export function getInjectedProvider(): unknown | undefined {
 
 /** Read-only viem client over a public RPC (defaults to the chain's public endpoint). */
 export function getPublicClient(rpcUrl?: string, chain: Chain = sepolia): PublicClient {
-  return createPublicClient({ chain, transport: rpcUrl ? http(rpcUrl) : http() });
+  // Precedence: explicit arg → user-configured RPC (Settings, decentralization choice) →
+  // viem's default public RPC. Lets a user point reads at their own node without code.
+  const url = rpcUrl ?? getRpcUrl() ?? undefined;
+  return createPublicClient({ chain, transport: url ? http(url) : http() });
 }
 
 /**


### PR DESCRIPTION
Brings the config center to **master** (cherry-picked foundation from the paused migration branch) so beta has it, and extends it for the **decentralization choice** you asked for: a user can point YAA at **their own** KMS / bundler / RPC / relay instead of AAStar's.

- `api-key-store`: + RPC + RELAY endpoint overrides (with KMS/bundler/API-key).
- `getPublicClient`: explicit arg → **user RPC (Settings)** → viem default, so a self-configured RPC actually drives client-side on-chain reads (real effect on master).
- Settings page (+ nav link): reframed **'blank = AAStar default, fill = your own node/service'**.

**Boundary:** endpoints + the user's API key only — **never private keys** (per `CONFIG_AND_DEPENDENCIES.md`; secrets are eliminated via the relay + API-key model, not surfaced in UI). On master's backend stack the KMS/bundler/relay overrides are config-ready-but-inert (server does that work); the RPC override is live now.

tsc + lint green. `next build` not run in the worktree (Turbopack rejects symlinked node_modules); authoritative build runs on master at deploy.