### PR TITLE
fix(settings): validate endpoint URLs before saving (#408 follow-up)

### DIFF
--- a/aastar-frontend/app/settings/page.tsx
+++ b/aastar-frontend/app/settings/page.tsx
@@ -39,7 +39,29 @@ export default function SettingsPage() {
     setResolvedKms(kmsBaseUrl());
   }, []);
 
+  const isValidUrl = (u: string): boolean => {
+    try {
+      const { protocol } = new URL(u);
+      return protocol === "http:" || protocol === "https:";
+    } catch {
+      return false;
+    }
+  };
+
   const handleSave = () => {
+    // Validate any non-empty endpoint override before persisting, so a typo doesn't
+    // silently break reads/ceremonies. Blank stays blank (= AAStar default).
+    for (const [label, val] of [
+      ["KMS", kmsUrl],
+      ["Bundler", bundlerUrl],
+      ["RPC", rpcUrl],
+      ["Relay", relayUrl],
+    ] as const) {
+      if (val.trim() && !isValidUrl(val.trim())) {
+        toast.error(`${label} endpoint must be a valid http(s) URL`);
+        return;
+      }
+    }
     if (apiKey.trim()) setApiKey(apiKey);
     else clearApiKey();
     setKmsUrl(kmsUrl);


### PR DESCRIPTION
#408 reviewer's non-blocking suggestion. Reject a non-empty KMS/bundler/RPC/relay override that isn't a valid **http(s)** URL (via the `URL` constructor) with a toast, instead of silently persisting a typo that would break reads/ceremonies. Blank stays blank (= AAStar default). tsc+lint green; `next build` verified on master (/settings static).