### PR TITLE
fix(role): default lookup to own address + 'AAStar'→'Mycelium' ecosystem copy

### DIFF
--- a/aastar-frontend/app/role/page.tsx
+++ b/aastar-frontend/app/role/page.tsx
@@ -93,7 +93,12 @@ export default function RolePage() {
         registryAPI.getRole().catch(() => null),
         registryAPI.getInfo(),
       ]);
-      if (roleRes) setRoleInfo(roleRes.data);
+      if (roleRes) {
+        setRoleInfo(roleRes.data);
+        // Default the lookup field to the user's own account so the Query button works
+        // out of the box (the field looks up ANY address; empty = no-op = "no response").
+        setQueryAddress(prev => prev || roleRes.data.address || "");
+      }
       setRegistryInfo(infoRes.data);
     } catch {
       toast.error(t("rolePage.loadError"));

--- a/aastar-frontend/lib/i18n/locales/en.json
+++ b/aastar-frontend/lib/i18n/locales/en.json
@@ -633,7 +633,7 @@
   },
   "rolePage": {
     "title": "Role Portal",
-    "subtitle": "View your role in the AAStar ecosystem and navigate to role-specific dashboards",
+    "subtitle": "View your role in the Mycelium ecosystem and navigate to role-specific dashboards",
     "registryOverview": "Registry Overview (Sepolia)",
     "communityAdmins": "Community Admins",
     "spoOperators": "SPO Operators",

--- a/aastar-frontend/lib/i18n/locales/zh.json
+++ b/aastar-frontend/lib/i18n/locales/zh.json
@@ -633,7 +633,7 @@
   },
   "rolePage": {
     "title": "角色门户",
-    "subtitle": "查看您在 AAStar 生态中的角色，并进入相应的角色仪表盘",
+    "subtitle": "查看您在 Mycelium 生态中的角色，并进入相应的角色仪表盘",
     "registryOverview": "注册表概览 (Sepolia)",
     "communityAdmins": "社区管理员",
     "spoOperators": "SPO 运营商",


### PR DESCRIPTION
Two fixes on `/role`:
1. **Query button 'no response'**: the lookup field started empty and `queryRole()` returns on empty — users expect it defaulted to their own address. Now prefilled with the user's account (`roleRes.data.address`) when empty, so Query works out of the box (still editable to look up any address).
2. **Copy**: subtitle 'View your role in the **AAStar** ecosystem' → '**Mycelium** ecosystem' (zh + en), per the Mycelium Protocol framing.

tsc + lint + i18n parity (766 keys) green; `next build` verified on master (/role static).